### PR TITLE
fix: align tsdown to 0.21.8 in cspell-config and markdownlint-cli2-config

### DIFF
--- a/packages/cspell-config/package.json
+++ b/packages/cspell-config/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@nozomiishii/tsconfig": "workspace:*",
     "@types/node": "24.12.2",
-    "tsdown": "0.21.7",
+    "tsdown": "0.21.8",
     "typescript": "6.0.2"
   },
   "packageManager": "pnpm@10.33.0",

--- a/packages/markdownlint-cli2-config/package.json
+++ b/packages/markdownlint-cli2-config/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@nozomiishii/tsconfig": "workspace:*",
-    "tsdown": "0.21.7",
+    "tsdown": "0.21.8",
     "typescript": "6.0.2"
   },
   "packageManager": "pnpm@10.33.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,8 +76,8 @@ importers:
         specifier: 24.12.2
         version: 24.12.2
       tsdown:
-        specifier: 0.21.7
-        version: 0.21.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(synckit@0.11.12)(typescript@6.0.2)
+        specifier: 0.21.8
+        version: 0.21.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(synckit@0.11.12)(typescript@6.0.2)
       typescript:
         specifier: 6.0.2
         version: 6.0.2
@@ -207,8 +207,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       tsdown:
-        specifier: 0.21.7
-        version: 0.21.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(synckit@0.11.12)(typescript@6.0.2)
+        specifier: 0.21.8
+        version: 0.21.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(synckit@0.11.12)(typescript@6.0.2)
       typescript:
         specifier: 6.0.2
         version: 6.0.2


### PR DESCRIPTION
## 概要

リリース PR #2065 の CI が 4 件全て `ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY` で落ちている問題を修正します。リリース PR には直接触らず、main の lockfile と package.json の不整合を直すことで、release-please bot が PR #2065 を自動再生成できるようにします。

## 原因

main ブランチで `pnpm-lock.yaml` と一部 package.json の `tsdown` バージョンが食い違っていました。

| ファイル | tsdown バージョン |
| --- | --- |
| `packages/cspell-config/package.json` | `0.21.7` |
| `packages/markdownlint-cli2-config/package.json` | `0.21.7` |
| `pnpm-lock.yaml` | `0.21.8` のみ（`0.21.7` エントリは無し） |

マージ順の問題:

1. #2070 で `tsdown` を `0.21.7` → `0.21.8` に更新し、`pnpm-lock.yaml` も追従
2. 並行して動いていた #2066 / #2067 の feature ブランチは古い base (`tsdown@0.21.7`) のままだった
3. それらが後からマージされた際、lockfile の競合解決が不完全で `package.json` 側だけ `0.21.7` が残った

結果として `pnpm install --frozen-lockfile` を使う CI ジョブ（`static` / `markdown-lint` / `test` / `format-check`）が全て壊れていました。

## 変更内容

- `packages/cspell-config/package.json` の `tsdown` を `0.21.8` に更新
- `packages/markdownlint-cli2-config/package.json` の `tsdown` を `0.21.8` に更新
- `pnpm install` で `pnpm-lock.yaml` の該当 importer の specifier を `0.21.8` に同期

## 検証

- [x] ローカルで `pnpm install --frozen-lockfile --ignore-scripts` が成功することを確認
- [x] `pnpm-lock.yaml` の差分は 2 importer の specifier が `0.21.7` → `0.21.8` になるだけの最小差分
- [ ] この PR 上で `static` / `markdown-lint` / `test` / `format-check` が緑になることを確認
- [ ] マージ後、release-please PR #2065 が自動再生成され CI が通ることを確認

## 関連

- Fixes CI failures on #2065
- Root cause: #2066, #2067, #2070 のマージ順
