### PR TITLE
feat(prettier-config)!: change printWidth default from 119 to 100

### DIFF
--- a/packages/cspell-config/src/cli.ts
+++ b/packages/cspell-config/src/cli.ts
@@ -5,7 +5,6 @@ import { fileURLToPath } from "node:url";
 const cli = fileURLToPath(import.meta.resolve("cspell/bin.mjs"));
 const configPath = fileURLToPath(new URL("./index.js", import.meta.url));
 
-spawn(process.execPath, [cli, "--config", configPath, ...process.argv.slice(2)], { stdio: "inherit" }).on(
-  "exit",
-  (code) => process.exit(code ?? 1),
-);
+spawn(process.execPath, [cli, "--config", configPath, ...process.argv.slice(2)], {
+  stdio: "inherit",
+}).on("exit", (code) => process.exit(code ?? 1));

--- a/packages/cspell-config/src/index.ts
+++ b/packages/cspell-config/src/index.ts
@@ -1,6 +1,8 @@
 import { fileURLToPath } from "node:url";
 
-const customDictionaryPath = fileURLToPath(new URL("../dictionaries/customised.txt", import.meta.url));
+const customDictionaryPath = fileURLToPath(
+  new URL("../dictionaries/customised.txt", import.meta.url),
+);
 
 /**
  * cspell configuration

--- a/packages/eslint-config/rules/eslint-comments.ts
+++ b/packages/eslint-config/rules/eslint-comments.ts
@@ -15,7 +15,10 @@ export function eslintComments() {
       name: name("eslint-comments"),
       rules: {
         ...configs.rules,
-        "@eslint-community/eslint-comments/disable-enable-pair": ["error", { allowWholeFile: true }],
+        "@eslint-community/eslint-comments/disable-enable-pair": [
+          "error",
+          { allowWholeFile: true },
+        ],
       },
     },
   ]);

--- a/packages/eslint-config/rules/nextjs.ts
+++ b/packages/eslint-config/rules/nextjs.ts
@@ -34,7 +34,13 @@ export function nextjs() {
             name: "next/link",
           },
           {
-            importNames: ["getPathname", "permanentRedirect", "redirect", "usePathname", "useRouter"],
+            importNames: [
+              "getPathname",
+              "permanentRedirect",
+              "redirect",
+              "usePathname",
+              "useRouter",
+            ],
             message: "Please import from `libs/next-intl` instead.",
             name: "next/navigation",
           },

--- a/packages/eslint-config/rules/storybook.ts
+++ b/packages/eslint-config/rules/storybook.ts
@@ -26,12 +26,14 @@ export function storybook() {
         /**
          * https://github.com/storybookjs/storybook/blob/next/code/lib/eslint-plugin/src/configs/flat/csf-strict.ts
          */
-        ...(eslintPluginStorybook.configs["flat/csf-strict"] as unknown as Linter.Config[])[1]?.rules,
+        ...(eslintPluginStorybook.configs["flat/csf-strict"] as unknown as Linter.Config[])[1]
+          ?.rules,
 
         /**
          * https://github.com/storybookjs/storybook/blob/next/code/lib/eslint-plugin/src/configs/flat/recommended.ts
          */
