### PR TITLE
ci: add timeout-minutes to release workflow jobs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,7 @@ jobs:
     if: github.actor != 'nektos/act'
 
     runs-on: ubuntu-slim
+    timeout-minutes: 10
 
     outputs:
       prs: ${{ steps.release-please.outputs.prs }}
@@ -49,6 +50,7 @@ jobs:
     if: needs.release-please.outputs.prs
 
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     strategy:
       matrix:
@@ -90,6 +92,7 @@ jobs:
     if: needs.release-please.outputs.releases_created == 'true' && needs.release-please.outputs.paths_released != '[]'
 
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

- release ワークフローの全ジョブ（`release-please`、`format`、`publish`）に `timeout-minutes: 10` を追加
- 他のワークフローと同じタイムアウト設定に統一

## Test plan

- [ ] CI が正常に通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)