### PR TITLE
feat(eslint-config): enforce .test.{ts,tsx} via vitest/consistent-test-filename

### DIFF
--- a/packages/eslint-config/rules/viest.ts
+++ b/packages/eslint-config/rules/viest.ts
@@ -11,12 +11,20 @@ export function viest() {
   return defineConfig([
     {
       ...eslintPluginVitest.configs.all,
-      files: ['**/*.test.{ts,tsx}'],
+      files: ['**/*.{test,spec}.{ts,tsx}'],
       ignores: ['**/e2e/**'],
       name: name('viest'),
 
       rules: {
         ...eslintPluginVitest.configs.all.rules,
+
+        /**
+         * テストファイル名は .test.{ts,tsx} に統一する。
+         * .spec.* も識別対象に含めた上で、ファイル名規則違反としてエラーにする。
+         *
+         * @see https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/consistent-test-filename.md
+         */
+        'vitest/consistent-test-filename': ['error', { pattern: '.*\\.test\\.[tj]sx?$' }],
 
         /**
          * itでなくtest句でテスト書く

--- a/packages/eslint-config/rules/viest.ts
+++ b/packages/eslint-config/rules/viest.ts
@@ -24,7 +24,7 @@ export function viest() {
          *
          * @see https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/consistent-test-filename.md
          */
-        'vitest/consistent-test-filename': ['error', { pattern: '.*\\.test\\.[tj]sx?$' }],
+        'vitest/consistent-test-filename': ['error', { pattern: String.raw`.*\.test\.[tj]sx?$` }],
 
         /**
          * itでなくtest句でテスト書く


### PR DESCRIPTION
## 背景

`@nozomiishii/lefthook-config` の `hooks/pre-commit/lint/file-extension/test.yaml` で担っていた「`.spec.*` 禁止 / `.test.*` 強制」を ESLint の `vitest/consistent-test-filename` ルールで代替する。Lefthook 整理（`test.yaml` 削除）の前段として、まず ESLint 側に寄せる。

## 変更点

- `packages/eslint-config/rules/viest.ts` の `files` を `'**/*.test.{ts,tsx}'` → `'**/*.{test,spec}.{ts,tsx}'` に拡張
- `'vitest/consistent-test-filename': ['error', { pattern: '.*\\.test\\.[tj]sx?$' }]` を明示的に追加

`configs.all` 経由で `'warn'` で取り込まれてはいたが、上記の `files` 絞り込みのため `.spec.*` には config object 自体が適用されず、ルールが事実上発火していなかった。

## 動作確認

`packages/eslint-config/__tmp_filename_test__/` に一時テストファイル 2 つを置いて `pnpm exec eslint` で検証（一時ファイルは確認後削除）。

| ファイル | rule 発火 |
|---|---|
| `valid.test.ts` | ❌（期待通り） |
| `violation.spec.ts` | ✅ `Use test file name pattern .*\.test\.[tj]sx?$` でエラー |

## 互換性

eslint-config の consumer で `.spec.*` の test ファイルがあるプロジェクトでは新規にエラーが出る。これは意図する挙動。

## Test plan

- [x] 動作テスト（一時ファイル）で `.spec.ts` への発火を確認
- [x] `.test.ts` で発火しないことを確認
- [x] commitlint hook が pass
- [ ] CI が green

Refs: #2118
