### PR TITLE
feat(commitlint-config): add body-ascii-only rule

### DIFF
--- a/packages/commitlint-config/src/index.ts
+++ b/packages/commitlint-config/src/index.ts
@@ -7,9 +7,23 @@ import type { UserConfig } from '@commitlint/types';
  * Rules
  * {@link https://commitlint.js.org/#/reference-rules}
  */
-export default {
+const config: UserConfig = {
   extends: ['@commitlint/config-conventional'],
+  plugins: [
+    {
+      rules: {
+        'body-ascii-only': ({ body }) => {
+          if (!body) return [true];
+          const valid = [...body].every((c) => c.charCodeAt(0) < 0x80);
+          return [valid, 'body must contain ASCII characters only (write in English)'];
+        },
+      },
+    },
+  ],
   rules: {
     'type-enum': [2, 'always', ['feat', 'fix', 'chore']],
+    'body-ascii-only': [2, 'always'],
   },
-} satisfies UserConfig;
+};
+
+export default config;


### PR DESCRIPTION
## 概要

`@nozomiishii/commitlint-config` に、コミット body を ASCII (英語) のみに制限するカスタムルール `body-ascii-only` を追加する。

## 背景

このパッケージを利用している `dotfiles` で運用状況を確認したところ、過去 6 ヶ月のコミット 190 件のうち **9 件で日本語 body が混入** していた。conventional commits の type-enum は英語で縛れているが、body 側は言語チェックが無く、気を抜くと日本語が紛れる状況。

## 仕様

- body が空の場合は PASS（body 無しコミットを禁止しない）
- body に 1 文字でも ASCII 範囲外 (`charCodeAt >= 0x80`) が含まれたら FAIL
- エラーメッセージ: `body must contain ASCII characters only (write in English)`

## 検証

`dotfiles` の `commitlint.config.ts` を一時的に本ルールで上書きし、3 ケースで動作確認済み:

| ケース | 期待 | 結果 |
|---|---|---|
| ASCII のみの body | PASS | exit 0 |
| 日本語を含む body | FAIL | exit 1 + エラーメッセージ表示 |
| body 無し | PASS | exit 0 |

## 実装メモ

- 正規表現 `\x00-\x7F` は TypeScript トランスパイラでパースエラーになるケースを確認したので、`[...body].every((c) => c.charCodeAt(0) < 0x80)` で実装
- 型推論で `Commit` 型が外部パッケージに依存して `tsdown` の dts 生成が失敗したため、`const config: UserConfig = ...` 形式に変更

## 影響

- リリース後、`@nozomiishii/commitlint-config` を extends する全リポジトリで日本語 body のコミットが拒否される
- 既存コミットは影響なし（commit-msg フックは新規コミットのみ検証）
