### PR TITLE
feat(lefthook-config): ship nozo-git-harvest shim

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@nozomiishii/postinstall": "workspace:*",
     "@nozomiishii/prettier-config": "workspace:*",
     "@nozomiishii/tsconfig": "workspace:*",
-    "git-harvest": "0.1.20",
     "lefthook": "2.1.6",
     "markdownlint-cli2": "0.22.1",
     "npkill": "0.12.2"

--- a/packages/lefthook-config/README.md
+++ b/packages/lefthook-config/README.md
@@ -19,14 +19,13 @@ either pull the whole preset or cherry-pick individual fragments.
 ## Install
 
 ```sh
-pnpm add -D lefthook git-harvest @nozomiishii/lefthook-config
+pnpm add -D lefthook @nozomiishii/lefthook-config
 ```
 
-`git-harvest` is invoked by the `cleanup-merged` post-merge fragment via
-`node_modules/.bin/git-harvest`. Listing it as a direct dependency of
-your project guarantees the binary is hoisted into your top-level
-`node_modules/.bin/`, regardless of package manager (pnpm strict layout,
-npm, yarn).
+Auxiliary runtimes (currently `git-harvest`, used by the `cleanup-merged`
+post-merge fragment) are wrapped by shims that this package ships under
+its own `bin` field, so they are exposed as `node_modules/.bin/nozo-*`
+without requiring consumers to add them as direct dependencies.
 
 ## Use the full preset
 
@@ -58,7 +57,7 @@ extends:
 - `hooks/commit-msg/commitlint.yaml` — runs `nozo-commitlint` (provided by `@nozomiishii/commitlint-config`)
 - `hooks/commit-msg/spell.yaml`
 - `hooks/post-merge/update-node-modules.yaml` — pnpm > bun > npm > yarn
