### PR TITLE
fix(lefthook-config): detect squash-merged branches in cleanup-merged script

### DIFF
--- a/packages/lefthook-config/scripts/cleanup-merged.sh
+++ b/packages/lefthook-config/scripts/cleanup-merged.sh
@@ -47,7 +47,7 @@ cleanup_branches() {
   echo "$merged_branches" | while read -r branch; do
     [ -z "$branch" ] && continue
     [ "$branch" = "$base" ] && continue
-    git branch -d "$branch" 2>/dev/null && echo "Deleted branch: $branch"
+    git branch -D "$branch" 2>/dev/null && echo "Deleted branch: $branch"
   done
   # リモートで削除済みの追跡ブランチを整理
   git fetch --prune
@@ -58,8 +58,19 @@ main() {
   base=$(default_branch)
 
   # デフォルトブランチにマージ済みのローカルブランチ一覧を取得
+  # git branch --merged は squash merge を検出できないため、
+  # git cherry を使ってパッチ単位で比較する
   local merged_branches
-  merged_branches=$(git branch --merged "$base" 2>/dev/null | sed 's/^[* ]*//' | grep -Ev "^\s*$" || true)
+  merged_branches=$(
+    git branch | sed 's/^[* ]*//' | while read -r branch; do
+      [ "$branch" = "$base" ] && continue
+      # git cherry: "+" = unmerged, "-" = already in upstream
+      # "+" が 0 件 = 全コミットが main に取り込み済み (squash merge 含む)
+      if [ "$(git cherry "$base" "$branch" 2>/dev/null | grep -c '^+')" -eq 0 ]; then
+        echo "$branch"
+      fi
+    done
+  )
 
   [ -z "$merged_branches" ] && exit 0
 


### PR DESCRIPTION
## 概要

`cleanup-merged.sh` がスクワッシュマージされたブランチを検出・削除できない問題を修正。

- `git branch --merged` → `git cherry` ベースの検出に変更（パッチ内容レベルで比較するため、スクワッシュマージも検出可能）
- `git branch -d` → `-D` に変更（スクワッシュマージされたブランチは `-d` では「not fully merged」と判定されるため）

## テスト

- [ ] `pnpx lefthook run post-merge` でスクワッシュマージ済みブランチが削除されることを確認