### PR TITLE
fix: add .pnpm-store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Dependencies
 node_modules
+.pnpm-store
 
 # log
 *.log*


### PR DESCRIPTION
## Summary

- `.pnpm-store` を `.gitignore` に追加
- Claude Code の sandbox がグローバルの pnpm store（`~/Library/pnpm/store`）への書き込みをブロックするため、pnpm がフォールバックとしてプロジェクトルートに `.pnpm-store` を生成していた
- 根本対策として sandbox の `allowWrite` に pnpm store パスを追加する変更は dotfiles リポジトリで別途対応

## Test plan

- [ ] `git status` で `.pnpm-store` が untracked に表示されないことを確認