-- `hooks/post-merge/cleanup-merged.yaml` — runs [`git-harvest`](https://github.com/nozomiishii/git-harvest)
+- `hooks/post-merge/cleanup-merged.yaml` — runs [`git-harvest`](https://github.com/nozomiishii/git-harvest) via the `nozo-git-harvest` shim shipped by this package
 - `hooks/pre-commit/format/prettier.yaml`
 - `hooks/pre-commit/lint/markdown.yaml`
 - `hooks/pre-commit/lint/file-extension/{storybook,test,yaml}.yaml`
@@ -102,6 +101,6 @@ run: node_modules/.bin/nozo-commitlint --edit {1}
 run: node_modules/.bin/nozo run commitlint --edit {1}
 ```
 
-### Rule 5: shims live in the config package, not in `lefthook-config`
+### Rule 5: each shim lives where its config package lives
 
-`@nozomiishii/lefthook-config` does not ship its own bin. Each runtime tool's shim is provided by the corresponding config package (e.g. `@nozomiishii/commitlint-config` ships `nozo-commitlint`).
+Most runtime tools have their own `@nozomiishii/<x>-config` package, and that package ships the `nozo-<x>` shim (e.g. `@nozomiishii/commitlint-config` ships `nozo-commitlint`). `lefthook-config` itself is the exception: it composes a few auxiliary runtimes (currently `git-harvest`) that don't have a dedicated config package, so it ships those shims (`nozo-git-harvest`) directly. The principle is "one shim per runtime, owned by exactly one package" — never duplicate.

--- a/packages/lefthook-config/hooks/post-merge/cleanup-merged.yaml
+++ b/packages/lefthook-config/hooks/post-merge/cleanup-merged.yaml
@@ -1,4 +1,4 @@
 post-merge:
   jobs:
     - name: cleanup-merged
-      run: node_modules/.bin/git-harvest
+      run: node_modules/.bin/nozo-git-harvest

--- a/packages/lefthook-config/package.json
+++ b/packages/lefthook-config/package.json
@@ -15,12 +15,30 @@
   },
   "license": "MIT",
   "author": "Nozomi Ishii",
+  "type": "module",
   "main": "index.yaml",
+  "bin": { "nozo-git-harvest": "./dist/cli.js" },
+  "files": [
+    "dist",
+    "hooks",
+    "index.yaml",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch --sourcemap",
+    "prepublishOnly": "pnpm run build",
+    "tsc": "tsc"
+  },
   "dependencies": {
     "lefthook": "2.1.6",
     "git-harvest": "0.1.20"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "@nozomiishii/tsconfig": "workspace:*",
+    "tsdown": "0.21.10",
+    "typescript": "6.0.3"
+  },
   "peerDependencies": {
     "lefthook": ">=2.1.6"
   },

--- a/packages/lefthook-config/src/cli.ts
+++ b/packages/lefthook-config/src/cli.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const cli = require.resolve('git-harvest/lib/git-harvest');
+
+spawn('bash', [cli, ...process.argv.slice(2)], { stdio: 'inherit' }).on('exit', (code) =>
+  process.exit(code ?? 1),
+);

--- a/packages/lefthook-config/tsconfig.json
+++ b/packages/lefthook-config/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@nozomiishii/tsconfig/tsconfig.json",
+
+  "compilerOptions": {
+    "moduleResolution": "Bundler",
+    "module": "ESNext",
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/lefthook-config/tsdown.config.ts
+++ b/packages/lefthook-config/tsdown.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/cli.ts'],
+  format: ['esm'],
+  clean: true,
+  platform: 'node',
+  outExtensions: () => ({ js: '.js' }),
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,6 @@ importers:
       '@nozomiishii/tsconfig':
         specifier: workspace:*
         version: link:packages/tsconfig
-      git-harvest:
-        specifier: 0.1.20
-        version: 0.1.20
       lefthook:
         specifier: 2.1.6
         version: 2.1.6
@@ -200,6 +197,16 @@ importers:
       lefthook:
         specifier: 2.1.6
         version: 2.1.6
+    devDependencies:
+      '@nozomiishii/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      tsdown:
+        specifier: 0.21.10
+        version: 0.21.10(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(synckit@0.11.12)(typescript@6.0.3)
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
 
   packages/markdownlint-cli2-config:
     dependencies:


### PR DESCRIPTION
## Summary

PR #2119 で導入した `cleanup-merged` post-merge fragment が `node_modules/.bin/git-harvest` を直接呼ぶ設計だったため、pnpm strict layout で transitive dep が hoist されず、consumer が `git-harvest` を直接 dep に追加する必要があった（PR #2119 ではルート `package.json` に直接 devDep として追加して対応）。これを解消するため、`@nozomiishii/lefthook-config` が `git-harvest` をラップする shim を `nozo-git-harvest` として publish する形へ変更する。

## 経緯

PR #2119 merge 後、ローカルで lefthook hook を試したところ：

```
┃  cleanup-merged ❯
sh: node_modules/.bin/git-harvest: No such file or directory
```

ルート `package.json` の直接依存に頼る方式は consumer 側にも同じ追加を要求することになり、`@nozomiishii/lefthook-config` を install するだけで完結する shim パターンに統一する方が筋が良い。

## 変更内容

- `packages/lefthook-config/src/cli.ts` (新規): TypeScript で書かれた 10 行 shim、git-harvest の bash スクリプトを `bash` 経由で起動
- `packages/lefthook-config/tsdown.config.ts` + `tsconfig.json` (新規): commitlint-config と同じ tsdown ビルドパイプラインを導入
- `packages/lefthook-config/package.json`:
  - `bin: { "nozo-git-harvest": "./dist/cli.js" }` 追加
  - `type: "module"` 追加
  - `scripts.build` / `prepublishOnly` 追加
  - `devDependencies` に `tsdown` / `typescript` / `@nozomiishii/tsconfig` 追加
- `hooks/post-merge/cleanup-merged.yaml`: `run` を `node_modules/.bin/nozo-git-harvest` に変更
- ルート `package.json`: `git-harvest` 直接 devDep を削除（もう不要）
- README:
  - install 例から `git-harvest` 削除
  - Rule 5 を改訂: lefthook-config が auxiliary runtime shim を持つ場合の例外を明記

## Test plan

- [ ] `pnpm install` がクリーンに通る（lefthook-config の build が postinstall で走り、`dist/cli.js` 生成）
- [ ] `pnpm install` 再実行後 `node_modules/.bin/nozo-git-harvest` が +x で symlink される
- [ ] `node_modules/.bin/nozo-git-harvest --version` が `git-harvest v0.1.20` を返す
- [ ] `node_modules/.bin/nozo-git-harvest --dry-run` が exit 0 で削除候補を表示
- [ ] `lefthook dump` の `cleanup-merged.run` が `node_modules/.bin/nozo-git-harvest` を呼ぶ
- [ ] CI: semantic-pull-request, lint, typecheck, format-check が pass

Refs: #2118