-        ...(eslintPluginStorybook.configs["flat/recommended"] as unknown as Linter.Config[])[1]?.rules,
+        ...(eslintPluginStorybook.configs["flat/recommended"] as unknown as Linter.Config[])[1]
+          ?.rules,
       },
     },
     {

--- a/packages/eslint-config/rules/typescript.ts
+++ b/packages/eslint-config/rules/typescript.ts
@@ -33,7 +33,10 @@ export function typescript() {
         "@typescript-eslint/method-signature-style": ["error", "property"],
 
         // Promiseをちゃんと処理する。VoidやIIFEは無視してよい。
-        "@typescript-eslint/no-floating-promises": ["error", { ignoreIIFE: true, ignoreVoid: true }],
+        "@typescript-eslint/no-floating-promises": [
+          "error",
+          { ignoreIIFE: true, ignoreVoid: true },
+        ],
 
         /**
          * 使ってない引数はアンダースコア始まりにする

--- a/packages/lefthook-config/src/cli.ts
+++ b/packages/lefthook-config/src/cli.ts
@@ -5,4 +5,6 @@ import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
 const cli = require.resolve("git-harvest/lib/git-harvest");
 
-spawn("bash", [cli, ...process.argv.slice(2)], { stdio: "inherit" }).on("exit", (code) => process.exit(code ?? 1));
+spawn("bash", [cli, ...process.argv.slice(2)], { stdio: "inherit" }).on("exit", (code) =>
+  process.exit(code ?? 1),
+);

--- a/packages/prettier-config/src/index.ts
+++ b/packages/prettier-config/src/index.ts
@@ -5,8 +5,8 @@ import type { Config } from "prettier";
  * {@link https://prettier.io/docs/en/options.html}
  */
 export default {
-  // 1 行あたりの文字数。Github のコードレビュー画面の幅に合わせて広めに取っている (default は 80)
-  printWidth: 119,
+  // 1 行あたりの文字数。default 80。型注釈言語コミュニティの収束点として 100 を採用 (Rust / Google Java / Apple swift-format / Linux kernel 2020 で 80 deprecate / OXC oxfmt 2025)。
+  printWidth: 100,
 
   // Prettier default タブ幅は 2 スペース
   tabWidth: 2,


### PR DESCRIPTION
## 概要

`@nozomiishii/prettier-config` の `printWidth` を **`119` → `100`** に変更する。**BREAKING CHANGE**: consumer 側の 100-119 chars 範囲の行が再 format される。

## TL;DR

- **119 は Django 由来の歴史的慣習で、当時から実証根拠が薄かった** ことが Wayback Machine の実測で判明
- **100 は 型注釈言語コミュニティ (Rust / Java / Swift / Linux kernel / OXC) が独立に到達した収束点**
- **TypeScript の型署名は JavaScript より長くなる** ため、Prettier の 80 default は窮屈
- **100 は 出版界 (O'Reilly Animal 81-86) / WCAG AAA (80) のすぐ外側に留まる local maximum**

## 議論の経緯 (要旨)

audit ([#2123](https://github.com/nozomiishii/configs/issues/2123)) きっかけで `printWidth: 119` の根拠を再調査したところ、複数の問題が判明した。深堀り調査全体は本 PR description の [Appendix](#appendix-調査の詳細) に残す。

## なぜ `119` を変えるか

### 1. Django 119 は 2014 年の retrofit

[django/django commit 1101467c](https://github.com/django/django/commit/1101467ce0756272a54f4c7bc65c4c335a94111b) (2014-09-04, Tim Graham) で導入された `119` は、coding-style.txt に「the width of GitHub code review」と記載された。

→ コミットメッセージにも django-developers ML スレッドにも **GitHub diff 幅の測定値・引用・スクリーンショットは一切無い**。
→ 議論参加者の実測も 113 (Chromium/Ubuntu) / 119 (Tim 主張) / 120 (Zach Borboa) / 127 (推定) でばらついていた。
→ Collin Anderson の「`120 - 1 (diff の +/- 列)` が PEP 8 の `80 - 1` と並行」 という reasoning も **PEP 8 への並行類推の retrofit** で、PEP 8 自体の 79 = 80-1 説 (=「wrap marker glyph 用」) とは別物。

### 2. 当時の GitHub UI を Wayback で実測した結果

[Wayback snapshot 2015-10-14 の Django PR #2692 files view](https://web.archive.org/web/20151014214227/https://github.com/django/django/pull/2692/files) を実測 (Chrome MCP で DOM 計測):

| 項目 | 値 |
|---|---|
| 当時の diff `<table>` 幅 | **918 px (固定)** |
| `max-width` | none、ただし `width: 920px` で固定 |
| font | Consolas 12px |
| 1 char ≈ 7.22 px |
| 最も広い blob-code-inner の幅 | 830 px ≈ **114 chars** |
| diff table 全体 | 918 px ≈ **127 chars** |

→ **Tim の主張「119 = GitHub diff 幅」は近似値であって、正確な 119 を実測した記録は無い**。当時の固定幅レイアウトに概ね収まる範囲を 120 (round number) → -1 で 119 に丸めた、というのが史実。

### 3. 現代 GitHub UI で 119 は実用上 wrap する

現代 (2026) の GitHub PR diff を Chrome MCP で実測:

| ビュー | viewport 1728 px での コンテンツ幅 | 入る ASCII chars | 119 chars は? |
|---|---|---|---|
| **Split view (file tree 閉)** | 791 px / 側 | **109 chars / 側** | **wrap** |
| Split view (file tree 開) | 654.5 px / 側 | 90 chars / 側 | wrap |
| Unified view | 1309 px | 181 chars | OK |
| Blob view | 1291 px | 178 chars | OK |

→ **modern GitHub の split view (= 一般的な PR review 形態) では 119 は wrap する**。Django 119 を支持していた「GitHub diff で水平スクロール回避」 の前提自体が成立しない。

### 4. 出版界・アクセシビリティ標準も 119 を support しない

人類が text 表示で長年実証してきた幅:

| 媒体 | 幅 |
|---|---|
| Bringhurst 散文 ideal | 66 cpl |
| WCAG 1.4.8 AAA | 80 chars (CJK 40) |
| 文庫本 (CJK 換算 76-84) | 38-42 字 |
| 学術論文 single column | 65-80 |
| **O'Reilly Animal Books (技術書 7×9 inch)** | **81-86 chars (max)** |
| Manning Publications | 72 max |

→ **119 はどの出版実務にも収まらない領域**。100 は O'Reilly Animal をわずかに超える程度、120 を越えると技術書として印刷できない。

## なぜ `100` か

### 1. 型注釈言語コミュニティの empirical convergence

| ツール / 言語 | default printWidth | 出典 |
|---|---|---|
| **Rust** (rustfmt) | **100** | [Rust Style Guide](https://doc.rust-lang.org/nightly/style-guide/) |
| **Google Java Style** | **100** | [Java guide](https://google.github.io/styleguide/javaguide.html) |
| **Apple swift-format** (公式) | **100** | [swift-format Configuration](https://github.com/swiftlang/swift-format/blob/main/Documentation/Configuration.md) |
| **Apache Spark Scala** | **100** | community spec |
| **Linux kernel** | preferred 80 / **warning 100** | [Joe Perches commit bdc48fa11e46](https://github.com/torvalds/linux/commit/bdc48fa11e46) (2020、Linus の方針反映) |
| **OXC oxfmt** | **100** | [RFC #15851](https://github.com/oxc-project/oxc/discussions/15851) (2025) |

→ **複数の独立した型注釈言語コミュニティが、互いに参照せずに 100 に収束**している (これは convention というより empirical attractor に近い)。

### 2. TypeScript の型署名は JavaScript より verbose

OXC RFC #15851 (Boshen) より:

> "TypeScript code tends to be longer than JavaScript due to type annotations. Import statements often contain many items."

→ Prettier の 80 default は 2017 年の TS 普及前に決められた値で、**現代の TS code には窮屈**。
TS 関数シグネチャの典型例:

```ts
export async function processCustomerOrders<T extends OrderItem & { customerId: string }>(
  orders: ReadonlyArray<T>,
  options: ProcessOptions
): Promise<Result<OrderSummary[], ProcessError>>
```

これは 1 行で 130+ chars。80 では break が頻発する。100 でも完全には収まらないが、break 頻度は実用範囲に収まる。

### 3. Linux kernel 2020 の "what are you doing" 警告ライン

[Joe Perches の commit `bdc48fa11e46`](https://github.com/torvalds/linux/commit/bdc48fa11e46) (Linus の LKML 表明を反映) コミットメッセージ:

> "Yes, staying within 80 columns is certainly still _preferred_. But it's not the hard limit that the checkpatch warnings imply, and other concerns can most certainly dominate.
>
> Increase the default limit to 100 characters. Not because 100 characters is some hard limit either, but that's certainly a 'what are you doing' kind of value and less likely to be about the occasional slightly longer lines."

→ **「80 はまだ preferred、100 は警告ライン」** という Linux kernel の公式判定。この判決は本 PR の最も articulate な公式根拠。

### 4. 100 は "local maximum" — 出版界の上限を半歩超える程度

| 値 | 出版・アクセシビリティ evidence |
|---|---|
| 80 | ✅ Bringhurst / WCAG AAA / O'Reilly Animal target / 文庫本 (CJK 換算) すべて該当 |
| 88 (Black) | ✅ 同上 + Black "10% over PEP 8" 経験則 |
| **100** | ✅ O'Reilly Animal max (86) のすぐ外側、Linux 警告ライン、modern split view fit |
| 119 | ❌ 出版界・アクセシビリティどこも support なし |
| 120 | ❌ 同上 |

→ **100 は「型注釈言語要件」と「出版・アクセシビリティ envelope」の交点**。ここから上は evidence が断絶する。

## なぜ `80` (Prettier default) でないか

80 は単独では 最も robust な evidence-based 数値だが:

- **TS の型署名で break が多発**する (typical function signature が 130+ chars だと 80 では 3-4 break 必要)
- 一方で、**型注釈の無い JS では 80 で十分**

Prettier の 80 default は **「JavaScript 時代の数値」** で、TS 移行後の現代では 100 が型システムに合致する。
JS only のチームは consumer config で `printWidth: 80` を override するのが筋。

## なぜ `88` (Black) でないか

Black の 88 は **Python の経験則 (PEP 8 79 + 10%)**。Python は型注釈が optional (gradual typing) なので、80 + α で十分。
TypeScript の型署名は Black の想定する「Python の optional な type hint」より圧倒的に verbose なので、+ 12 ではなく + 20 (= 100) が妥当。

## なぜ `120` でないか

120 は **JetBrains IntelliJ default の "全言語共通の中庸値"** であり、技術的制約 (= 言語ごとに変えられないため) からくる妥協値。

- 出版界 (O'Reilly Animal 86 max) を超える
- WCAG AAA 違反域 (80 chars/CJK 40)
- modern split view (1728px, file tree 閉) でも依然 wrap する
- 「**型注釈言語の収束点**」ではなく「**全言語共通中庸**」

→ JetBrains IDE 独自の制約由来で、TypeScript の言語要件に応じた値ではない。

## "soft fence" の哲学的フレーミング

100 を hard rule にするのではなく、**Linus の 2020 commit と Rob Pike の gofmt 哲学** を架橋する位置取り:

- gofmt: 「formatter は line break に介入しない、人間が文脈で決めるべき」
- Linus 2020: 「100 は警告ライン、たまに超えるのは OK」
- 100 = **soft fence (= 警告ライン)**、break が必要な時は break、break が不要なら 100 を多少越えても良い

formatter としての強制は Prettier の特性上 hard だが、**100 を「絶対の正解」 ではなく「型注釈言語の現代的妥協値」 として扱う** のが本 PR のスタンス。

## BREAKING CHANGE

- `@nozomiishii/prettier-config` の `printWidth` default を **`119` → `100`** に変更
- 次回 format 実行時、 consumer の **100-119 chars 範囲の行が再 format** される
- 互換性を維持したい consumer は自前 `prettier.config.js` で `printWidth: 119` を明示することで opt-out 可能

## このリポジトリでの cascade

新たに reformat される 6 ファイル:

```
packages/cspell-config/src/cli.ts
packages/cspell-config/src/index.ts
packages/eslint-config/rules/eslint-comments.ts
packages/eslint-config/rules/nextjs.ts
packages/eslint-config/rules/storybook.ts
packages/eslint-config/rules/typescript.ts
```

→ ほとんどが ESLint config rules / cspell config の long identifier や chained API call。**型注釈による break というより API 呼び出しの長さ** が dominant な driver で、`+ 6 ファイル` で済む小規模な cascade。

| Commit | Type | 内容 |
|--------|------|------|
| `feat(prettier-config)!: change printWidth default from 119 to 100` | 設計変更 | src/index.ts の値とコメント変更 (1 ファイル) |
| `chore: reformat repo to printWidth=100` | 機械的反映 | リポジトリ全体の re-format (6 ファイル) |

## 検証

- `pnpm --filter @nozomiishii/prettier-config build` ✅
- `pnpm format` ✅ (`All matched files use Prettier code style!`)
- `pnpm -r --if-present run lint` ✅ (pre-push hook で自動実行)

## 関連 PR

このシリーズの 3 PR:

- **PR A** [#2139](https://github.com/nozomiishii/configs/pull/2139): audit findings (非破壊) — **merged**
- **PR B** [#2140](https://github.com/nozomiishii/configs/pull/2140): `singleQuote` 変更 (BREAKING)
- **PR C** (本 PR): `printWidth` 変更 (BREAKING)

PR B と PR C は互いに独立 (singleQuote と printWidth は orthogonal)。順序は問わない。

---

## Appendix: 調査の詳細

本 PR の決定に至る調査の元になった全データ:

### 出版業界の line length 収束データ

| 媒体 | 1 行 cpl |
|---|---|
| Netflix subtitle | 42 |
| BBC Teletext subtitle | 37 |
| CEA-708 (16:9 broadcast) | 42 |
| 新聞 (1 column) | 40-50 (英) / 12-24 col 換算 (日本) |
| 文庫本 (新潮/角川/講談社) | 38-42 (CJK chars) |
| Bringhurst ideal | 66 |
| paperback novel | 50-60 |
| 学術論文 single column | 65-80 |
| **O'Reilly Animal Books** | **81-86 max** |
| Manning Publications | 72 max |
| Pocket Reference | 51 max |

### コード読解の認知科学 (chunking)

[Busjahn et al. 2015 ICPC](https://huang.isis.vanderbilt.edu/cs8395/paper/linear-order-eye.pdf) (Andrew Begel / Bonita Sharif 等) の eye-tracking 研究:

- 熟練者は code を **41% しか視覚的に追わない**
- 熟練者の saccade length は **novice の 1.7 倍**
- 熟練者は **60% しか線形に読まない** (40% は execution-order 飛ばし読み)
- → 熟練者にとっては 100 chars 行も chunk-based に処理可能

ただし chunking でも **眼球の物理的 fovea (~3°) は不変** なので、line length cost は完全には相殺できない。

### アクセシビリティ視点

[WCAG 2.1 SC 1.4.8 (AAA)](https://www.w3.org/TR/WCAG21/#visual-presentation): 80 chars (CJK 40) max — code への適用は灰色だが、80 を超えると低視野 / 拡大鏡 / dyslexia / cognitive disability 利用者の不利益が増える。

100 はこの基準を超えるが、**120 / 119 よりは accessibility-friendly**:

- 拡大鏡 200% 拡大時に reflow 余地が残る
- side-by-side review が壊れる閾値 (Black が指摘) は 100 程度

### 他分野の line length 収束

「画面が大きくなる = 1 行を伸ばす」 は他分野で empirically 棄却されている:

| 分野 | 物理サイズ | 1 行 chars | 拡大方針 |
|---|---|---|---|
| TV 字幕 | 65"+ | 32-42 | 拡大しても変えない |
| Bloomberg | 6 monitors | 80 級 panel × N | panel 数を増やす |
| 新聞 (大型紙面) | broadsheet | 40-50 / column | column 数を増やす |
| プレゼン | 100" 投影 | 30-40 | 拡大しても変えない |
| **モニタ + IDE** | **27"** | **?** | **split pane が筋** |

→ programming も同じ pattern に従うなら、line length を伸ばすより **split editor を活用** が筋。100 はこの議論の中で「split view + file tree 閉でちょうど fit する」 値として選ばれている。

### 個別 formatter の default 比較 (フル版)

| ツール / Style | default | rationale 強度 |
|---|---|---|
| Bringhurst 散文 ideal | 66 | ★★★★ tipo 研究 |
| Black (Python) | 88 | ★★★★★ 明示 rationale + WCAG 引用 |
| PEP 8 (Python) | 79 | ★★★★ UI grounded |
| Prettier (JS/TS) | 80 | ★★★ vjeux pragmatism |
| Biome (JS/TS) | 80 | ★★ Prettier 互換 |
| Ruff (Python) | 88 | ★★ Black 互換 |
| **rustfmt** | **100** | ★★ Style Guide 明記、根拠記述薄 |
| **Google Java** | **100** | ★★ |
| **Linux kernel** | **80 preferred / 100 警告** | ★★★★★ Joe Perches commit (Linus 反映) |
| **OXC oxfmt** | **100** | ★★★★★ RFC #15851 で 5 つの理由を明記 |
| Airbnb JS | 100 | ★ |
| swift-format (Apple) | 100 | ★★ Apple 公式 |
| SwiftLint warning | 120 | ★ third-party |
| RuboCop | 120 | ★ |
| Microsoft .NET | 120 | ★ |
| **Django** | **119** | ❌ retrofit (本 PR で立証) |

→ **100 は型注釈言語ファミリーの "rationale 付き" attractor**、119 は「rationale 検証で崩れた」 唯一の値。

### Sources

- [Issue #2123 (audit)](https://github.com/nozomiishii/configs/issues/2123)
- [django/django commit 1101467c (Tim Graham 2014)](https://github.com/django/django/commit/1101467ce0756272a54f4c7bc65c4c335a94111b)
- [django-developers ML thread (2014)](https://groups.google.com/g/django-developers/c/3o7i18ewMWs)
- [Wayback Django PR #2692 (2015 snapshot)](https://web.archive.org/web/20151014214227/https://github.com/django/django/pull/2692/files)
- [Linux kernel commit bdc48fa11e46 (Joe Perches 2020)](https://github.com/torvalds/linux/commit/bdc48fa11e46)
- [OXC RFC #15851 (Boshen 2025)](https://github.com/oxc-project/oxc/discussions/15851)
- [Apple swift-format Configuration](https://github.com/swiftlang/swift-format/blob/main/Documentation/Configuration.md)
- [Rust Style Guide](https://doc.rust-lang.org/nightly/style-guide/)
- [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)
- [PEP 8](https://peps.python.org/pep-0008/)
- [Black code style (88 rationale)](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html)
- [Prettier rationale](https://prettier.io/docs/rationale)
- [Prettier Option Philosophy](https://prettier.io/docs/option-philosophy)
- [Prettier #4298 (vjeux on printWidth)](https://github.com/prettier/prettier/issues/4298)
- [Bringhurst — Elements of Typographic Style (web port)](http://webtypography.net/2.1.2)
- [O'Reilly Style Guide](https://oreillymedia.github.io/production-resources/styleguide/)
- [WCAG 2.1 SC 1.4.8](https://www.w3.org/TR/WCAG21/#visual-presentation)
- [W3C Low Vision Accessibility Task Force — Line Length](https://www.w3.org/WAI/GL/low-vision-a11y-tf/wiki/Line_Length)
- [Busjahn et al. 2015 — Eye Movements in Code Reading (ICPC)](https://huang.isis.vanderbilt.edu/cs8395/paper/linear-order-eye.pdf)
- [Brooks 1983 — Beacons in program comprehension](https://dl.acm.org/doi/10.1145/15683.1044090)
