### PR TITLE
chore(markdownlint-cli2-config): migrate to TypeScript source with tsdown build

### DIFF
--- a/.markdownlint-cli2.cjs
+++ b/.markdownlint-cli2.cjs
@@ -1,1 +1,0 @@
-module.exports = require('@nozomiishii/markdownlint-cli2-config');

--- a/.markdownlint-cli2.mjs
+++ b/.markdownlint-cli2.mjs
@@ -1,0 +1,1 @@
+export { default } from '@nozomiishii/markdownlint-cli2-config';

--- a/packages/markdownlint-cli2-config/bin/cli.sh
+++ b/packages/markdownlint-cli2-config/bin/cli.sh
@@ -16,8 +16,8 @@ npm pkg set scripts.markdownlint="markdownlint-cli2 '**/*.md' '#node_modules'"
 npm pkg set scripts.lint:md="pnpm markdownlint"
 npm pkg set scripts.lint:md:fix="pnpm markdownlint --fix"
 
-echo -e "Creating markdownlint-cli2.cjs"
+echo -e "Creating .markdownlint-cli2.mjs"
 find . -type f -name '.markdownlint-cli2*' -delete
-echo "module.exports = require('@nozomiishii/markdownlint-cli2-config');" > .markdownlint-cli2.cjs
+echo "export { default } from '@nozomiishii/markdownlint-cli2-config';" > .markdownlint-cli2.mjs
 
 echo -e "All set! Your markdownlint-cli2 configuration has been set up successfully🎉"

--- a/packages/markdownlint-cli2-config/package.json
+++ b/packages/markdownlint-cli2-config/package.json
@@ -16,12 +16,33 @@
   },
   "license": "MIT",
   "author": "Nozomi Ishii",
-  "main": "index.cjs",
+  "type": "module",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "bin": "bin/cli.sh",
+  "files": [
+    "bin",
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch --sourcemap",
+    "prepublishOnly": "pnpm run build",
+    "tsc": "tsc"
+  },
   "dependencies": {
     "markdownlint-cli2": "0.22.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "@nozomiishii/tsconfig": "workspace:*",
+    "tsdown": "0.21.7",
+    "typescript": "6.0.2"
+  },
   "packageManager": "pnpm@10.33.0",
   "publishConfig": {
     "access": "public",

--- a/packages/markdownlint-cli2-config/src/index.ts
+++ b/packages/markdownlint-cli2-config/src/index.ts
@@ -2,7 +2,7 @@
  * markdownlint
  * {@link https://github.com/DavidAnson/markdownlint}
  */
-module.exports = {
+export default {
   /**
    * Rules
    * {@link https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md}

--- a/packages/markdownlint-cli2-config/tsconfig.json
+++ b/packages/markdownlint-cli2-config/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@nozomiishii/tsconfig/tsconfig.json",
+
+  "compilerOptions": {
+    "moduleResolution": "Bundler",
+    "module": "ESNext",
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/markdownlint-cli2-config/tsdown.config.ts
+++ b/packages/markdownlint-cli2-config/tsdown.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  clean: true,
+  platform: 'node',
+  outExtensions: () => ({ js: '.js', dts: '.d.ts' }),
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,6 +185,16 @@ importers:
       markdownlint-cli2:
         specifier: 0.22.0
         version: 0.22.0
+    devDependencies:
+      '@nozomiishii/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      tsdown:
+        specifier: 0.21.7
+        version: 0.21.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(synckit@0.11.12)(typescript@6.0.2)
+      typescript:
+        specifier: 6.0.2
+        version: 6.0.2
 
   packages/postinstall:
     dependencies:


### PR DESCRIPTION
## 概要

`@nozomiishii/markdownlint-cli2-config` を `@nozomiishii/commitlint-config` / `@nozomiishii/prettier-config` と同じ流儀で TypeScript ソース + tsdown ビルド構成に移行する。

- `index.cjs` を削除し、`src/index.ts` + `dist/index.js`（ESM）に置き換え
- `tsconfig.json`, `tsdown.config.ts` を新設
- `package.json` の `exports` / `main` / `types` を `dist/` 配下に更新、`type: "module"` を追加
- ルート設定ファイルを `.markdownlint-cli2.cjs` → `.markdownlint-cli2.mjs` に変更
  - markdownlint-cli2 (v0.22.0) のソースは `.markdownlint-cli2.{jsonc,yaml,cjs,mjs}` のみ認識し、`.js` は未対応のため `.mjs` で固定
- `bin/cli.sh` のセットアップテンプレートも `.mjs` を生成するよう更新

## 検証

- [x] `pnpm install` 成功（postinstall で `dist/index.js` + `dist/index.d.ts` 生成）
- [x] `pnpm -F @nozomiishii/markdownlint-cli2-config tsc` 通過
- [x] `pnpm format` 通過
- [x] `markdownlint-cli2 '**/*.md' '#node_modules'` で 29 ファイルを 0 エラーで lint（`ignores` と rule 設定が dist 経由で正しく読まれていることを確認）
- [x] `npm pack --dry-run` で `bin/cli.sh`, `dist/`, `package.json`, `README.md` の 5 ファイルのみ同梱
