### PR TITLE
docs: fix markdown lint errors in AGENTS.md and CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,4 +54,3 @@ pnpm postinstall
 
 - 設定変更は基本的に `packages/` 配下の設定・ドキュメント側を優先して更新する。
 - フォーマット・リントは `pnpm format` / `pnpm prettier` と `pnpm fix:md`（markdown）を使う。
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,3 @@
+# Claude Code Guidelines
+
 @AGENTS.md


### PR DESCRIPTION
## 概要

- AGENTS.md:58 の連続空行エラー（MD012）を修正
- CLAUDE.md:1 の先頭行見出しエラー（MD041）を修正

## テストプラン

- [x] `pnpm fix:md` でリントエラー 0 件を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)