### PR TITLE
chore: document cascade-reformat split rule in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,3 +56,4 @@ pnpm postinstall
 ## リリース・Conventional Commits
 
 - `BREAKING CHANGE:` フッターと `feat!:` / `fix!:` の `!` 修飾は、**リリースされるパッケージ・公開アセットの互換性を破る変更にのみ**使用する。CI / workflows / branch protection / リポジトリ運用上の変更には使わない。これらの注意事項は PR 本文に記述する（release-please など自動リリースツールが major / minor バンプを誤って行い、CHANGELOG に `⚠ BREAKING CHANGES` セクションを誤生成するのを防ぐため。実例: 2026-04-25 にこのリポジトリ群で `chore: migrate reusable workflows to v3.0.0` PR が誤って BREAKING CHANGE として記録された）。
+- shared-config (例: `prettier-config`) の挙動変更で発生する cascade reformat は、**設定変更 PR (`feat(<config>)!: ...`) と必ず別 PR に分離**し、scope なしの `chore: reformat ...` で出すこと。同一 PR の squash commit に混ざると release-please の path-based 振り分けにより、変更 scope と無関係なパッケージにも `⚠ BREAKING CHANGES` セクションと minor バンプが波及する（実例: 2026-05-01 の PR #2140 / #2141 が release PR #2128 で全パッケージに BREAKING を誤付与）。


### PR DESCRIPTION
## Summary

CLAUDE.md の「リリース・Conventional Commits」セクションに、shared-config の挙動変更で発生する cascade reformat を別 PR (`chore:` scope なし) に分離する運用ルールを追記する。

## 背景

直前の PR [#2140](https://github.com/nozomiishii/configs/pull/2140) / [#2141](https://github.com/nozomiishii/configs/pull/2141) で `feat(prettier-config)!: ...` と「自リポジトリ内の全パッケージを再フォーマットした cascade reformat」を同一 PR の squash commit に混ぜて main にマージした。

release-please は commit を **path-based** でパッケージに振り分けるため、cascade reformat が他パッケージのファイル (cspell-config / eslint-config / lefthook-config / markdownlint-cli2-config / postinstall / nozo / commitlint-config) を変更している分、その commit が各パッケージの changelog にも入った。さらに `feat!:` の `!` が BREAKING change として解釈され、release PR [#2128](https://github.com/nozomiishii/configs/pull/2128) で全パッケージに `⚠ BREAKING CHANGES` セクションと minor バンプが誤付与された。

## 調査結果

release-please には scope ベースで commit をパッケージに振り分ける機能がなく、`exclude-paths` 程度しか調整手段がない。`exclude-paths` は逆向きで使うとメンテ困難なため、根本対策は **PR / commit 構造側で予防する** しかない。

## 採用した対策

設定変更コミットと cascade reformat コミットを別 PR に分離する。reformat 側は scope なしの `chore: reformat ...` で出すことで、release-please は path-based に振り分けつつも `Miscellaneous` セクションに入るだけで `⚠ BREAKING CHANGES` も minor バンプも引き起こさない。

CI による機械的強制 (PR タイトルの scope と touched paths の整合チェック) は将来の選択肢として保留。今回は CLAUDE.md への運用ルール明記まで。

## Test plan

- [ ] CLAUDE.md の diff が「リリース・Conventional Commits」末尾の 1 bullet 追加のみ
