### PR TITLE
feat(prettier-config)!: revert singleQuote to Prettier default

### DIFF
--- a/.github/actions/setup-node/action.yaml
+++ b/.github/actions/setup-node/action.yaml
@@ -1,14 +1,14 @@
-name: 'Node.js with pnpm'
-description: 'Setup Node.js and install dependencies using pnpm'
+name: "Node.js with pnpm"
+description: "Setup Node.js and install dependencies using pnpm"
 
 inputs:
   working-directory:
-    description: 'keyword specifies the working directory where the command is run.'
+    description: "keyword specifies the working directory where the command is run."
     required: false
-    default: '.'
+    default: "."
 
 runs:
-  using: 'composite'
+  using: "composite"
 
   steps:
     - name: pnpm setup
@@ -19,7 +19,7 @@ runs:
       with:
         node-version-file: ${{ inputs.working-directory }}/package.json
         # Required for publishing packages to npm
-        registry-url: 'https://registry.npmjs.org'
+        registry-url: "https://registry.npmjs.org"
 
     - name: Install dependencies
       shell: bash

--- a/.markdownlint-cli2.mjs
+++ b/.markdownlint-cli2.mjs
@@ -1,1 +1,1 @@
-export { default } from '@nozomiishii/markdownlint-cli2-config';
+export { default } from "@nozomiishii/markdownlint-cli2-config";

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -1,1 +1,1 @@
-export default { extends: ['@nozomiishii/commitlint-config'] };
+export default { extends: ["@nozomiishii/commitlint-config"] };

--- a/packages/commitlint-config/src/cli.ts
+++ b/packages/commitlint-config/src/cli.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
-import { spawn } from 'node:child_process';
-import { createRequire } from 'node:module';
+import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
-const cli = require.resolve('@commitlint/cli/cli.js');
+const cli = require.resolve("@commitlint/cli/cli.js");
 
-spawn(process.execPath, [cli, ...process.argv.slice(2)], { stdio: 'inherit' }).on('exit', (code) =>
+spawn(process.execPath, [cli, ...process.argv.slice(2)], { stdio: "inherit" }).on("exit", (code) =>
   process.exit(code ?? 1),
 );

--- a/packages/commitlint-config/src/index.ts
+++ b/packages/commitlint-config/src/index.ts
@@ -1,4 +1,4 @@
-import type { UserConfig } from '@commitlint/types';
+import type { UserConfig } from "@commitlint/types";
 
 /**
  * Configuration
@@ -8,21 +8,21 @@ import type { UserConfig } from '@commitlint/types';
  * {@link https://commitlint.js.org/#/reference-rules}
  */
 const config: UserConfig = {
-  extends: ['@commitlint/config-conventional'],
+  extends: ["@commitlint/config-conventional"],
   plugins: [
     {
       rules: {
-        'body-ascii-only': ({ body }) => {
+        "body-ascii-only": ({ body }) => {
           if (!body) return [true];
           const valid = [...body].every((c) => c.charCodeAt(0) < 0x80);
-          return [valid, 'body must contain ASCII characters only (write in English)'];
+          return [valid, "body must contain ASCII characters only (write in English)"];
         },
       },
     },
   ],
   rules: {
-    'type-enum': [2, 'always', ['feat', 'fix', 'chore']],
-    'body-ascii-only': [2, 'always'],
+    "type-enum": [2, "always", ["feat", "fix", "chore"]],
+    "body-ascii-only": [2, "always"],
   },
 };
 

--- a/packages/commitlint-config/tsdown.config.ts
+++ b/packages/commitlint-config/tsdown.config.ts
@@ -1,10 +1,10 @@
-import { defineConfig } from 'tsdown';
+import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/cli.ts'],
-  format: ['esm'],
+  entry: ["src/index.ts", "src/cli.ts"],
+  format: ["esm"],
   dts: true,
   clean: true,
-  platform: 'node',
-  outExtensions: () => ({ js: '.js', dts: '.d.ts' }),
+  platform: "node",
+  outExtensions: () => ({ js: ".js", dts: ".d.ts" }),
 });

--- a/packages/cspell-config/src/cli.ts
+++ b/packages/cspell-config/src/cli.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
-import { spawn } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
 
-const cli = fileURLToPath(import.meta.resolve('cspell/bin.mjs'));
-const configPath = fileURLToPath(new URL('./index.js', import.meta.url));
+const cli = fileURLToPath(import.meta.resolve("cspell/bin.mjs"));
+const configPath = fileURLToPath(new URL("./index.js", import.meta.url));
 
-spawn(process.execPath, [cli, '--config', configPath, ...process.argv.slice(2)], { stdio: 'inherit' }).on(
-  'exit',
+spawn(process.execPath, [cli, "--config", configPath, ...process.argv.slice(2)], { stdio: "inherit" }).on(
+  "exit",
   (code) => process.exit(code ?? 1),
 );

--- a/packages/cspell-config/src/index.ts
+++ b/packages/cspell-config/src/index.ts
@@ -1,14 +1,14 @@
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath } from "node:url";
 
-const customDictionaryPath = fileURLToPath(new URL('../dictionaries/customised.txt', import.meta.url));
+const customDictionaryPath = fileURLToPath(new URL("../dictionaries/customised.txt", import.meta.url));
 
 /**
  * cspell configuration
  * {@link https://cspell.org/docs/Configuration}
  */
 export default {
-  version: '0.2',
-  language: 'en',
+  version: "0.2",
+  language: "en",
   // 外部辞書
   // cspellの辞書一覧 https://github.com/streetsidesoftware/cspell-dicts#all-dictionaries
   import: [],
@@ -17,35 +17,35 @@ export default {
   // 人名、プロジェクト依存、他のプロジェクトでも使えそうな単語集みたいなかんじで分類分けできたらいいかもしれない。
   dictionaryDefinitions: [
     {
-      name: 'custom-dictionary',
+      name: "custom-dictionary",
       path: customDictionaryPath,
       addWords: true,
     },
   ],
   dictionaries: [
     // Built-in dictionaries (alphabetical ascending order)
-    'bash',
-    'companies',
-    'css',
-    'docker',
-    'dotnet',
-    'en_US',
-    'en-gb',
-    'filetypes',
-    'fonts',
-    'fullstack',
-    'html',
-    'html-symbol-entities',
-    'networking-terms',
-    'node',
-    'npm',
-    'public-licenses',
-    'python',
-    'rust',
-    'softwareTerms',
-    'typescript',
+    "bash",
+    "companies",
+    "css",
+    "docker",
+    "dotnet",
+    "en_US",
+    "en-gb",
+    "filetypes",
+    "fonts",
+    "fullstack",
+    "html",
+    "html-symbol-entities",
+    "networking-terms",
+    "node",
+    "npm",
+    "public-licenses",
+    "python",
+    "rust",
+    "softwareTerms",
+    "typescript",
     // Custom dictionaries
-    'custom-dictionary',
+    "custom-dictionary",
   ],
   ignorePaths: [],
 };

--- a/packages/cspell-config/tsdown.config.ts
+++ b/packages/cspell-config/tsdown.config.ts
@@ -1,10 +1,10 @@
-import { defineConfig } from 'tsdown';
+import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/cli.ts'],
-  format: ['esm'],
+  entry: ["src/index.ts", "src/cli.ts"],
+  format: ["esm"],
   dts: true,
   clean: true,
-  platform: 'node',
-  outExtensions: () => ({ js: '.js', dts: '.d.ts' }),
+  platform: "node",
+  outExtensions: () => ({ js: ".js", dts: ".d.ts" }),
 });

