### PR TITLE
chore: use ubuntu-slim runner for lightweight jobs

### DIFF
--- a/.github/workflows/_pull-request.yaml
+++ b/.github/workflows/_pull-request.yaml
@@ -16,7 +16,7 @@ defaults:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/eslint-config.yaml
+++ b/.github/workflows/eslint-config.yaml
@@ -21,7 +21,7 @@ defaults:
 jobs:
   static:
     if: ${{ !github.event.pull_request.draft }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   markdown-lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Check out
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
   release-please:
     if: github.actor != 'nektos/act'
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     outputs:
       prs: ${{ steps.release-please.outputs.prs }}

--- a/.github/workflows/setting-files.yaml
+++ b/.github/workflows/setting-files.yaml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   format-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Check out
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6


### PR DESCRIPTION
Migrate lightweight CI jobs to ubuntu-slim runner to reduce costs.

## Changes
- Migrated lightweight jobs (lint, format check, validation) to `ubuntu-slim` runner
- Docker-based jobs (`_actionlint.yaml`, `_secretlint.yaml`) remain on `ubuntu-latest` as `ubuntu-slim` doesn't support Docker

## Note
Actionlint doesn't support `ubuntu-slim` runner yet (see https://github.com/rhysd/actionlint/pull/585), so actionlint checks may fail until the upstream is updated.

Refs: https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Move selected CI jobs to the `ubuntu-slim` runner across multiple workflows.
> 
> - **CI Workflows**:
>   - Switch `runs-on` to `ubuntu-slim` for:
>     - `._pull-request.yaml` → `jobs.validate`
>     - `eslint-config.yaml` → `jobs.static`
>     - `markdown.yaml` → `jobs.markdown-lint`
>     - `release.yaml` → `jobs.release-please` (other jobs unchanged)
>     - `setting-files.yaml` → `jobs.format-check`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b194774bca9250a68f77ebd28bd1847c3ad8bdaa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->