### PR TITLE
chore: add provenance to publishConfig for all packages

### DIFF
--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {},
   "packageManager": "pnpm@10.32.1",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/cspell-config/package.json
+++ b/packages/cspell-config/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {},
   "packageManager": "pnpm@10.32.1",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -79,6 +79,7 @@
     "node": ">=24.0.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/lefthook-config/package.json
+++ b/packages/lefthook-config/package.json
@@ -26,6 +26,7 @@
   },
   "packageManager": "pnpm@10.32.1",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/markdownlint-cli2-config/package.json
+++ b/packages/markdownlint-cli2-config/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {},
   "packageManager": "pnpm@10.32.1",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/postinstall/package.json
+++ b/packages/postinstall/package.json
@@ -47,6 +47,7 @@
   },
   "packageManager": "pnpm@10.32.1",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {},
   "packageManager": "pnpm@10.32.1",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {},
   "packageManager": "pnpm@10.32.1",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }


### PR DESCRIPTION
## Summary

- 全パッケージの `publishConfig` に `"provenance": true` を追加
- npm publish 時に SLSA provenance attestation が生成されるようになる

## 対象パッケージ

- `@nozomiishii/commitlint-config`
- `@nozomiishii/cspell-config`
- `@nozomiishii/eslint-config`
- `@nozomiishii/lefthook-config`
- `@nozomiishii/markdownlint-cli2-config`
- `@nozomiishii/postinstall`
- `@nozomiishii/prettier-config`
- `@nozomiishii/tsconfig`

## Test plan

- [ ] CI が通ることを確認
- [ ] 次回 release-please でのパブリッシュ時に provenance attestation が付与されることを確認