### PR TITLE
chore(lefthook-config): remove pre-push format-check job

### DIFF
--- a/packages/lefthook-config/index.yaml
+++ b/packages/lefthook-config/index.yaml
@@ -8,12 +8,6 @@
 #   pnpx lefthook run --verbose pre-commit
 #   pnpx lefthook run --verbose commit-msg
 #   pnpx lefthook run --verbose post-merge
-pre-push:
-  parallel: true
-
-  jobs:
-    - name: format-check
-      run: pnpm prettier {push_files} --check
 
 commit-msg:
   parallel: true


### PR DESCRIPTION
## 概要

`packages/lefthook-config/index.yaml` から `pre-push` フックの `format-check` ジョブ（`pnpm prettier {push_files} --check`）を削除しました。

## 変更点

- `pre-push` セクション全体を削除
  - `format-check` ジョブのみが定義されていたため、セクションごと削除しています

## 背景・補足

- フォーマットチェックは `pre-commit` フックや CI でカバーされており、`pre-push` での重複チェックが不要なため削除します。
- これにより `git push` 時の待ち時間が短縮されます。

## 影響範囲

- このパッケージ (`@nozomiishii/lefthook-config`) を `extends` ではなく `index.yaml` 経由で利用しているプロジェクトの push 時挙動。
- リリース系・公開アセットの互換性は破壊しません（運用フックの調整のみ）。