### PR TITLE
chore: recommend opentofu vscode extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -196,6 +196,7 @@
     // ----------------------------------------------------------------
     "hashicorp.terraform",
     "hashicorp.hcl",
+    "opentofu.vscode-opentofu",
     "emeraldwalk.runonsave",
 
     // ----------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `.vscode/extensions.json` の Terraform セクションに `opentofu.vscode-opentofu` を推奨拡張として追加。

## Test plan

- [ ] VS Code で当リポジトリを開き、`opentofu.vscode-opentofu` が推奨拡張として表示されることを確認する。
