### PR TITLE
fix: inject README metadata into package.json before pnpm publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -109,5 +109,20 @@ jobs:
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
+      - name: Inject README metadata for npm registry
+        run: |
+          node --input-type=module -e "
+            import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+            import { join } from 'node:path';
+            const pkgPath = join('${{ matrix.path }}', 'package.json');
+            const readmePath = join('${{ matrix.path }}', 'README.md');
+            if (existsSync(readmePath)) {
+              const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+              pkg.readme = readFileSync(readmePath, 'utf8');
+              pkg.readmeFilename = 'README.md';
+              writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+            }
+          "
+
       - name: Publish package
         run: pnpm --filter "./${{ matrix.path }}" publish


### PR DESCRIPTION
## Summary

- `pnpm publish` は npm レジストリへの PUT リクエスト時に `readme` メタデータフィールドを送信しない（[pnpm/pnpm#4091](https://github.com/pnpm/pnpm/issues/4091)）
- npm ウェブサイトは tarball 内の README.md ではなくメタデータの `readme` フィールドを表示するため、全パッケージで README が「This package does not have a README」と表示されていた
- CI の publish ステップ前に README.md の内容を package.json の `readme` フィールドに注入するステップを追加

## Test plan

- [ ] CI の release workflow で publish が成功することを確認
- [ ] publish 後に `npm view @nozomiishii/<package> readme` で readme 内容が取得できることを確認
- [ ] npm ウェブサイトで README が表示されることを確認