### PR TITLE
fix(postinstall): increase build test timeout to avoid CI flakiness

### DIFF
--- a/packages/postinstall/tests/build.test.ts
+++ b/packages/postinstall/tests/build.test.ts
@@ -7,7 +7,8 @@ const packageDir = resolve(import.meta.dirname, '..');
 const distDir = resolve(packageDir, 'dist');
 
 // ビルド成果物に .map ファイルが含まれないことを検証する
-test('build output should not contain .map files', () => {
+// `pnpm build` の実行を含むため、CI runner の負荷ブレで 5s デフォルトを超えうる（実測 5137ms / 7143ms）
+test('build output should not contain .map files', { timeout: 30_000 }, () => {
   execSync('pnpm build', { cwd: packageDir });
 
   const mapFiles = readdirSync(distDir).filter((f) => f.endsWith('.map'));


### PR DESCRIPTION
## Summary

`packages/postinstall/tests/build.test.ts` が CI で flaky にタイムアウトする問題への修正。

### 症状

- テスト `build output should not contain .map files` が vitest デフォルト `testTimeout` 5000ms で timeout する
- Release PR / renovate PR で少なくとも 3 回発生（実測所要時間 5137ms, 7143ms）
  - [run 24818627164](https://github.com/nozomiishii/configs/actions/runs/24818627164/job/72638281669?pr=2065)（Release PR #2065, 今回）
  - [run 24706993098](https://github.com/nozomiishii/configs/actions/runs/24706993098) 5137ms
  - [run 24706906654](https://github.com/nozomiishii/configs/actions/runs/24706906654) 7143ms
- PR の内容とは無関係に、GitHub Actions runner の瞬間負荷次第で発生する flakiness

### 根本原因

テスト内で `execSync('pnpm build')` を実行しており、pnpm 起動 + tsdown 起動 + TS ビルドの合計時間が CI runner の負荷によっては 5 秒を超える。デフォルトタイムアウトに対してマージンが薄すぎる設計だった。

### 対応

該当テストに個別 `timeout: 30_000` を付与し、runner の負荷ブレを吸収できるマージンを確保する。

- 実測 5137ms / 7143ms に対して 30 秒は約 4〜6 倍のマージン
- PR #2013 で確立された「`pnpm build` を駆動して `.map` 不在を検証する」という設計意図は維持（ビルドをテストから分離しない）
- グローバル `vitest.config` ではなくテスト個別に指定することで、「このテストは重いビルド実行を含む」という根拠をコード上に残す

## Test plan

- [x] ローカルで `pnpm -F @nozomiishii/postinstall test` が pass（1.22s）
- [ ] CI の Postinstall workflow が pass することを確認
