### PR TITLE
fix(postinstall): always use --force on lefthook install

### DIFF
--- a/packages/postinstall/src/lefthook.ts
+++ b/packages/postinstall/src/lefthook.ts
@@ -22,7 +22,7 @@ export async function setupLefthook() {
   try {
     await createLocalConfig();
 
-    const result = await $`lefthook install`;
+    const result = await $`lefthook install --force`;
     echo(result);
   } catch (e) {
     echo(e);


### PR DESCRIPTION
## 概要

`@nozomiishii/postinstall` の `setupLefthook` が呼ぶ `lefthook install` に `--force` を追加し、lefthook バージョン更新後の hook script ドリフトを構造的に防ぐ。

## 背景

`pnpm install` のたびに postinstall が `lefthook install` を実行する設計だが、過去のインストールが `core.hooksPath` を local config に書き込んでいると、`lefthook install`（無印）はそれを尊重して hook 同期をスキップする（`Skipping hook sync` メッセージ）。結果として:

- `.git/hooks/*` のスクリプトに古い lefthook バージョンへのハードコードパスが残る
- 後続の `git pull` / `git merge` などで「ちょいちょい」hint メッセージが出る
- 最悪、古い hook テンプレートのまま動き続ける

実際にこの問題が複数 repo（`configs` / `dotfiles` / `dev` / `nozomiishii` / `renovate`）で発生しており、今回は手動で `lefthook install --reset-hooks-path` 等を実行して個別修復した。本 PR は再発防止のための構造修正。

## 変更内容

`packages/postinstall/src/lefthook.ts` の `lefthook install` に `--force` を付与。

`--force` の意味（CLI ヘルプ一次情報）:

> overwrite .old files and proceed even if core.hooksPath is set

→ `core.hooksPath` がセットされていてもインストールを続行し、hook script を確実に上書き再生成する。`core.hooksPath` の値そのものは触らないので、副作用は最小限。

## 影響範囲

`@nozomiishii/postinstall` を使用する全 repo（`configs` / `dotfiles` / `dev` / `nozomiishii` / `renovate` 等）。本パッケージが publish され各 repo で `pnpm update` された後、`pnpm install` のたびに hook が確実に最新版で再生成されるようになる。

## 参考リンク

- [lefthook install ドキュメント](https://lefthook.dev/usage/commands/install)
- [evilmartians/lefthook · cmd/install.go](https://github.com/evilmartians/lefthook/blob/master/cmd/install.go)

## Test plan

- [x] `pnpm --filter @nozomiishii/postinstall build`: dist に `--force` が反映されていることを確認
- [x] `pnpm --filter @nozomiishii/postinstall tsc`: 型エラーなし
- [x] `pnpm --filter @nozomiishii/postinstall test`: 1/1 pass
- [x] `pnpm format`: prettier 崩れなし
- [x] pre-push hook（全パッケージ lint）通過