--- a/packages/eslint-config/eslint.config.ts
+++ b/packages/eslint-config/eslint.config.ts
@@ -1,28 +1,28 @@
-import gitignore from 'eslint-config-flat-gitignore';
-import { defineConfig } from 'eslint/config';
-import globals from 'globals';
-import { deMorgan } from './rules/de-morgan';
-import { eslintComments } from './rules/eslint-comments';
-import { importX } from './rules/import-x';
-import { javascript } from './rules/javascript';
-import { jsdoc } from './rules/jsdoc';
-import { jsxA11yX } from './rules/jsx-a11y-x';
-import { n } from './rules/n';
-import { nextjs } from './rules/nextjs';
-import { perfectionist } from './rules/perfectionist';
-import { playwright } from './rules/playwright';
-import { prettier } from './rules/prettier';
-import { react } from './rules/react';
-import { reactHooks } from './rules/react-hooks';
-import { reactRefresh } from './rules/react-refresh';
-import { regexp } from './rules/regexp';
-import { storybook } from './rules/storybook';
-import { stylistic } from './rules/stylistic';
-import { betterTailwindcss } from './rules/tailwindcss';
-import { typescript } from './rules/typescript';
-import { unicorn } from './rules/unicorn';
-import { viest } from './rules/viest';
-import { name } from './utils/name';
+import gitignore from "eslint-config-flat-gitignore";
+import { defineConfig } from "eslint/config";
+import globals from "globals";
+import { deMorgan } from "./rules/de-morgan";
+import { eslintComments } from "./rules/eslint-comments";
+import { importX } from "./rules/import-x";
+import { javascript } from "./rules/javascript";
+import { jsdoc } from "./rules/jsdoc";
+import { jsxA11yX } from "./rules/jsx-a11y-x";
+import { n } from "./rules/n";
+import { nextjs } from "./rules/nextjs";
+import { perfectionist } from "./rules/perfectionist";
+import { playwright } from "./rules/playwright";
+import { prettier } from "./rules/prettier";
+import { react } from "./rules/react";
+import { reactHooks } from "./rules/react-hooks";
+import { reactRefresh } from "./rules/react-refresh";
+import { regexp } from "./rules/regexp";
+import { storybook } from "./rules/storybook";
+import { stylistic } from "./rules/stylistic";
+import { betterTailwindcss } from "./rules/tailwindcss";
+import { typescript } from "./rules/typescript";
+import { unicorn } from "./rules/unicorn";
+import { viest } from "./rules/viest";
+import { name } from "./utils/name";
 
 export default defineConfig([
   /**
@@ -47,7 +47,7 @@ export default defineConfig([
         ...globals.node,
       },
     },
-    name: name('languageOptions/globals'),
+    name: name("languageOptions/globals"),
   },
   {
     languageOptions: {
@@ -56,7 +56,7 @@ export default defineConfig([
         tsconfigRootDir: import.meta.dirname,
       },
     },
-    name: name('languageOptions/parserOptions'),
+    name: name("languageOptions/parserOptions"),
   },
 
   javascript(),
@@ -90,4 +90,4 @@ export default defineConfig([
   // packageJson()
 ]);
 
-export { defineConfig } from 'eslint/config';
+export { defineConfig } from "eslint/config";

--- a/packages/eslint-config/rules/de-morgan.ts
+++ b/packages/eslint-config/rules/de-morgan.ts
@@ -1,6 +1,6 @@
-import eslintPluginDeMorgan from 'eslint-plugin-de-morgan';
-import { defineConfig } from 'eslint/config';
-import { name } from '../utils/name';
+import eslintPluginDeMorgan from "eslint-plugin-de-morgan";
+import { defineConfig } from "eslint/config";
+import { name } from "../utils/name";
 
 /**
  * @returns eslint-plugin-de-morgan
@@ -11,7 +11,7 @@ export function deMorgan() {
   return defineConfig([
     {
       ...eslintPluginDeMorgan.configs.recommended,
-      name: name('de-morgan'),
+      name: name("de-morgan"),
     },
   ]);
 }

--- a/packages/eslint-config/rules/eslint-comments.ts
+++ b/packages/eslint-config/rules/eslint-comments.ts
@@ -1,6 +1,6 @@
-import eslintPluginEslintComments from '@eslint-community/eslint-plugin-eslint-comments/configs';
-import { defineConfig } from 'eslint/config';
-import { name } from '../utils/name';
+import eslintPluginEslintComments from "@eslint-community/eslint-plugin-eslint-comments/configs";
+import { defineConfig } from "eslint/config";
+import { name } from "../utils/name";
 
 const configs = eslintPluginEslintComments.recommended;
 
@@ -12,10 +12,10 @@ export function eslintComments() {
   return defineConfig([
     {
       ...configs,
-      name: name('eslint-comments'),
+      name: name("eslint-comments"),
       rules: {
         ...configs.rules,
-        '@eslint-community/eslint-comments/disable-enable-pair': ['error', { allowWholeFile: true }],
+        "@eslint-community/eslint-comments/disable-enable-pair": ["error", { allowWholeFile: true }],
       },
     },
   ]);

--- a/packages/eslint-config/rules/import-x.ts
+++ b/packages/eslint-config/rules/import-x.ts
@@ -1,6 +1,6 @@
-import pluginImportX from 'eslint-plugin-import-x';
-import { defineConfig } from 'eslint/config';
-import { name } from '../utils/name';
+import pluginImportX from "eslint-plugin-import-x";
+import { defineConfig } from "eslint/config";
+import { name } from "../utils/name";
 
 /**
  * @returns eslint-plugin-import-x
@@ -28,35 +28,35 @@ export function importX() {
   return defineConfig({
     // https://github.com/un-ts/eslint-plugin-import-x/blob/master/src/config/flat/typescript.ts
     ...pluginImportX.flatConfigs.typescript,
-    name: name('import-x'),
+    name: name("import-x"),
     rules: {
       /**
        * import文は先頭に書く
        *
        * @see https://github.com/un-ts/eslint-plugin-import-x/blob/HEAD/docs/rules/first.md
        */
-      'import-x/first': 'warn',
+      "import-x/first": "warn",
 
       /**
        * 循環依存を禁止
        *
        * @see https://github.com/un-ts/eslint-plugin-import-x/blob/HEAD/docs/rules/no-cycle.md
        */
-      'import-x/no-cycle': 'warn',
+      "import-x/no-cycle": "warn",
 
       /**
        * 同じモジュールの繰り返しインポートを禁止
        *
        * @see https://github.com/un-ts/eslint-plugin-import-x/blob/HEAD/docs/rules/no-duplicates.md
        */
-      'import-x/no-duplicates': 'warn',
+      "import-x/no-duplicates": "warn",
 
       /**
        * default import名がモジュールのnamed export名と一致することを禁止
        *
        * @see https://github.com/un-ts/eslint-plugin-import-x/blob/HEAD/docs/rules/no-named-as-default.md
        */
-      'import-x/no-named-as-default': 'warn',
+      "import-x/no-named-as-default": "warn",
     },
   });
 }

--- a/packages/eslint-config/rules/javascript.ts
+++ b/packages/eslint-config/rules/javascript.ts
@@ -1,6 +1,6 @@
-import eslintConfigJavascript from '@eslint/js';
-import { defineConfig } from 'eslint/config';
-import { name } from '../utils/name';
+import eslintConfigJavascript from "@eslint/js";
+import { defineConfig } from "eslint/config";
+import { name } from "../utils/name";
 
 /**
  * @returns @eslint/js
@@ -10,8 +10,8 @@ import { name } from '../utils/name';
 export function javascript() {
   return defineConfig([
     {
-      files: ['**/*.{js,mjs,cjs,ts,jsx,tsx}'],
-      name: name('javascript'),
+      files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"],
+      name: name("javascript"),
       plugins: {
         js: eslintConfigJavascript,
       },
@@ -22,35 +22,35 @@ export function javascript() {
          *
          * @see https://github.com/prettier/eslint-config-prettier?tab=readme-ov-file#curly
          */
-        curly: ['warn', 'all'],
+        curly: ["warn", "all"],
 
         /**
          * == と != の使用を禁止し、=== と !== の使用を強制
          *
          * @see https://eslint.org/docs/latest/rules/eqeqeq
          */
-        eqeqeq: ['warn', 'allow-null'],
+        eqeqeq: ["warn", "allow-null"],
 
         /**
          * consoleの消し忘れ防止
          *
          * @see https://eslint.org/docs/latest/rules/no-console
          */
-        'no-console': ['warn', { allow: ['warn', 'error'] }],
+        "no-console": ["warn", { allow: ["warn", "error"] }],
 
         /**
          * 不必要な再命名防止
          *
          * @see https://eslint.org/docs/latest/rules/no-useless-rename
          */
-        'no-useless-rename': 'warn',
+        "no-useless-rename": "warn",
 
         /**
          * 比較式において、リテラルを前に置く「ヨーダ条件」を禁止
          *
          * @see https://eslint.org/docs/latest/rules/yoda
          */
-        yoda: 'warn',
+        yoda: "warn",
       },
     },
   ]);

--- a/packages/eslint-config/rules/jsdoc.ts
+++ b/packages/eslint-config/rules/jsdoc.ts
@@ -1,8 +1,8 @@
-import eslintPluginJsdoc from 'eslint-plugin-jsdoc';
-import { defineConfig } from 'eslint/config';
-import { name } from '../utils/name';
+import eslintPluginJsdoc from "eslint-plugin-jsdoc";
+import { defineConfig } from "eslint/config";
+import { name } from "../utils/name";
 
