### PR TITLE
chore: add changelog-sections to release-please config

### DIFF
--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -6,6 +6,12 @@
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
 
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "chore", "section": "Miscellaneous" }
+  ],
+
   "packages": {
     "packages/commitlint-config": {
       "release-type": "node",


### PR DESCRIPTION
## Summary

- release-please の設定に `changelog-sections` を追加し、`feat` / `fix` / `chore` の 3 タイプを明示的にセクションへマッピング
- `chore` コミットも CHANGELOG の Miscellaneous セクションに残るようにする
- 狙い: 依存更新等の `chore` も含めた完全なリリース履歴を CHANGELOG に残すため

## Notes

- top-level に定義しているため monorepo 配下の全パッケージへ一括適用される
- commitlint 側は `type-enum` を `['feat', 'fix', 'chore']` に限定済みのため、この 3 タイプだけで必要十分
- 既存の CHANGELOG は遡って書き換わらない（次回 release-please 実行以降のみ反映）
- `BREAKING CHANGE` 表示は別ロジックで判定されるため従来通り

## Test plan

- [ ] 次回 release-please 実行時、`chore` コミットが `### Miscellaneous` として CHANGELOG に出力されることを確認
- [ ] 既存の `### Features` / `### Bug Fixes` セクションが従来通り生成されること
