### PR TITLE
chore: drop cspell from repo root and lefthook

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -12,7 +12,6 @@
     "naumovs.color-highlight",
     "usernamehw.errorlens",
     "dotenv.dotenv-vscode",
-    "streetsidesoftware.code-spell-checker",
     "mechatroner.rainbow-csv",
     "janisdd.vscode-edit-csv",
     "grapecity.gc-excelviewer",

--- a/cspell.config.js
+++ b/cspell.config.js
@@ -1,1 +1,0 @@
-export { default } from '@nozomiishii/cspell-config';

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "devDependencies": {
     "@nozomiishii/commitlint-config": "workspace:*",
-    "@nozomiishii/cspell-config": "workspace:*",
     "@nozomiishii/lefthook-config": "workspace:*",
     "@nozomiishii/markdownlint-cli2-config": "workspace:*",
     "@nozomiishii/postinstall": "workspace:*",

--- a/packages/lefthook-config/README.md
+++ b/packages/lefthook-config/README.md
@@ -55,7 +55,6 @@ extends:
 ## Available fragments
 
 - `hooks/commit-msg/commitlint.yaml` — runs `nozo-commitlint` (provided by `@nozomiishii/commitlint-config`)
-- `hooks/commit-msg/spell.yaml`
 - `hooks/post-merge/update-node-modules.yaml` — pnpm > bun > npm > yarn
 - `hooks/post-merge/cleanup-merged.yaml` — runs [`git-harvest`](https://github.com/nozomiishii/git-harvest) via the `nozo-git-harvest` shim shipped by this package
 - `hooks/pre-commit/format/prettier.yaml`

--- a/packages/lefthook-config/hooks/commit-msg/spell.yaml
+++ b/packages/lefthook-config/hooks/commit-msg/spell.yaml
@@ -1,4 +1,0 @@
-commit-msg:
-  jobs:
-    - name: cspell
-      run: npx -y @nozomiishii/cspell-config@latest {1}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@nozomiishii/commitlint-config':
         specifier: workspace:*
         version: link:packages/commitlint-config
-      '@nozomiishii/cspell-config':
-        specifier: workspace:*
-        version: link:packages/cspell-config
       '@nozomiishii/lefthook-config':
         specifier: workspace:*
         version: link:packages/lefthook-config


### PR DESCRIPTION
## 背景

`commit-msg` の cspell hook は技術用語で false positive が多く、運用コストが高かったので、cspell をリポジトリの開発フローから外す。

## 変更点

- `packages/lefthook-config/hooks/commit-msg/spell.yaml` 削除
- ルートの `cspell.config.js` 削除
- ルート `package.json` の devDep から `@nozomiishii/cspell-config` 削除
- `.vscode/extensions.json` から `streetsidesoftware.code-spell-checker` 削除
- `packages/lefthook-config/README.md` の fragment 一覧から `spell.yaml` を削除

## 残すもの

`@nozomiishii/cspell-config` パッケージ自体は workspace に残す。後続の PR で `nozo-cspell` shim を追加して、`nozo` CLI 経由で使う想定。

## 互換性

`@nozomiishii/lefthook-config` の preset (`index.yaml`) は元々 `spell.yaml` を extends していないので preset 利用者には影響なし。fragment を直接 cherry-pick していた consumer は影響を受けるが、当該 fragment は `npx -y @nozomiishii/cspell-config@latest {1}` という壊れた呼び出しで実質動いていなかったので、実害は小さいと判断。

## Test plan

- [x] `pnpm format` が pass する
- [x] commitlint hook が壊れずに走る（このコミットで実証）
- [ ] CI が green

Refs: #2118