-const configs = eslintPluginJsdoc.configs['flat/recommended-typescript'];
+const configs = eslintPluginJsdoc.configs["flat/recommended-typescript"];
 
 /**
  * @returns eslint-plugin-jsdoc
@@ -30,16 +30,16 @@ export function jsdoc() {
     // },
     {
       ...configs,
-      files: ['**/libs/**/*.ts', '**/utils/**/*.tsx'],
-      name: name('jsdoc'),
+      files: ["**/libs/**/*.ts", "**/utils/**/*.tsx"],
+      name: name("jsdoc"),
       rules: {
         ...configs.rules,
 
         /**
          * タグの順番
          */
-        'jsdoc/sort-tags': [
-          'warn',
+        "jsdoc/sort-tags": [
+          "warn",
           {
             reportIntraTagGroupSpacing: false,
           },
@@ -48,9 +48,9 @@ export function jsdoc() {
         /**
          * タグのごとにスペース開ける
          */
-        'jsdoc/tag-lines': [
-          'warn',
-          'always',
+        "jsdoc/tag-lines": [
+          "warn",
+          "always",
           {
             applyToEndTag: false,
             startLines: 1,

--- a/packages/eslint-config/rules/jsonc.ts
+++ b/packages/eslint-config/rules/jsonc.ts
@@ -1,6 +1,6 @@
 // import eslintPluginJsonc from 'eslint-plugin-jsdoc';
-import { defineConfig } from 'eslint/config';
-import { name } from '../utils/name';
+import { defineConfig } from "eslint/config";
+import { name } from "../utils/name";
 
 /**
  * @returns eslint-plugin-jsonc
@@ -15,7 +15,7 @@ export function perfectionist() {
   return defineConfig([
     {
       // slintPluginJsonc.configs['flat/recommended-with-jsonc'],
-      name: name('jsonc'),
+      name: name("jsonc"),
       rules: {
         // rules: {
         //   'jsonc/require-properties': [
@@ -31,7 +31,7 @@ export function perfectionist() {
          *
          * @see https://ota-meshi.github.io/eslint-plugin-jsonc/rules/sort-keys.html#jsonc-sort-keys
          */
-        'jsonc/sort-keys': 'warn',
+        "jsonc/sort-keys": "warn",
       },
     },
   ]);

--- a/packages/eslint-config/rules/jsx-a11y-x.ts
+++ b/packages/eslint-config/rules/jsx-a11y-x.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 // @ts-expect-error missing types 型がない
-import eslintPluginJsxA11yX from 'eslint-plugin-jsx-a11y-x';
-import { defineConfig } from 'eslint/config';
-import { name } from '../utils/name';
+import eslintPluginJsxA11yX from "eslint-plugin-jsx-a11y-x";
+import { defineConfig } from "eslint/config";
+import { name } from "../utils/name";
 
 /**
  * @returns eslint-plugin-jsx-a11y-x
@@ -13,7 +13,7 @@ export function jsxA11yX() {
   return defineConfig([
     {
       ...eslintPluginJsxA11yX.flatConfigs.recommended,
-      name: name('jsx-a11y-x'),
+      name: name("jsx-a11y-x"),
     },
   ]);
 }

--- a/packages/eslint-config/rules/n.ts
+++ b/packages/eslint-config/rules/n.ts
@@ -1,8 +1,8 @@
-import eslintPluginN from 'eslint-plugin-n';
-import { defineConfig } from 'eslint/config';
-import { name } from '../utils/name';
+import eslintPluginN from "eslint-plugin-n";
+import { defineConfig } from "eslint/config";
+import { name } from "../utils/name";
 
-const config = eslintPluginN.configs['flat/recommended-module'];
+const config = eslintPluginN.configs["flat/recommended-module"];
 
 /**
  * @returns eslint-plugin-n
@@ -13,14 +13,14 @@ export function n() {
   return defineConfig([
     {
       ...config,
-      name: name('n'),
+      name: name("n"),
       rules: {
         ...config.rules,
 
         /**
          * typescriptやeslint-plugin-import-xで解決する
          */
-        'n/no-missing-import': 'off',
+        "n/no-missing-import": "off",
       },
       // pnpmでnode管理したいので設定。engines設定してるならここは省略できる。
       // pnpm.executionEnv.nodeVersionがcustomManagers書いてもenginesと同じタイミングでアップデートしてくれない。
@@ -35,15 +35,15 @@ export function n() {
     },
 
     {
-      ignores: ['**/env.ts'],
-      name: name('n/no-process-env'),
+      ignores: ["**/env.ts"],
+      name: name("n/no-process-env"),
       rules: {
         /**
          * process.envの直接使用禁止
          *
          * @see https://github.com/eslint-community/eslint-plugin-n/blob/master/docs/rules/no-process-env.md
          */
-        'n/no-process-env': 'error',
+        "n/no-process-env": "error",
       },
     },
   ]);

--- a/packages/eslint-config/rules/nextjs.ts
+++ b/packages/eslint-config/rules/nextjs.ts
@@ -1,6 +1,6 @@
-import eslintPluginNext from '@next/eslint-plugin-next';
-import { defineConfig } from 'eslint/config';
-import { name } from '../utils/name';
+import eslintPluginNext from "@next/eslint-plugin-next";
+import { defineConfig } from "eslint/config";
+import { name } from "../utils/name";
 
 /**
  * @returns `@next/eslint-plugin-next`
@@ -16,7 +16,7 @@ export function nextjs() {
   return defineConfig([
     {
       ...eslintPluginNext.configs.recommended,
-      name: name('nextjs'),
+      name: name("nextjs"),
     },
 
     {
@@ -25,24 +25,24 @@ export function nextjs() {
        *
        * @see https://next-intl-docs.vercel.app/docs/workflows/linting#consistent-usage-of-navigation-apis
        */
