### PR TITLE
chore(workflows): fix zizmor findings in caller workflows

### DIFF
--- a/.github/workflows/_github-actions.yaml
+++ b/.github/workflows/_github-actions.yaml
@@ -12,9 +12,9 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
-  pull-requests: read
-  actions: read
+  contents: read  # required by actions/checkout to fetch repository code
+  pull-requests: read  # required by dorny/paths-filter to list PR files via the GitHub API
+  actions: read  # required by gh api referenced_workflows to resolve the zizmor config SHA
 
 jobs:
   github-actions:

--- a/.github/workflows/_github-actions.yaml
+++ b/.github/workflows/_github-actions.yaml
@@ -12,9 +12,9 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read  # required by actions/checkout to fetch repository code
-  pull-requests: read  # required by dorny/paths-filter to list PR files via the GitHub API
-  actions: read  # required by gh api referenced_workflows to resolve the zizmor config SHA
+  contents: read # required by actions/checkout to fetch repository code
+  pull-requests: read # required by dorny/paths-filter to list PR files via the GitHub API
+  actions: read # required by gh api referenced_workflows to resolve the zizmor config SHA
 
 jobs:
   github-actions:

--- a/.github/workflows/_pull-request.yaml
+++ b/.github/workflows/_pull-request.yaml
@@ -8,7 +8,7 @@ on:
       - synchronize
 
 permissions:
-  pull-requests: read  # required by action-semantic-pull-request to read the PR title via the GitHub API
+  pull-requests: read # required by action-semantic-pull-request to read the PR title via the GitHub API
 
 jobs:
   pull-request:

--- a/.github/workflows/_pull-request.yaml
+++ b/.github/workflows/_pull-request.yaml
@@ -8,7 +8,7 @@ on:
       - synchronize
 
 permissions:
-  pull-requests: read
+  pull-requests: read  # required by action-semantic-pull-request to read the PR title via the GitHub API
 
 jobs:
   pull-request:

--- a/.github/workflows/eslint-config.yaml
+++ b/.github/workflows/eslint-config.yaml
@@ -6,6 +6,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -21,9 +23,15 @@ jobs:
     runs-on: ubuntu-slim
     timeout-minutes: 10
 
+    permissions:
+      contents: read  # required by actions/checkout to fetch repository code
+      pull-requests: read  # required by dorny/paths-filter to list PR files via the GitHub API
+
     steps:
       - name: Check out
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Check for changes
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1

--- a/.github/workflows/eslint-config.yaml
+++ b/.github/workflows/eslint-config.yaml
@@ -24,8 +24,8 @@ jobs:
     timeout-minutes: 10
 
     permissions:
-      contents: read  # required by actions/checkout to fetch repository code
-      pull-requests: read  # required by dorny/paths-filter to list PR files via the GitHub API
+      contents: read # required by actions/checkout to fetch repository code
+      pull-requests: read # required by dorny/paths-filter to list PR files via the GitHub API
 
     steps:
       - name: Check out

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -9,6 +9,8 @@ on:
       - '**/*.md'
   pull_request:
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -16,9 +18,16 @@ concurrency:
 jobs:
   markdown-lint:
     runs-on: ubuntu-slim
+
+    permissions:
+      contents: read  # required by actions/checkout to fetch repository code
+      pull-requests: read  # required by dorny/paths-filter to list PR files via the GitHub API
+
     steps:
       - name: Check out
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Check for changes
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-slim
 
     permissions:
-      contents: read  # required by actions/checkout to fetch repository code
-      pull-requests: read  # required by dorny/paths-filter to list PR files via the GitHub API
+      contents: read # required by actions/checkout to fetch repository code
+      pull-requests: read # required by dorny/paths-filter to list PR files via the GitHub API
 
     steps:
       - name: Check out

--- a/.github/workflows/postinstall.yaml
+++ b/.github/workflows/postinstall.yaml
@@ -6,6 +6,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -21,9 +23,15 @@ jobs:
     runs-on: ubuntu-slim
     timeout-minutes: 10
 
+    permissions:
+      contents: read  # required by actions/checkout to fetch repository code
+      pull-requests: read  # required by dorny/paths-filter to list PR files via the GitHub API
+
     steps:
       - name: Check out
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Check for changes
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1

--- a/.github/workflows/postinstall.yaml
+++ b/.github/workflows/postinstall.yaml
@@ -24,8 +24,8 @@ jobs:
     timeout-minutes: 10
 
     permissions:
