### PR TITLE
fix(lefthook-config): resolve exit status 1 and improve squash merge detection

### DIFF
--- a/packages/lefthook-config/scripts/cleanup-merged.sh
+++ b/packages/lefthook-config/scripts/cleanup-merged.sh
@@ -59,14 +59,18 @@ main() {
 
   # デフォルトブランチにマージ済みのローカルブランチ一覧を取得
   # git branch --merged は squash merge を検出できないため、
-  # git cherry を使ってパッチ単位で比較する
+  # commit-tree で仮想 squash コミットを作成し git cherry で比較する
   local merged_branches
   merged_branches=$(
     while read -r branch; do
       [ "$branch" = "$base" ] && continue
-      # git cherry: "+" = unmerged, "-" = already in upstream
-      # "+" が 0 件 = 全コミットが main に取り込み済み (squash merge 含む)
-      if [ "$(git cherry "$base" "$branch" 2>/dev/null | grep -c '^+')" -eq 0 ]; then
+      local merge_base
+      merge_base=$(git merge-base "$base" "$branch" 2>/dev/null) || continue
+      # ブランチの tree を使い、merge-base を親に持つ仮想 squash コミットを作成
+      local squash_commit
+      squash_commit=$(git commit-tree "$branch^{tree}" -p "$merge_base" -m "_" 2>/dev/null) || continue
+      # 仮想 squash コミットが base に既に含まれていれば "-" を返す
+      if [ "$(git cherry "$base" "$squash_commit" 2>/dev/null | grep -c '^+')" -eq 0 ]; then
         echo "$branch"
       fi
     done < <(git branch | sed 's/^[* ]*//')


### PR DESCRIPTION
## Summary

- `set -euo pipefail` 環境下で pipe-to-while パターンにより意図しない非ゼロ終了コードが発生していた問題を修正
- 全箇所をプロセス置換（`< <(...)`）またはヒアストリング（`<<<`）に置き換え
- `git fetch --prune` に `|| true` を追加
- squash merge 検出を `git cherry`（パッチ単位比較）から `commit-tree` + `cherry`（仮想 squash コミット比較）に切り替え、複数コミットの squash merge も検出可能に

## Test plan

- [ ] マージ済みブランチがある状態でスクリプトを実行し、exit code 0 で終了することを確認
- [ ] マージ済みブランチがない状態でも正常終了することを確認
- [ ] 複数コミットの squash merge 済みブランチが正しく検出・削除されることを確認