-      name: name('next-intl'),
+      name: name("next-intl"),
       rules: {
-        'no-restricted-imports': [
-          'error',
+        "no-restricted-imports": [
+          "error",
           {
-            message: 'Please import from `libs/next-intl` instead.',
-            name: 'next/link',
+            message: "Please import from `libs/next-intl` instead.",
+            name: "next/link",
           },
           {
-            importNames: ['getPathname', 'permanentRedirect', 'redirect', 'usePathname', 'useRouter'],
-            message: 'Please import from `libs/next-intl` instead.',
-            name: 'next/navigation',
+            importNames: ["getPathname", "permanentRedirect", "redirect", "usePathname", "useRouter"],
+            message: "Please import from `libs/next-intl` instead.",
+            name: "next/navigation",
           },
 
           {
-            importNames: ['getLocale'],
-            message: 'Please import from `libs/next-intl` instead.',
-            name: 'next-intl/server',
+            importNames: ["getLocale"],
+            message: "Please import from `libs/next-intl` instead.",
+            name: "next-intl/server",
           },
         ],
       },

--- a/packages/eslint-config/rules/package-json.ts
+++ b/packages/eslint-config/rules/package-json.ts
@@ -1,6 +1,6 @@
-import eslintPluginPackageJson from 'eslint-plugin-package-json';
-import { defineConfig } from 'eslint/config';
-import { name } from '../utils/name';
+import eslintPluginPackageJson from "eslint-plugin-package-json";
+import { defineConfig } from "eslint/config";
+import { name } from "../utils/name";
 
 /**
  * @returns eslint-plugin-package-json
@@ -12,7 +12,7 @@ export function packageJson() {
     {
       // https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/src/index.ts
       ...eslintPluginPackageJson.configs.recommended,
-      name: name('package-json'),
+      name: name("package-json"),
     },
   ]);
 }

--- a/packages/eslint-config/rules/perfectionist.ts
+++ b/packages/eslint-config/rules/perfectionist.ts
@@ -1,6 +1,6 @@
-import eslintPluginPerfectionist from 'eslint-plugin-perfectionist';
-import { defineConfig } from 'eslint/config';
-import { name } from '../utils/name';
+import eslintPluginPerfectionist from "eslint-plugin-perfectionist";
+import { defineConfig } from "eslint/config";
+import { name } from "../utils/name";
 
 /**
  * @returns eslint-plugin-perfectionist
@@ -10,20 +10,20 @@ import { name } from '../utils/name';
 export function perfectionist() {
   return defineConfig([
     {
-      name: name('perfectionist'),
+      name: name("perfectionist"),
       plugins: {
         perfectionist: eslintPluginPerfectionist,
       },
       rules: {
-        ...eslintPluginPerfectionist.configs['recommended-natural'].rules,
+        ...eslintPluginPerfectionist.configs["recommended-natural"].rules,
 
         /**
          * import文の並び順
          *
          * @see https://perfectionist.dev/rules/sort-imports
          */
-        'perfectionist/sort-imports': [
-          'error',
+        "perfectionist/sort-imports": [
+          "error",
           {
             newlinesBetween: 0,
           },

--- a/packages/eslint-config/rules/playwright.ts
+++ b/packages/eslint-config/rules/playwright.ts
@@ -1,8 +1,8 @@
-import eslintPluginPlaywright from 'eslint-plugin-playwright';
-import { defineConfig } from 'eslint/config';
-import { name } from '../utils/name';
+import eslintPluginPlaywright from "eslint-plugin-playwright";
+import { defineConfig } from "eslint/config";
+import { name } from "../utils/name";
 
-const config = eslintPluginPlaywright.configs['flat/recommended'];
+const config = eslintPluginPlaywright.configs["flat/recommended"];
 
 /**
  * @returns eslint-plugin-playwright
@@ -13,8 +13,8 @@ export function playwright() {
   return defineConfig([
     {
       ...config,
-      files: ['**/e2e/**'],
-      name: name('playwright'),
+      files: ["**/e2e/**"],
+      name: name("playwright"),
       rules: {
         ...config.rules,
 
@@ -23,14 +23,14 @@ export function playwright() {
          *
          * @see https://github.com/playwright-community/eslint-plugin-playwright/blob/main/docs/rules/max-expects.md
          */
-        'playwright/max-expects': ['error', { max: 5 }],
+        "playwright/max-expects": ["error", { max: 5 }],
 
         /**
          * describeはnestの数の制限
          *
          * @see https://github.com/playwright-community/eslint-plugin-playwright/blob/main/docs/rules/max-nested-describe.md
          */
-        'playwright/max-nested-describe': ['error', { max: 2 }],
+        "playwright/max-nested-describe": ["error", { max: 2 }],
 
         /**
          * getByTitleは使わない。built in locatorsを使う。
@@ -39,14 +39,14 @@ export function playwright() {
          *
          * @see https://github.com/playwright-community/eslint-plugin-playwright/blob/main/docs/rules/no-get-by-title.md
          */
-        'playwright/no-get-by-title': 'warn',
+        "playwright/no-get-by-title": "warn",
 
         /**
          * setup and teardown hooksは使わない。関数を逐一呼び出す。
          *
          * @see https://github.com/playwright-community/eslint-plugin-playwright/blob/main/docs/rules/no-hooks.md
          */
-        'playwright/no-hooks': 'error',
+        "playwright/no-hooks": "error",
 
         /**
          * raw locatorsは使わない。built in locatorsを使う。
@@ -55,42 +55,42 @@ export function playwright() {
          *
          * @see https://github.com/playwright-community/eslint-plugin-playwright/blob/main/docs/rules/no-raw-locators.md
          */
-        'playwright/no-raw-locators': 'error',
+        "playwright/no-raw-locators": "error",
 
         /**
          * comparison-matcherでいけるところはcomparison-matcher使う
          *
          * @see https://github.com/playwright-community/eslint-plugin-playwright/blob/main/docs/rules/prefer-comparison-matcher.md
          */
-        'playwright/prefer-comparison-matcher': 'warn',
+        "playwright/prefer-comparison-matcher": "warn",
 
         /**
          * テストタイトルは小文字からはじめる
          *
          * @see https://github.com/playwright-community/eslint-plugin-playwright/blob/main/docs/rules/prefer-lowercase-title.md
          */
-        'playwright/prefer-lowercase-title': 'warn',
+        "playwright/prefer-lowercase-title": "warn",
 
         /**
          * toBeでいけるところはtoBe
          *
          * @see https://github.com/playwright-community/eslint-plugin-playwright/blob/main/docs/rules/prefer-to-be.md
          */
-        'playwright/prefer-to-be': 'warn',
+        "playwright/prefer-to-be": "warn",
 
         /**
          * toContainでいけるところはtoContain
          *
          * @see https://github.com/playwright-community/eslint-plugin-playwright/blob/main/docs/rules/prefer-to-contain.md
          */
-        'playwright/prefer-to-contain': 'warn',
+        "playwright/prefer-to-contain": "warn",
 
         /**
          * toHaveLengthでいけるところはtoHaveLength
          *
          * @see https://github.com/playwright-community/eslint-plugin-playwright/blob/main/docs/rules/prefer-to-have-length.md
          */
-        'playwright/prefer-to-have-length': 'warn',
+        "playwright/prefer-to-have-length": "warn",
 
         // /**
         //  * describe内にテスト書く

--- a/packages/eslint-config/rules/prettier.ts
+++ b/packages/eslint-config/rules/prettier.ts
@@ -1,6 +1,6 @@
-import eslintConfigPrettier from 'eslint-config-prettier/flat';
-import { defineConfig } from 'eslint/config';
-import { name } from '../utils/name';
+import eslintConfigPrettier from "eslint-config-prettier/flat";
+import { defineConfig } from "eslint/config";
+import { name } from "../utils/name";
 
 /**
  * @returns eslint-config-prettier
@@ -11,7 +11,7 @@ export function prettier() {
   return defineConfig([
     {
       ...eslintConfigPrettier,
-      name: name('prettier'),
+      name: name("prettier"),
     },
   ]);
 }

--- a/packages/eslint-config/rules/react-hooks.ts
+++ b/packages/eslint-config/rules/react-hooks.ts
@@ -1,6 +1,6 @@
-import eslintPluginReactHooks from 'eslint-plugin-react-hooks';
-import { defineConfig } from 'eslint/config';
-import { name } from '../utils/name';
+import eslintPluginReactHooks from "eslint-plugin-react-hooks";
+import { defineConfig } from "eslint/config";
+import { name } from "../utils/name";
 
 /**
  * @returns eslint-plugin-react-hooks
@@ -11,7 +11,7 @@ export function reactHooks() {
   return defineConfig([
     {
       ...eslintPluginReactHooks.configs.flat.recommended,
-      name: name('react-hooks'),
+      name: name("react-hooks"),
     },
   ]);
 }

--- a/packages/eslint-config/rules/react-refresh.ts
+++ b/packages/eslint-config/rules/react-refresh.ts
@@ -1,6 +1,6 @@
-import eslintPluginReactRefresh from 'eslint-plugin-react-refresh';
-import { defineConfig } from 'eslint/config';
-import { name } from '../utils/name';
+import eslintPluginReactRefresh from "eslint-plugin-react-refresh";
+import { defineConfig } from "eslint/config";
+import { name } from "../utils/name";
 
 /**
  * @returns eslint-plugin-react-refresh
@@ -11,7 +11,7 @@ export function reactRefresh() {
   return defineConfig([
     {
       ...eslintPluginReactRefresh.configs.next,
-      name: name('react-refresh'),
+      name: name("react-refresh"),
     },
   ]);
 }

--- a/packages/eslint-config/rules/react.ts
+++ b/packages/eslint-config/rules/react.ts
@@ -1,6 +1,6 @@
-import eslintPluginReact from '@eslint-react/eslint-plugin';
-import { defineConfig } from 'eslint/config';
-import { name } from '../utils/name';
+import eslintPluginReact from "@eslint-react/eslint-plugin";
+import { defineConfig } from "eslint/config";
+import { name } from "../utils/name";
 
 /**
  * @returns `@eslint-react/eslint-plugin`
@@ -11,8 +11,8 @@ export function react() {
   return defineConfig([
     {
       // https://github.com/Rel1cx/eslint-react/blob/main/packages/plugins/eslint-plugin/src/configs/recommended-type-checked.ts
-      ...eslintPluginReact.configs['recommended-type-checked'],
-      name: name('react/recommended-type-checked'),
+      ...eslintPluginReact.configs["recommended-type-checked"],
+      name: name("react/recommended-type-checked"),
     },
   ]);
 }

--- a/packages/eslint-config/rules/regexp.ts
+++ b/packages/eslint-config/rules/regexp.ts
@@ -1,6 +1,6 @@
-import eslintPluginRegexp from 'eslint-plugin-regexp';
-import { defineConfig } from 'eslint/config';
-import { name } from '../utils/name';
+import eslintPluginRegexp from "eslint-plugin-regexp";
+import { defineConfig } from "eslint/config";
+import { name } from "../utils/name";
 
 /**
  * @returns eslint-plugin-regexp
@@ -10,8 +10,8 @@ import { name } from '../utils/name';
 export function regexp() {
   return defineConfig([
     {
-      ...eslintPluginRegexp.configs['flat/recommended'],
-      name: name('regexp'),
+      ...eslintPluginRegexp.configs["flat/recommended"],
+      name: name("regexp"),
     },
   ]);
 }

--- a/packages/eslint-config/rules/storybook.ts
+++ b/packages/eslint-config/rules/storybook.ts
@@ -1,9 +1,9 @@
-import type { Linter } from 'eslint';
-import eslintPluginStorybook from 'eslint-plugin-storybook';
-import { defineConfig } from 'eslint/config';
-import { name } from '../utils/name';
+import type { Linter } from "eslint";
+import eslintPluginStorybook from "eslint-plugin-storybook";
+import { defineConfig } from "eslint/config";
+import { name } from "../utils/name";
 
-const configs = eslintPluginStorybook.configs['flat/recommended'] as unknown as Linter.Config[];
+const configs = eslintPluginStorybook.configs["flat/recommended"] as unknown as Linter.Config[];
 const plugins = configs[0];
 
 /**
@@ -20,25 +20,25 @@ export function storybook() {
     {
       ...plugins,
       ...configs[1],
-      ignores: ['!.storybook'],
-      name: name('storybook'),
+      ignores: ["!.storybook"],
+      name: name("storybook"),
       rules: {
         /**
          * https://github.com/storybookjs/storybook/blob/next/code/lib/eslint-plugin/src/configs/flat/csf-strict.ts
          */
-        ...(eslintPluginStorybook.configs['flat/csf-strict'] as unknown as Linter.Config[])[1]?.rules,
+        ...(eslintPluginStorybook.configs["flat/csf-strict"] as unknown as Linter.Config[])[1]?.rules,
 
         /**
          * https://github.com/storybookjs/storybook/blob/next/code/lib/eslint-plugin/src/configs/flat/recommended.ts
          */
-        ...(eslintPluginStorybook.configs['flat/recommended'] as unknown as Linter.Config[])[1]?.rules,
+        ...(eslintPluginStorybook.configs["flat/recommended"] as unknown as Linter.Config[])[1]?.rules,
       },
     },
     {
       ...plugins,
       ...configs[2],
-      ignores: ['!.storybook'],
-      name: name('storybook/add-ons'),
+      ignores: ["!.storybook"],
+      name: name("storybook/add-ons"),
       rules: {
         /**
          * https://github.com/storybookjs/storybook/blob/next/code/lib/eslint-plugin/src/configs/flat/recommended.ts

--- a/packages/eslint-config/rules/stylistic.ts
+++ b/packages/eslint-config/rules/stylistic.ts
@@ -1,6 +1,6 @@
-import eslintPluginStylistic from '@stylistic/eslint-plugin';
-import { defineConfig } from 'eslint/config';
-import { name } from '../utils/name';
+import eslintPluginStylistic from "@stylistic/eslint-plugin";
+import { defineConfig } from "eslint/config";
+import { name } from "../utils/name";
 
 /**
  * @returns @stylistic/eslint-plugin
@@ -10,9 +10,9 @@ import { name } from '../utils/name';
 export function stylistic() {
   return defineConfig([
     {
-      name: name('stylistic'),
+      name: name("stylistic"),
       plugins: {
-        '@stylistic': eslintPluginStylistic,
+        "@stylistic": eslintPluginStylistic,
       },
       rules: {
         /**
@@ -20,20 +20,20 @@ export function stylistic() {
          *
          * @see https://eslint.org/docs/latest/rules/padding-line-between-statements#rule-details
          */
-        '@stylistic/padding-line-between-statements': [
-          'warn',
-          { blankLine: 'always', next: 'block', prev: '*' },
-          { blankLine: 'always', next: 'function', prev: '*' },
-          { blankLine: 'always', next: 'export', prev: '*' },
-          { blankLine: 'always', next: 'for', prev: '*' },
-          { blankLine: 'always', next: 'if', prev: '*' },
-          { blankLine: 'always', next: '*', prev: 'import' },
-          { blankLine: 'never', next: 'import', prev: 'import' },
-          { blankLine: 'always', next: 'return', prev: '*' },
-          { blankLine: 'always', next: 'switch', prev: '*' },
-          { blankLine: 'always', next: 'throw', prev: '*' },
-          { blankLine: 'always', next: 'try', prev: '*' },
-          { blankLine: 'always', next: 'while', prev: '*' },
+        "@stylistic/padding-line-between-statements": [
+          "warn",
+          { blankLine: "always", next: "block", prev: "*" },
+          { blankLine: "always", next: "function", prev: "*" },
+          { blankLine: "always", next: "export", prev: "*" },
+          { blankLine: "always", next: "for", prev: "*" },
+          { blankLine: "always", next: "if", prev: "*" },
+          { blankLine: "always", next: "*", prev: "import" },
+          { blankLine: "never", next: "import", prev: "import" },
+          { blankLine: "always", next: "return", prev: "*" },
+          { blankLine: "always", next: "switch", prev: "*" },
+          { blankLine: "always", next: "throw", prev: "*" },
+          { blankLine: "always", next: "try", prev: "*" },
+          { blankLine: "always", next: "while", prev: "*" },
         ],
       },
     },

--- a/packages/eslint-config/rules/tailwindcss.ts
+++ b/packages/eslint-config/rules/tailwindcss.ts
@@ -1,6 +1,6 @@
-import eslintPluginBetterTailwindcss from 'eslint-plugin-better-tailwindcss';
-import { defineConfig } from 'eslint/config';
-import { name } from '../utils/name';
+import eslintPluginBetterTailwindcss from "eslint-plugin-better-tailwindcss";
+import { defineConfig } from "eslint/config";
+import { name } from "../utils/name";
 
 type Options = {
   entryPoint?: string;
@@ -14,19 +14,19 @@ type Options = {
 export function betterTailwindcss(options?: Options) {
   return defineConfig([
     {
-      name: name('tailwindcss'),
+      name: name("tailwindcss"),
       plugins: {
-        'better-tailwindcss': eslintPluginBetterTailwindcss,
+        "better-tailwindcss": eslintPluginBetterTailwindcss,
       },
       rules: {
-        ...eslintPluginBetterTailwindcss.configs['recommended-warn'].rules,
+        ...eslintPluginBetterTailwindcss.configs["recommended-warn"].rules,
 
         // Prettierと競合する
-        'better-tailwindcss/enforce-consistent-line-wrapping': 'off',
+        "better-tailwindcss/enforce-consistent-line-wrapping": "off",
       },
       settings: {
-        'better-tailwindcss': {
-          entryPoint: options?.entryPoint ?? 'src/global.css',
+        "better-tailwindcss": {
+          entryPoint: options?.entryPoint ?? "src/global.css",
         },
       },
     },

--- a/packages/eslint-config/rules/typescript.ts
+++ b/packages/eslint-config/rules/typescript.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from 'eslint/config';
-import tseslint from 'typescript-eslint';
-import { name } from '../utils/name';
+import { defineConfig } from "eslint/config";
+import tseslint from "typescript-eslint";
+import { name } from "../utils/name";
 
 /**
  * @returns typescript-eslint
@@ -18,48 +18,48 @@ export function typescript() {
     // https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/flat/stylistic-type-checked.ts
     tseslint.configs.stylisticTypeChecked,
     {
-      files: ['**/*.{ts,tsx}'],
-      name: name('typescript'),
+      files: ["**/*.{ts,tsx}"],
+      name: name("typescript"),
       rules: {
         /**
          * interfaceではなくtypeを使う
          *
          * @see https://typescript-eslint.io/rules/consistent-type-definitions
          */
-        '@typescript-eslint/consistent-type-definitions': ['warn', 'type'],
+        "@typescript-eslint/consistent-type-definitions": ["warn", "type"],
 
         // Method shorthand syntaxではなくObject property syntaxで関数の型定義する
         // https://www.totaltypescript.com/method-shorthand-syntax-considered-harmful
-        '@typescript-eslint/method-signature-style': ['error', 'property'],
+        "@typescript-eslint/method-signature-style": ["error", "property"],
 
         // Promiseをちゃんと処理する。VoidやIIFEは無視してよい。
-        '@typescript-eslint/no-floating-promises': ['error', { ignoreIIFE: true, ignoreVoid: true }],
+        "@typescript-eslint/no-floating-promises": ["error", { ignoreIIFE: true, ignoreVoid: true }],
 
         /**
          * 使ってない引数はアンダースコア始まりにする
          *
          * @see https://typescript-eslint.io/rules/no-unused-vars
          */
-        '@typescript-eslint/no-unused-vars': [
-          'warn',
+        "@typescript-eslint/no-unused-vars": [
+          "warn",
           {
-            argsIgnorePattern: '^_',
-            caughtErrorsIgnorePattern: '^_',
-            destructuredArrayIgnorePattern: '^_',
+            argsIgnorePattern: "^_",
+            caughtErrorsIgnorePattern: "^_",
+            destructuredArrayIgnorePattern: "^_",
           },
         ],
       },
     },
     {
-      files: ['**/*.d.ts'],
-      name: name('typescript/d.ts'),
+      files: ["**/*.d.ts"],
+      name: name("typescript/d.ts"),
       rules: {
         /**
          * typeではなくinterfaceを使う
          *
          * @see https://typescript-eslint.io/rules/consistent-type-definitions
          */
-        '@typescript-eslint/consistent-type-definitions': ['warn', 'interface'],
+        "@typescript-eslint/consistent-type-definitions": ["warn", "interface"],
       },
     },
   ]);

--- a/packages/eslint-config/rules/unicorn.ts
+++ b/packages/eslint-config/rules/unicorn.ts
@@ -1,7 +1,7 @@
-import eslintPluginUnicorn from 'eslint-plugin-unicorn';
-import { defineConfig } from 'eslint/config';
-import globals from 'globals';
-import { name } from '../utils/name';
+import eslintPluginUnicorn from "eslint-plugin-unicorn";
+import { defineConfig } from "eslint/config";
+import globals from "globals";
+import { name } from "../utils/name";
 
 /**
  * @returns eslint-plugin-unicorn
@@ -14,7 +14,7 @@ export function unicorn() {
       languageOptions: {
         globals: globals.builtin,
       },
-      name: name('unicorn'),
+      name: name("unicorn"),
       plugins: {
         unicorn: eslintPluginUnicorn,
       },
@@ -26,14 +26,14 @@ export function unicorn() {
          *
          * @see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-null.md
          */
-        'unicorn/no-null': 'off',
+        "unicorn/no-null": "off",
 
         /**
          * 略語の制限。やるなら明示的にreplacementを記載していく
          *
          * @see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prevent-abbreviations.md
          */
-        'unicorn/prevent-abbreviations': 'off',
+        "unicorn/prevent-abbreviations": "off",
       },
     },
   ]);

--- a/packages/eslint-config/rules/viest.ts
+++ b/packages/eslint-config/rules/viest.ts
@@ -1,6 +1,6 @@
-import eslintPluginVitest from '@vitest/eslint-plugin';
-import { defineConfig } from 'eslint/config';
-import { name } from '../utils/name';
+import eslintPluginVitest from "@vitest/eslint-plugin";
+import { defineConfig } from "eslint/config";
+import { name } from "../utils/name";
 
 /**
  * @returns eslint-plugin-vitest
@@ -11,9 +11,9 @@ export function viest() {
   return defineConfig([
     {
       ...eslintPluginVitest.configs.all,
-      files: ['**/*.{test,spec}.{ts,tsx}'],
-      ignores: ['**/e2e/**'],
-      name: name('viest'),
+      files: ["**/*.{test,spec}.{ts,tsx}"],
+      ignores: ["**/e2e/**"],
+      name: name("viest"),
 
       rules: {
         ...eslintPluginVitest.configs.all.rules,
@@ -24,22 +24,22 @@ export function viest() {
          *
          * @see https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/consistent-test-filename.md
          */
-        'vitest/consistent-test-filename': ['error', { pattern: String.raw`.*\.test\.[tj]sx?$` }],
+        "vitest/consistent-test-filename": ["error", { pattern: String.raw`.*\.test\.[tj]sx?$` }],
 
         /**
          * itでなくtest句でテスト書く
          */
-        'vitest/consistent-test-it': ['warn', { fn: 'test' }],
+        "vitest/consistent-test-it": ["warn", { fn: "test" }],
 
         /**
          * 同一テスト内で複数expectやめる
          */
-        'vitest/max-expects': ['error', { max: 1 }],
+        "vitest/max-expects": ["error", { max: 1 }],
 
         /**
          * describeのネストやめる
          */
-        'vitest/max-nested-describe': ['error', { max: 1 }],
+        "vitest/max-nested-describe": ["error", { max: 1 }],
 
         /**
          * Deprecated
@@ -47,15 +47,15 @@ export function viest() {
          *
          * https://github.com/vitest-dev/eslint-plugin-vitest/issues/312
          */
-        'vitest/no-done-callback': 'off',
+        "vitest/no-done-callback": "off",
 
         /**
          * 非同期テストなどで、期待されるアサーションが呼び出されない場合を防ぐ
          *
          * @see https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-expect-assertions.md
          */
-        'vitest/prefer-expect-assertions': [
-          'warn',
+        "vitest/prefer-expect-assertions": [
+          "warn",
           {
             onlyFunctionsWithExpectInCallback: true,
             onlyFunctionsWithExpectInLoop: true,
@@ -67,7 +67,7 @@ export function viest() {
          *
          * @see https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/require-top-level-describe.md
          */
-        'vitest/require-top-level-describe': 'off',
+        "vitest/require-top-level-describe": "off",
       },
     },
   ]);

--- a/packages/eslint-config/scripts/typegen.ts
+++ b/packages/eslint-config/scripts/typegen.ts
@@ -1,5 +1,5 @@
-import typegen from 'eslint-typegen';
-import configs from '../eslint.config';
+import typegen from "eslint-typegen";
+import configs from "../eslint.config";
 
 /**
  * import typegen from 'eslint-typegen'

--- a/packages/eslint-config/utils/name.ts
+++ b/packages/eslint-config/utils/name.ts
@@ -1,6 +1,6 @@
-import pkg from '../package.json' with { type: 'json' };
+import pkg from "../package.json" with { type: "json" };
 
-const scope = pkg.name.split('/')[0];
+const scope = pkg.name.split("/")[0];
 
 /**
  * @param name The config name.

--- a/packages/eslint-config/utils/package-json.ts
+++ b/packages/eslint-config/utils/package-json.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from 'node:fs';
-import path from 'node:path';
+import { readFileSync } from "node:fs";
+import path from "node:path";
 
 type PackageJson = {
   pnpm?: {
@@ -17,8 +17,8 @@ type PackageJson = {
 export function getNodeVersion(): string | undefined {
   try {
     // プロジェクトルートのpackage.jsonを読み込み
-    const packageJsonPath = path.join(process.cwd(), 'package.json');
-    const packageJsonContent = readFileSync(packageJsonPath, 'utf8');
+    const packageJsonPath = path.join(process.cwd(), "package.json");
+    const packageJsonContent = readFileSync(packageJsonPath, "utf8");
     const packageJson = JSON.parse(packageJsonContent) as PackageJson;
 
     return packageJson.pnpm?.executionEnv?.nodeVersion;

--- a/packages/lefthook-config/src/cli.ts
+++ b/packages/lefthook-config/src/cli.ts
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
-import { spawn } from 'node:child_process';
-import { createRequire } from 'node:module';
+import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
-const cli = require.resolve('git-harvest/lib/git-harvest');
+const cli = require.resolve("git-harvest/lib/git-harvest");
 
-spawn('bash', [cli, ...process.argv.slice(2)], { stdio: 'inherit' }).on('exit', (code) =>
-  process.exit(code ?? 1),
-);
+spawn("bash", [cli, ...process.argv.slice(2)], { stdio: "inherit" }).on("exit", (code) => process.exit(code ?? 1));

--- a/packages/lefthook-config/tsdown.config.ts
+++ b/packages/lefthook-config/tsdown.config.ts
@@ -1,9 +1,9 @@
-import { defineConfig } from 'tsdown';
+import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ['src/cli.ts'],
-  format: ['esm'],
+  entry: ["src/cli.ts"],
+  format: ["esm"],
   clean: true,
-  platform: 'node',
-  outExtensions: () => ({ js: '.js' }),
+  platform: "node",
+  outExtensions: () => ({ js: ".js" }),
 });

--- a/packages/markdownlint-cli2-config/src/index.ts
+++ b/packages/markdownlint-cli2-config/src/index.ts
@@ -13,7 +13,7 @@ export default {
      * {@link https://github.com/DavidAnson/markdownlint/blob/main/doc/md004.md}
      */
     MD004: {
-      style: 'dash',
+      style: "dash",
     },
 
     /**
@@ -37,5 +37,5 @@ export default {
     MD033: false,
   },
 
-  ignores: ['**/node_modules', '**/submodules', 'LICENSE', '.git'],
+  ignores: ["**/node_modules", "**/submodules", "LICENSE", ".git"],
 };

--- a/packages/markdownlint-cli2-config/tsdown.config.ts
+++ b/packages/markdownlint-cli2-config/tsdown.config.ts
@@ -1,10 +1,10 @@
-import { defineConfig } from 'tsdown';
+import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ['src/index.ts'],
-  format: ['esm'],
+  entry: ["src/index.ts"],
+  format: ["esm"],
   dts: true,
   clean: true,
-  platform: 'node',
-  outExtensions: () => ({ js: '.js', dts: '.d.ts' }),
+  platform: "node",
+  outExtensions: () => ({ js: ".js", dts: ".d.ts" }),
 });

--- a/packages/nozo/src/commands/init.ts
+++ b/packages/nozo/src/commands/init.ts
@@ -1,32 +1,32 @@
-import * as p from '@clack/prompts';
-import { defineCommand } from 'citty';
-import { consola } from 'consola';
+import * as p from "@clack/prompts";
+import { defineCommand } from "citty";
+import { consola } from "consola";
 
 export default defineCommand({
   meta: {
-    name: 'init',
-    description: 'Initialize a project with nozo configs',
+    name: "init",
+    description: "Initialize a project with nozo configs",
   },
   args: {
     tool: {
-      type: 'positional',
+      type: "positional",
       required: false,
-      description: 'Tool to set up (lefthook, commitlint, cspell)',
+      description: "Tool to set up (lefthook, commitlint, cspell)",
     },
     verbose: {
-      type: 'boolean',
-      alias: 'v',
-      description: 'Verbose output',
+      type: "boolean",
+      alias: "v",
+      description: "Verbose output",
     },
   },
   async run({ args }) {
     if (args.verbose) consola.level = 4;
 
-    p.intro('🥊 nozo init');
-    consola.info('init はまだ骨格だけです');
+    p.intro("🥊 nozo init");
+    consola.info("init はまだ骨格だけです");
     if (args.tool) {
       consola.info(`requested tool: ${args.tool}`);
     }
-    p.outro('done');
+    p.outro("done");
   },
 });

--- a/packages/nozo/src/index.ts
+++ b/packages/nozo/src/index.ts
@@ -1,18 +1,18 @@
 #!/usr/bin/env node
-import { defineCommand, runMain } from 'citty';
-import { consola } from 'consola';
-import { spawn } from 'node:child_process';
-import { access, constants } from 'node:fs/promises';
-import { delimiter, join } from 'node:path';
+import { defineCommand, runMain } from "citty";
+import { consola } from "consola";
+import { spawn } from "node:child_process";
+import { access, constants } from "node:fs/promises";
+import { delimiter, join } from "node:path";
 
-import pkg from '../package.json' with { type: 'json' };
-import init from './commands/init.js';
+import pkg from "../package.json" with { type: "json" };
+import init from "./commands/init.js";
 
-const BUILTIN_COMMANDS = new Set(['init']);
+const BUILTIN_COMMANDS = new Set(["init"]);
 
 async function findOnPath(name: string): Promise<null | string> {
-  const exe = process.platform === 'win32' ? `${name}.exe` : name;
-  for (const dir of (process.env.PATH ?? '').split(delimiter)) {
+  const exe = process.platform === "win32" ? `${name}.exe` : name;
+  for (const dir of (process.env.PATH ?? "").split(delimiter)) {
     if (!dir) continue;
     const candidate = join(dir, exe);
     try {
@@ -27,14 +27,14 @@ async function findOnPath(name: string): Promise<null | string> {
 
 async function execExternal(command: string, args: string[]): Promise<number> {
   return new Promise((resolve) => {
-    const child = spawn(command, args, { stdio: 'inherit' });
-    child.on('exit', (code) => resolve(code ?? 0));
-    child.on('error', () => resolve(1));
+    const child = spawn(command, args, { stdio: "inherit" });
+    child.on("exit", (code) => resolve(code ?? 0));
+    child.on("error", () => resolve(1));
   });
 }
 
 const sub = process.argv[2];
-const isFlag = sub?.startsWith('-') ?? false;
+const isFlag = sub?.startsWith("-") ?? false;
 const isBuiltin = sub !== undefined && BUILTIN_COMMANDS.has(sub);
 
 if (sub !== undefined && !isFlag && !isBuiltin) {
@@ -50,7 +50,7 @@ if (sub !== undefined && !isFlag && !isBuiltin) {
 // Built-in command (or --help / --version / no args) → citty に委譲
 const main = defineCommand({
   meta: {
-    name: 'nozo',
+    name: "nozo",
     version: pkg.version,
     description: "Nozomi's config manager",
   },

--- a/packages/nozo/tsdown.config.ts
+++ b/packages/nozo/tsdown.config.ts
@@ -1,9 +1,9 @@
-import { defineConfig } from 'tsdown';
+import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ['src/index.ts'],
-  format: ['esm'],
+  entry: ["src/index.ts"],
+  format: ["esm"],
   clean: true,
-  platform: 'node',
-  outExtensions: () => ({ js: '.js' }),
+  platform: "node",
+  outExtensions: () => ({ js: ".js" }),
 });

--- a/packages/postinstall/src/act.ts
+++ b/packages/postinstall/src/act.ts
@@ -1,15 +1,15 @@
-import { fs, echo, path } from 'zx';
+import { fs, echo, path } from "zx";
 
-const TARGET_FILE = '.actrc';
-const EXAMPLE_FILE = '.actrc.example';
+const TARGET_FILE = ".actrc";
+const EXAMPLE_FILE = ".actrc.example";
 
 /**
  * Setup act
  */
 export async function setupAct() {
-  echo('Setup act');
+  echo("Setup act");
 
-  const projectRoot = process.env.INIT_CWD || '.';
+  const projectRoot = process.env.INIT_CWD || ".";
   const actrcExamplePath = path.resolve(projectRoot, EXAMPLE_FILE);
   const targetFilePath = path.resolve(projectRoot, TARGET_FILE);
 

--- a/packages/postinstall/src/git.ts
+++ b/packages/postinstall/src/git.ts
@@ -1,10 +1,10 @@
-import { echo, $ } from 'zx';
+import { echo, $ } from "zx";
 
 /**
  * Setup git
  */
 export async function setupGit() {
-  echo('Setup git');
+  echo("Setup git");
 
   // Gitでファイルの大文字小文字を区別
   await $`git config core.ignorecase false`;

--- a/packages/postinstall/src/index.ts
+++ b/packages/postinstall/src/index.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
-import { setupLefthook } from './lefthook';
-import { setupVSCode } from './vscode';
-import { welcome } from './welcome';
-import { setupAct } from './act';
-import { setupGit } from './git';
+import { setupLefthook } from "./lefthook";
+import { setupVSCode } from "./vscode";
+import { welcome } from "./welcome";
+import { setupAct } from "./act";
+import { setupGit } from "./git";
 
 await setupGit();
 await setupVSCode();

--- a/packages/postinstall/src/lefthook.ts
+++ b/packages/postinstall/src/lefthook.ts
@@ -1,6 +1,6 @@
-import { fs, $, echo } from 'zx';
+import { fs, $, echo } from "zx";
 
-const TARGET_FILE = 'lefthook-local.yaml';
+const TARGET_FILE = "lefthook-local.yaml";
 
 /**
  * Create a local config file
@@ -17,7 +17,7 @@ async function createLocalConfig() {
  * Setup lefthook
  */
 export async function setupLefthook() {
-  echo('Setup lefthook');
+  echo("Setup lefthook");
 
   try {
     await createLocalConfig();

--- a/packages/postinstall/src/vscode.ts
+++ b/packages/postinstall/src/vscode.ts
@@ -1,15 +1,15 @@
-import { echo, fs, glob, path } from 'zx';
+import { echo, fs, glob, path } from "zx";
 
 /**
  * Recursively convert .vscode/settings.example.jsonc to .vscode/settings.json
  */
 export async function setupVSCode() {
-  echo('Setup vscode');
+  echo("Setup vscode");
 
-  const examples = await glob(['**/.vscode/settings.example.jsonc']);
+  const examples = await glob(["**/.vscode/settings.example.jsonc"]);
 
   for (const example of examples) {
-    const file = path.join(path.dirname(example), 'settings.json');
+    const file = path.join(path.dirname(example), "settings.json");
 
     if (fs.existsSync(file)) {
       echo(`Skipped: ${file} already exists.`);

--- a/packages/postinstall/src/welcome.ts
+++ b/packages/postinstall/src/welcome.ts
@@ -1,14 +1,14 @@
-import figlet from 'figlet';
-import { echo } from 'zx';
-import fs from 'node:fs';
-import path from 'node:path';
+import figlet from "figlet";
+import { echo } from "zx";
+import fs from "node:fs";
+import path from "node:path";
 
 /**
  * Convert text to ASCII art
  */
 function createAsciiArt(text: string) {
   return figlet.textSync(text, {
-    font: 'ANSI Shadow',
+    font: "ANSI Shadow",
   });
 }
 
@@ -20,11 +20,11 @@ export async function welcome() {
     // Get workspace root package.json path using INIT_CWD
     // INIT_CWD contains the directory where the command (e.g., pnpm install) was originally run.
     // See: https://docs.npmjs.com/cli/v10/using-npm/scripts#environment
-    const projectRoot = process.env.INIT_CWD || '.';
-    const packageJsonPath = path.resolve(projectRoot, 'package.json');
+    const projectRoot = process.env.INIT_CWD || ".";
+    const packageJsonPath = path.resolve(projectRoot, "package.json");
 
     // Read and parse package.json
-    const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf-8');
+    const packageJsonContent = fs.readFileSync(packageJsonPath, "utf-8");
     const { name } = JSON.parse(packageJsonContent);
 
     // Don't display anything if package name is missing
@@ -33,8 +33,8 @@ export async function welcome() {
     }
 
     // For scoped packages (e.g., @scope/name)
-    if (name.includes('/')) {
-      const [scope, namePart] = name.split('/');
+    if (name.includes("/")) {
+      const [scope, namePart] = name.split("/");
       echo(`${scope}/`);
       echo(createAsciiArt(namePart));
       return;
@@ -43,6 +43,6 @@ export async function welcome() {
     // For non-scoped packages
     echo(createAsciiArt(name));
   } catch (error) {
-    console.error('Failed to display welcome message:', error);
+    console.error("Failed to display welcome message:", error);
   }
 }

--- a/packages/postinstall/tests/build.test.ts
+++ b/packages/postinstall/tests/build.test.ts
@@ -1,17 +1,17 @@
-import { execSync } from 'node:child_process';
-import { readdirSync } from 'node:fs';
-import { resolve } from 'node:path';
-import { test, expect } from 'vitest';
+import { execSync } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { test, expect } from "vitest";
 
-const packageDir = resolve(import.meta.dirname, '..');
-const distDir = resolve(packageDir, 'dist');
+const packageDir = resolve(import.meta.dirname, "..");
+const distDir = resolve(packageDir, "dist");
 
 // ビルド成果物に .map ファイルが含まれないことを検証する
 // `pnpm build` の実行を含むため、CI runner の負荷ブレで 5s デフォルトを超えうる（実測 5137ms / 7143ms）
-test('build output should not contain .map files', { timeout: 30_000 }, () => {
-  execSync('pnpm build', { cwd: packageDir });
+test("build output should not contain .map files", { timeout: 30_000 }, () => {
+  execSync("pnpm build", { cwd: packageDir });
 
-  const mapFiles = readdirSync(distDir).filter((f) => f.endsWith('.map'));
+  const mapFiles = readdirSync(distDir).filter((f) => f.endsWith(".map"));
 
   expect(mapFiles).toStrictEqual([]);
 });

--- a/packages/postinstall/tsdown.config.ts
+++ b/packages/postinstall/tsdown.config.ts
@@ -1,10 +1,10 @@
-import { defineConfig } from 'tsdown';
+import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ['src/index.ts'],
-  format: ['esm'],
+  entry: ["src/index.ts"],
+  format: ["esm"],
   dts: true,
   clean: true,
-  platform: 'node',
-  outExtensions: () => ({ js: '.js', dts: '.d.ts' }),
+  platform: "node",
+  outExtensions: () => ({ js: ".js", dts: ".d.ts" }),
 });

--- a/packages/prettier-config/src/index.ts
+++ b/packages/prettier-config/src/index.ts
@@ -17,8 +17,8 @@ export default {
   // Prettier default 文末にセミコロンを付ける
   semi: true,
 
-  // ダブルクォート派だったが、tutorial の先生たちがシングルクォート多めだったので合わせた (default は false)
-  singleQuote: true,
+  // Prettier default ダブルクォートを使う (apostrophe を含む string と混在しにくく、Prettier の escape 最少優先 logic とも整合)
+  singleQuote: false,
 
   // Prettier default 必要なときだけプロパティ名をクオート
   quoteProps: 'as-needed',

--- a/packages/prettier-config/src/index.ts
+++ b/packages/prettier-config/src/index.ts
@@ -1,4 +1,4 @@
-import type { Config } from 'prettier';
+import type { Config } from "prettier";
 
 /**
  * Prettier options
@@ -21,13 +21,13 @@ export default {
   singleQuote: false,
 
   // Prettier default 必要なときだけプロパティ名をクオート
-  quoteProps: 'as-needed',
+  quoteProps: "as-needed",
 
   // Prettier default JSX 属性はダブルクォート (HTML 慣習)
   jsxSingleQuote: false,
 
   // Prettier default 関数引数や型パラメータも含め可能な限り末尾カンマを付ける
-  trailingComma: 'all',
+  trailingComma: "all",
 
   // Prettier default オブジェクトリテラルの { 直後と } 直前にスペース ({ a } 形式)
   bracketSpacing: true,
@@ -36,7 +36,7 @@ export default {
   bracketSameLine: false,
 
   // Prettier default アロー関数の引数が 1 つでも括弧を付ける
-  arrowParens: 'always',
+  arrowParens: "always",
 
   // Prettier default pragma が無くても全ファイルを format
   requirePragma: false,
@@ -45,39 +45,39 @@ export default {
   insertPragma: false,
 
   // Prettier default Markdown の改行・折り返しを元の状態のまま保つ
-  proseWrap: 'preserve',
+  proseWrap: "preserve",
 
   // Prettier default CSS の display 値で HTML 内空白の扱いを判定
-  htmlWhitespaceSensitivity: 'css',
+  htmlWhitespaceSensitivity: "css",
 
   // Prettier default Vue SFC の <script>/<style> 内をインデントしない
   vueIndentScriptAndStyle: false,
 
   // Prettier default 改行コードは LF
-  endOfLine: 'lf',
+  endOfLine: "lf",
 
   // Prettier default template literal 等の埋め込み言語も format
-  embeddedLanguageFormatting: 'auto',
+  embeddedLanguageFormatting: "auto",
 
   // Prettier default HTML/JSX 属性を 1 行ずつにしない
   singleAttributePerLine: false,
 
   // Prettier default 複数行に分かれたオブジェクトの改行スタイルを保つ
-  objectWrap: 'preserve',
+  objectWrap: "preserve",
 
-  plugins: ['prettier-plugin-packagejson'],
+  plugins: ["prettier-plugin-packagejson"],
 
   overrides: [
     {
       // prettier の format を実行したくないものを指定
       files: [
-        'pnpm-lock.yaml',
-        'submodules/**',
+        "pnpm-lock.yaml",
+        "submodules/**",
         // Next.js が next dev のたびに自動生成上書きするため
-        'next-env.d.ts',
+        "next-env.d.ts",
         // markdown は remark で行う
-        '*.md',
-        '*.mdx',
+        "*.md",
+        "*.mdx",
       ],
       options: {
         requirePragma: true,
@@ -87,9 +87,9 @@ export default {
       // JSONC / JSON5 は native parser に委ねコメント等の言語機能を保つ。
       // ただし VSCode の JSONC モードは trailing comma を allowed-but-discouraged 扱いで warning を出す
       // ({@link https://code.visualstudio.com/docs/languages/json}) ため、自動付与は止める
-      files: ['*.json5', '*.jsonc'],
+      files: ["*.json5", "*.jsonc"],
       options: {
-        trailingComma: 'none',
+        trailingComma: "none",
       },
     },
   ],

--- a/packages/prettier-config/tsdown.config.ts
+++ b/packages/prettier-config/tsdown.config.ts
@@ -1,10 +1,10 @@
-import { defineConfig } from 'tsdown';
+import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ['src/index.ts'],
-  format: ['esm'],
+  entry: ["src/index.ts"],
+  format: ["esm"],
   dts: true,
   clean: true,
-  platform: 'node',
-  outExtensions: () => ({ js: '.js', dts: '.d.ts' }),
+  platform: "node",
+  outExtensions: () => ({ js: ".js", dts: ".d.ts" }),
 });

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,20 +8,20 @@
 useNodeVersion: 24.15.0
 
 packages:
-  - 'packages/*'
+  - "packages/*"
 
 # モノレポのpackagesもシンボリックリンクで管理する
 linkWorkspacePackages: true
 
 # 依存解決のうまくいっていないdependenciesのdependenciesをrootのnode_modulesまで巻き上げる
 publicHoistPattern:
-  - '@types/*'
-  - '*eslint*'
-  - '*prettier*'
-  - '*storybook*'
+  - "@types/*"
+  - "*eslint*"
+  - "*prettier*"
+  - "*storybook*"
 
 # pinバージョンでインストールする
-savePrefix: ''
+savePrefix: ""
 
 # 公開から3日未満のバージョンをインストールしない（サプライチェーン攻撃対策）
 # https://pnpm.io/settings#minimumreleaseage

--- a/prettier.config.ts
+++ b/prettier.config.ts
@@ -1,1 +1,1 @@
-export { default } from '@nozomiishii/prettier-config';
+export { default } from "@nozomiishii/prettier-config";


### PR DESCRIPTION
> ⚠️ **このPRは [#2139](https://github.com/nozomiishii/configs/pull/2139) (audit findings) を base にしている stacked PR**。先に #2139 をマージ後、自動的に main 基底に rebase される。

## 概要

`@nozomiishii/prettier-config` の `singleQuote` を **`true` → `false`** (= Prettier default) に戻す。**BREAKING CHANGE**: consumer 側のすべての string literal が `'...'` → `"..."` に再 format される。

## 議論の経緯

`@nozomiishii/prettier-config` は元々 `singleQuote: true` を採用しており、README にも「ダブルクォート派だったが、tutorial の先生たちがシングルクォート多めだったので合わせた」と「**なんとなく決めた**」 旨の記載があった。

audit で見直す際、Prettier の quote 選択ロジックの動作を [公式 rationale](https://prettier.io/docs/rationale) で再確認したところ、**`singleQuote` が想定より遥かに弱い設定**であることが判明した:

> "Prettier chooses the one which results in the fewest number of escapes. In case of a tie or the string not containing any quotes, Prettier defaults to double quotes (but that can be changed via the singleQuote option)."

## なぜ `false` (Prettier default) に戻すか

### 1. `singleQuote` は実質「タイブレーカー」しか効かない

| `singleQuote` 設定 | `'He said "hi"'` (double 含む) | `"It's a test"` (single 含む) | `"hello"` (どちらも無し) |
|---|---|---|---|
| `false` (default) | `'He said "hi"'` | `"It's a test"` | `"hello"` |
| `true` | `'He said "hi"'` | `"It's a test"` | `'hello'` |

→ **クォートを含まない文字列だけが設定値の影響を受ける**。それ以外は escape 最少優先で自動決定される (Prettier の logic)。

### 2. 英語 string は apostrophe を含むケースが多い

`"don't"`, `"it's"`, `"user's profile"` など apostrophe を含む string は **設定に関わらず常に double quote** で出力される (escape 最少 logic)。

`singleQuote: true` だとこれらは double, それ以外は single → **同じファイル内で単純混在**

`singleQuote: false` だと全部 double → **codebase 全体の quote が統一される**

→ **default false (double) のほうが consistency が高い**

### 3. Prettier が `false` を default にしている公式根拠

[Prettier docs (Strings rationale)](https://prettier.io/docs/rationale#strings) より:

> "JSX has its roots from HTML, where the dominant use of quotes for attributes is double quotes. Browser developer tools also follow this convention by always displaying HTML with double quotes, even if the source code uses single quotes."

→ **HTML/JSX 慣習との整合**。JSX 属性は別 option (`jsxSingleQuote`) で制御するが、JS/TS string も同じ default を取るのが自然。

### 4. 元 README の表記「なんとなく決めた」 が今や根拠としては弱い

audit 段階で `singleQuote: true` を維持する積極的根拠が見当たらなかった。default に戻した方が:
- Prettier の一般的慣習に沿う
- consumer 移行時の差分要求に応える理由が明確
- 「**なぜこの値か**」の説明が **短く明快** になる (= "Prettier default")

## 反対理由 (考慮したが採用しなかった)

- 「**single quote 派の人もいる**」 → consumer 側で `prettier.config.js` に `singleQuote: true` を override すれば opt-out 可能。default を変えても消える機能ではない。
- 「**diff が大きくなる**」 → 初回 format で大きな diff が出るが、以降の差分は安定する。今回の repo 自体も 55 files の cascade で発生したが、機械的 reformat なので review コストは低い (commit を分割してある)。

## BREAKING CHANGE

- `@nozomiishii/prettier-config` の `singleQuote` default を `true` → `false` に変更
- 次回 format 実行時、 consumer の **すべての string literal が `'...'` → `"..."` に書き換わる**
- 互換性を維持したい consumer は自前 `prettier.config.js` で `singleQuote: true` を明示することで opt-out 可能

## このリポジトリでの cascade

本 repo にも `@nozomiishii/prettier-config` が `workspace:*` で読まれているため、自動的に re-format される (= **dogfood**)。**設計判断**を表す `feat(prettier-config)!:` commit と、**機械的 cascade** を表す `chore:` commit を **分けて** いるので、レビューは前者のみで設計判断を把握できる。

| Commit | Type | 内容 |
|--------|------|------|
| `feat(prettier-config)!: revert singleQuote to Prettier default (false)` | 設計変更 | src/index.ts の値変更 (1 ファイル, 2 行) |
| `chore: reformat repo to double quotes after singleQuote default change` | 機械的反映 | リポジトリ全体の re-format (55 files) |

## 検証

- `pnpm --filter @nozomiishii/prettier-config build` ✅
- `pnpm format` ✅
- `pnpm -r --if-present run lint` ✅ (pre-push hook で自動実行)

## 関連 PR

このシリーズの 3 PR:

- **PR A** [#2139](https://github.com/nozomiishii/configs/pull/2139): audit findings (非破壊) — 本 PR の base
- **PR B** (本 PR): `singleQuote` 変更 (BREAKING)
- **PR C**: `printWidth` 変更 (BREAKING、別 PR)