-      contents: read  # required by actions/checkout to fetch repository code
-      pull-requests: read  # required by dorny/paths-filter to list PR files via the GitHub API
+      contents: read # required by actions/checkout to fetch repository code
+      pull-requests: read # required by dorny/paths-filter to list PR files via the GitHub API
 
     steps:
       - name: Check out

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # デフォルト権限を無効化し、各ジョブで必要最小限の権限のみ付与する
 permissions: {}
 
@@ -21,9 +25,9 @@ jobs:
     timeout-minutes: 10
 
     permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+      contents: write  # required by release-please-action to create release tags and commits
+      issues: write  # required by release-please-action to label release issues
+      pull-requests: write  # required by release-please-action to open the release PR
 
     outputs:
       prs: ${{ steps.release-please.outputs.prs }}
@@ -69,7 +73,7 @@ jobs:
     timeout-minutes: 10
 
     permissions:
-      contents: write
+      contents: write  # required to push the formatted CHANGELOG commit back to the release-please PR branch
 
     strategy:
       matrix:
@@ -96,6 +100,7 @@ jobs:
         with:
           ref: ${{ matrix.pr.headBranchName }}
           token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Setup Node
         uses: ./.github/actions/setup-node
@@ -137,9 +142,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
       - name: Publish package
-        run: pnpm --filter "./${{ matrix.path }}" publish
+        env:
+          MATRIX_PATH: ${{ matrix.path }}
+        run: pnpm --filter "./${MATRIX_PATH}" publish

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -99,8 +99,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ matrix.pr.headBranchName }}
-          token: ${{ steps.app-token.outputs.token }}
-          persist-credentials: false
+          persist-credentials: false  # auth は後段の `gh auth setup-git` で配線する
 
       - name: Setup Node
         uses: ./.github/actions/setup-node
@@ -116,7 +115,10 @@ jobs:
           pnpm format:fix
 
       - name: Commit and push
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          gh auth setup-git
           git add '*.md' '**/*.md'
           git diff --cached --quiet && echo 'No changes to commit' && exit 0
           git commit -m 'chore: format CHANGELOG.md' --no-verify

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,9 +25,9 @@ jobs:
     timeout-minutes: 10
 
     permissions:
-      contents: write  # required by release-please-action to create release tags and commits
-      issues: write  # required by release-please-action to label release issues
-      pull-requests: write  # required by release-please-action to open the release PR
+      contents: write # required by release-please-action to create release tags and commits
+      issues: write # required by release-please-action to label release issues
+      pull-requests: write # required by release-please-action to open the release PR
 
     outputs:
       prs: ${{ steps.release-please.outputs.prs }}
@@ -73,7 +73,7 @@ jobs:
     timeout-minutes: 10
 
     permissions:
-      contents: write  # required to push the formatted CHANGELOG commit back to the release-please PR branch
+      contents: write # required to push the formatted CHANGELOG commit back to the release-please PR branch
 
     strategy:
       matrix:
@@ -99,7 +99,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ matrix.pr.headBranchName }}
-          persist-credentials: false  # auth は後段の `gh auth setup-git` で配線する
+          persist-credentials: false # auth は後段の `gh auth setup-git` で配線する
 
       - name: Setup Node
         uses: ./.github/actions/setup-node

--- a/.github/workflows/setting-files.yaml
+++ b/.github/workflows/setting-files.yaml
@@ -7,6 +7,8 @@ on:
       - main
   pull_request:
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -14,9 +16,15 @@ concurrency:
 jobs:
   format-check:
     runs-on: ubuntu-slim
+
+    permissions:
+      contents: read  # required by actions/checkout to fetch repository code
+
     steps:
       - name: Check out
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: ./.github/actions/setup-node

--- a/.github/workflows/setting-files.yaml
+++ b/.github/workflows/setting-files.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-slim
 
     permissions:
-      contents: read  # required by actions/checkout to fetch repository code
+      contents: read # required by actions/checkout to fetch repository code
 
     steps:
       - name: Check out


### PR DESCRIPTION
## Summary

Migration PR (#2101) に stacked。zizmor auditor persona の finding を全部解消する。

## Fixes
- `_github-actions.yaml` / `_pull-request.yaml`: permissions justification コメント
- `eslint-config.yaml` / `markdown.yaml` / `postinstall.yaml` / `setting-files.yaml`: top-level `permissions: {}` + job 最小 permissions + `persist-credentials: false`
- `release.yaml`: `concurrency:` + `persist-credentials: false` + `${{ }}` を `env:` 経由に refactor + permissions コメント

## Test plan
- [ ] `github-actions / required` 緑
- [ ] `secret-scan / secretlint` 緑
- [ ] `pull-request / validate` 緑
