### PR TITLE
chore: migrate reusable workflows to v3.0.0

### DIFF
--- a/.github/workflows/_github-actions.yaml
+++ b/.github/workflows/_github-actions.yaml
@@ -12,9 +12,9 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
-  pull-requests: read
-  actions: read
+  contents: read # required by actions/checkout to fetch repository code
+  pull-requests: read # required by dorny/paths-filter to list PR files via the GitHub API
+  actions: read # required by gh api referenced_workflows to resolve the zizmor config SHA
 
 jobs:
   github-actions:

--- a/.github/workflows/_github-actions.yaml
+++ b/.github/workflows/_github-actions.yaml
@@ -1,4 +1,4 @@
-name: Lint GitHub Actions workflows
+name: GitHub Actions
 
 on:
   workflow_dispatch:
@@ -14,7 +14,8 @@ concurrency:
 permissions:
   contents: read
   pull-requests: read
+  actions: read
 
 jobs:
-  actionlint:
-    uses: nozomiishii/workflows/.github/workflows/actionlint.yaml@7e6fb98cc189a7b5ef23eee616a04238c5d9a468 # v1.1.1
+  github-actions:
+    uses: nozomiishii/workflows/.github/workflows/github-actions.yaml@4114f39af968607bdcef88b48d29605df89728fd # v3.0.0

--- a/.github/workflows/_pull-request.yaml
+++ b/.github/workflows/_pull-request.yaml
@@ -8,7 +8,7 @@ on:
       - synchronize
 
 permissions:
-  pull-requests: read
+  pull-requests: read # required by action-semantic-pull-request to read the PR title via the GitHub API
 
 jobs:
   pull-request:

--- a/.github/workflows/_pull-request.yaml
+++ b/.github/workflows/_pull-request.yaml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   pull-request:
-    uses: nozomiishii/workflows/.github/workflows/pull-request.yaml@7e6fb98cc189a7b5ef23eee616a04238c5d9a468 # v1.1.1
+    uses: nozomiishii/workflows/.github/workflows/pull-request.yaml@4114f39af968607bdcef88b48d29605df89728fd # v3.0.0

--- a/.github/workflows/_secret-scan.yaml
+++ b/.github/workflows/_secret-scan.yaml
@@ -11,5 +11,5 @@ permissions:
   contents: read
 
 jobs:
-  secretlint:
-    uses: nozomiishii/workflows/.github/workflows/secretlint.yaml@7e6fb98cc189a7b5ef23eee616a04238c5d9a468 # v1.1.1
+  secret-scan:
+    uses: nozomiishii/workflows/.github/workflows/secret-scan.yaml@4114f39af968607bdcef88b48d29605df89728fd # v3.0.0

--- a/.github/workflows/eslint-config.yaml
+++ b/.github/workflows/eslint-config.yaml
@@ -6,6 +6,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -21,9 +23,15 @@ jobs:
     runs-on: ubuntu-slim
     timeout-minutes: 10
 
+    permissions:
+      contents: read # required by actions/checkout to fetch repository code
+      pull-requests: read # required by dorny/paths-filter to list PR files via the GitHub API
+
     steps:
       - name: Check out
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Check for changes
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -9,6 +9,8 @@ on:
       - '**/*.md'
   pull_request:
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -16,9 +18,16 @@ concurrency:
 jobs:
   markdown-lint:
     runs-on: ubuntu-slim
+
+    permissions:
+      contents: read # required by actions/checkout to fetch repository code
+      pull-requests: read # required by dorny/paths-filter to list PR files via the GitHub API
+
     steps:
       - name: Check out
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Check for changes
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1

--- a/.github/workflows/postinstall.yaml
+++ b/.github/workflows/postinstall.yaml
@@ -6,6 +6,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -21,9 +23,15 @@ jobs:
     runs-on: ubuntu-slim
     timeout-minutes: 10
 
+    permissions:
+      contents: read # required by actions/checkout to fetch repository code
+      pull-requests: read # required by dorny/paths-filter to list PR files via the GitHub API
+
     steps:
       - name: Check out
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Check for changes
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # デフォルト権限を無効化し、各ジョブで必要最小限の権限のみ付与する
 permissions: {}
 
@@ -21,9 +25,9 @@ jobs:
     timeout-minutes: 10
 
     permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+      contents: write # required by release-please-action to create release tags and commits
+      issues: write # required by release-please-action to label release issues
+      pull-requests: write # required by release-please-action to open the release PR
 
     outputs:
       prs: ${{ steps.release-please.outputs.prs }}
@@ -69,7 +73,7 @@ jobs:
     timeout-minutes: 10
 
     permissions:
-      contents: write
+      contents: write # required to push the formatted CHANGELOG commit back to the release-please PR branch
 
     strategy:
       matrix:
@@ -95,7 +99,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ matrix.pr.headBranchName }}
-          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false # auth は後段の `gh auth setup-git` で配線する
 
       - name: Setup Node
         uses: ./.github/actions/setup-node
@@ -111,7 +115,10 @@ jobs:
           pnpm format:fix
 
       - name: Commit and push
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          gh auth setup-git
           git add '*.md' '**/*.md'
           git diff --cached --quiet && echo 'No changes to commit' && exit 0
           git commit -m 'chore: format CHANGELOG.md' --no-verify
@@ -137,9 +144,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
       - name: Publish package
-        run: pnpm --filter "./${{ matrix.path }}" publish
+        env:
+          MATRIX_PATH: ${{ matrix.path }}
+        run: pnpm --filter "./${MATRIX_PATH}" publish

--- a/.github/workflows/setting-files.yaml
+++ b/.github/workflows/setting-files.yaml
@@ -7,6 +7,8 @@ on:
       - main
   pull_request:
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -14,9 +16,15 @@ concurrency:
 jobs:
   format-check:
     runs-on: ubuntu-slim
+
+    permissions:
+      contents: read # required by actions/checkout to fetch repository code
+
     steps:
       - name: Check out
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: ./.github/actions/setup-node


### PR DESCRIPTION
## 概要

`nozomiishii/workflows` v3.0.0 リリースに先行して caller 側を移行する。pin は main HEAD の SHA（v3.0.0 release PR merge 直前の状態）を使用。

## 変更内容

- `_actionlint.yaml` → **`_github-actions.yaml`**
  - 呼び先を v2 aggregator `github-actions.yaml`（actionlint + zizmor）に差し替え
  - permissions に `actions: read` 追加（zizmor auditor persona 用）
  - job / workflow 名も v2 に合わせて rename
- `_secretlint.yaml` → **`_secret-scan.yaml`**
  - 呼び先を v2 concept-named `secret-scan.yaml` に差し替え
- `_pull-request.yaml`
  - SHA pin を v3.0.0（未リリース、main HEAD）に bump

## ⚠️ branch protection 更新が必要

この PR を merge する前に、default branch の required status checks を以下に更新:

| 旧 | 新 |
|---|---|
| `actionlint / lint` | `github-actions / required` |
| `secretlint / scan` | `secret-scan / secretlint` |
| `pull-request / validate` | そのまま |

## 関連

- 既存の renovate PR（SHA の単純 bump）は本 PR で代替するので close する
- `nozomiishii/workflows` 側の v3.0.0 release PR は全 caller migration 完了後に merge される予定
