### PR TITLE
chore: add pre-push hook running lint on all workspace packages

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -10,3 +10,14 @@
 #   pnpx lefthook run --verbose post-merge
 extends:
   - ./node_modules/@nozomiishii/lefthook-config/index.yaml
+
+pre-push:
+  jobs:
+    - name: lint-affected
+      # `pnpm --filter '...[<ref>]'` is broken inside git worktrees on both pnpm
+      # 10.x and 11.0.1 (returns "No projects matched"), so derive the affected
+      # package set from `git diff` and pass them as path filters instead.
+      run: |
+        ARGS=$(git diff --name-only origin/main...HEAD | grep -oE '^packages/[^/]+' | sort -u | sed 's|^|--filter=./|' | tr '\n' ' ')
+        [ -z "$ARGS" ] && exit 0
+        pnpm $ARGS --if-present run lint

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -13,11 +13,5 @@ extends:
 
 pre-push:
   jobs:
-    - name: lint-affected
-      # `pnpm --filter '...[<ref>]'` is broken inside git worktrees on both pnpm
-      # 10.x and 11.0.1 (returns "No projects matched"), so derive the affected
-      # package set from `git diff` and pass them as path filters instead.
-      run: |
-        ARGS=$(git diff --name-only origin/main...HEAD | grep -oE '^packages/[^/]+' | sort -u | sed 's|^|--filter=./|' | tr '\n' ' ')
-        [ -z "$ARGS" ] && exit 0
-        pnpm $ARGS --if-present run lint
+    - name: lint
+      run: pnpm -r --if-present run lint


### PR DESCRIPTION
## 概要

ルート `lefthook.yaml` に `pre-push` hook を追加し、push 前に `pnpm -r --if-present run lint` を実行する。

```yaml
pre-push:
  jobs:
    - name: lint
      run: pnpm -r --if-present run lint
```

## 設計判断（経緯）

当初は `pnpm --filter '...[origin/main]'` で affected な package のみ lint する方針だったが、調査の結果以下が判明したため全 package 実行に切り替えた:

- **pnpm `[<ref>]` filter は git worktree 内で壊れる**: 実機検証で pnpm 10.33.2 / 11.0.1 共に worktree 内で `No projects matched` を返す。main repo (worktree 外) では正常動作。
- **standalone affected library**: `@front-ops/domino` (deps 0、AST 解析) が最有力だが 2026-03 リリースで新しく、採用判断は保留。`@traf/core` は nx 依存。`lockfile-affected` は lockfile ベースのみで対象外。
- **Turborepo `--affected`**: 9 packages + lint task 1 個ではキャッシュ・並列性のメリットが薄く、依存追加コストに見合わない。
- **自前 shell**: `git diff` + pnpm path filter する案は読みにくい。
- **計測**: 全 package lint しても **約 5 秒** で完了（実 lint 走るのは eslint-config の 1 package のみ、他は `--if-present` で skip）。affected 制御を入れる複雑性に見合わない。

## 動作確認

| 計測 | 時間 |
|---|---|
| `pnpm -r --if-present run lint` 直接実行 | 6.44 秒 |
| `pnpm exec lefthook run pre-push` 経由 | 5.16 秒 |
| `git push` 経由の実 hook | 4.81 秒で pass |

将来 lint script を持つ package が増えたら自動的に対象に含まれる。

## commit 構成

検討経緯を残すため 2 commit で構成。マージ時 squash 推奨。

- `dfef29da` 旧案: 自前 shell の git diff filter
- `d4463fda` 新案: 全 package 対象に簡略化

## 残課題（別 Issue / 別 PR で対応）

- `@front-ops/domino` の実機検証（worktree 内挙動、`*.md` のみ変更時の検出可否）
- pnpm filter `[<ref>]` が worktree 内で壊れる件を pnpm 公式に issue 報告
- `nozo` CLI に `nozo affected` サブコマンドとして統合（Issue #2118 Phase 4 の延長として）

## Test plan

- [x] 直接実行と lefthook simulation で動作確認
- [x] 実 `git push` で hook が走り pass
- [ ] CI が green

Refs: #2118
