### PR TITLE
feat(tsconfig)!: apply config audit findings (breaking)

### DIFF
--- a/packages/tsconfig/README.md
+++ b/packages/tsconfig/README.md
@@ -22,7 +22,9 @@ pnpm add -D @nozomiishii/tsconfig
 
 `tsconfig.json`
 
-### tsup
+### tsup / tsdown / esbuild など bundler 系
+
+base が `module: "preserve"` (TS 5.4+) を提供するため、bundler 系では追加設定は最小限で済む。
 
 ```json
 {
@@ -30,11 +32,6 @@ pnpm add -D @nozomiishii/tsconfig
   "extends": "@nozomiishii/tsconfig",
 
   "compilerOptions": {
-    // ----------------------------------------------------------------
-    // Transpiling
-    // ----------------------------------------------------------------
-    "moduleResolution": "Bundler",
-    "module": "ESNext",
     "noEmit": true
   },
   "include": ["src/**/*"],
@@ -43,6 +40,8 @@ pnpm add -D @nozomiishii/tsconfig
 ```
 
 ### tsc
+
+base の `module: "preserve"` を `NodeNext` で上書きする。
 
 ```json
 {

--- a/packages/tsconfig/tsconfig.json
+++ b/packages/tsconfig/tsconfig.json
@@ -18,7 +18,16 @@
     // どのJavaScriptのバージョンに変換するか
     // 使うnodeバージョンによって変更する
     // 対応表 https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping
-    "target": "ES2023",
+    // ES2024でObject.groupBy / Promise.withResolvers / ArrayBuffer.prototype.transfer等の型が利用可能
+    // Node 22 LTS / Node 24 / 主要モダンブラウザは2026年時点でES2024をネイティブサポート
+    "target": "ES2024",
+
+    // バンドラー / トランスパイラ前提のmoduleモード (TS 5.4+)
+    // ECMAScript imports/exportsを変換せず保持し、moduleResolution: "bundler" を暗黙的に指定する
+    // tsupなどでtsc以外がtranspileするのが標準的な現状に最適
+    // tscでtranspileする場合はconsumer側で `module: "NodeNext"` 等に上書きする
+    // https://www.typescriptlang.org/tsconfig/module.html#preserve
+    "module": "preserve",
 
     // .jsファイルのインポートを許可するか
     "allowJs": true,
@@ -41,6 +50,19 @@
     // import typeやexport typeすることを強制
     // 可読性向上とトランスパイル時に不必要なimportが残ってしまうのを減らせる
     "verbatimModuleSyntax": true,
+
+    // typoした副作用importを silent に許す挙動を防止 (TS 5.6+)
+    // `import "./typo.css"` のような副作用importの解決失敗をエラー化
+    // TS 6.0でデフォルト化予定のため先行採用が安全
+    // CSS等のアンビエント宣言が必要な場合は `declare module "*.css";` を追加
+    // https://www.typescriptlang.org/tsconfig/#noUncheckedSideEffectImports
+    "noUncheckedSideEffectImports": true,
+
+    // Node 23.6+ の type-stripping や `tsgo` などでも実行可能なTypeScript構文に制限 (TS 5.8+)
+    // enum / runtime namespace / parameter properties をエラー化
+    // 既に `verbatimModuleSyntax: true` を採用しているため整合性が高い
+    // https://devblogs.microsoft.com/typescript/announcing-typescript-5-8/
+    "erasableSyntaxOnly": true,
 
     // ----------------------------------------------------------------
     // Strictness
@@ -72,15 +94,13 @@
     // tsconfig.tsbuildinfoを生成して差分コンパイルにより時間短縮するか
     // "incremental": true,
 
-    // TSCでTranspileする場合
+    // TSCでTranspileする場合 (base の `module: "preserve"` を上書きする)
     // "moduleResolution": "NodeNext",
     // "module": "NodeNext",
     // "outDir": "dist",
     // "sourceMap": true,
 
-    // TSC以外でTranspileする場合
-    // "moduleResolution": "Bundler",
-    // "module": "ESNext",
+    // TSC以外でTranspileする場合 (base の `module: "preserve"` で十分なケースが多い)
     // "noEmit": true,
 
     /* ライブラリの場合 */
@@ -103,9 +123,9 @@
     // Libs
     // ----------------------------------------------------------------
     /* If your code runs in the DOM: */
-    // "lib": ["ES2023", "dom", "dom.iterable"]
+    // "lib": ["ES2024", "dom"]
     /* If your code doesn't run in the DOM: */
-    "lib": ["ES2023"]
+    "lib": ["ES2024"]
 
     // ----------------------------------------------------------------
     // Types


### PR DESCRIPTION
## 概要

[Issue #2126](https://github.com/nozomiishii/configs/issues/2126) の `packages/tsconfig` 設定陳腐化監査で挙がった findings のうち、**consumer の型挙動に観測可能な変化が出る** 4 件を一括で適用する。`@nozomiishii/tsconfig` の major bump。

非破壊的部分は別 PR ([#2144](https://github.com/nozomiishii/configs/pull/2144)) で先行マージ済み（または並行マージ予定）。

Refs #2126

## 議論の経緯

`@nozomiishii/tsconfig` の audit を 4 軸で実施。9 件の findings のうち本 PR では BREAKING 4 件を扱う:

| Finding | 優先度 | 本 PR 扱い |
|---|---|---|
| #1 base に `module` / `moduleResolution` 明示 | high | ✅ `module: "preserve"` |
| #2 `noUncheckedSideEffectImports: true` | high | ✅ |
| #3 `target` / `lib` を `ES2024` に更新 | high | ✅ |
| #4 `erasableSyntaxOnly: true` | medium | ✅ |
| #5 #7 #9 (非破壊的 3 件) | — | 別 PR (#2144) |
| #6 / #8 | medium / low | 見送り (詳細は #2144 参照) |

### なぜ 4 件を 1 PR に集約するか

prettier-config の audit (`#2139` / `#2140` / `#2141`) は default 値変更で性質が異なる 2 件 (`singleQuote`, `printWidth`) を別 PR に分離した。一方、本 PR の 4 件はすべて **「TypeScript バージョン追従」というひとつの趣旨** に基づく関連変更で、consumer 側も同時にエラー対応するのが効率的。release-please の major bump も 1 回で済む。

## 変更内容

### 1. `module: "preserve"` を base に明示 (#1)

```diff
+ // バンドラー / トランスパイラ前提の module モード (TS 5.4+)
+ "module": "preserve",
```

`module: "preserve"` は TS 5.4+ で導入。ECMAScript imports/exports を変換せず保持し、`moduleResolution: "bundler"` を暗黙的に指定する。Total TypeScript の cheat sheet 推奨値で、tsup / tsdown / esbuild など bundler 系で transpile するのが標準的な現状に最適。

#### `"preserve"` を選んだ根拠

| 候補 | 特性 | 採否 |
|---|---|---|
| `"preserve"` | bundler/transpiler 前提。`moduleResolution: "bundler"` を含意 | ✅ |
| `"nodenext"` | Node 直接実行向け。bundler 系で extension 必須等の制約が降りる | 不採用 |
| 未指定 (現状) | TS 6.0 で `moduleResolution: "node10"` が deprecated | 不採用 |

README の利用例 3 件のうち 2 件 (tsup, nextjs) が bundler 系で多数派。tsc 直接 transpile 用途は README 例で `module: "NodeNext"` への上書きを案内する。

### 2. `noUncheckedSideEffectImports: true` を追加 (#2)

`import "./typo.css"` のような副作用 import の解決失敗を silent に許す挙動を防止 (TS 5.6+)。TS 6.0 でデフォルト化予定のため先行採用が安全。

CSS / SVG 等のアセットは consumer 側で `declare module "*.css";` 等のアンビエント宣言で対応する。Next.js プロジェクトはデフォルトで対応済み。

### 3. `target` / `lib` を `ES2024` に更新 (#3)

```diff
- "target": "ES2023",
+ "target": "ES2024",
- "lib": ["ES2023"]
+ "lib": ["ES2024"]
```

TS 5.7+ で追加。`Object.groupBy` / `Map.groupBy` / `Promise.withResolvers` / `ArrayBuffer.prototype.transfer` 等の標準 API 型が利用可能になる。

ランタイム要件:
- **Node 22 LTS / Node 24**: ES2024 ネイティブサポート (Vercel 現行サポート全て対応)
- **モダンブラウザ**: 2026 年時点で全主要ブラウザがサポート

### 4. `erasableSyntaxOnly: true` を追加 (#4)

Node 23.6+ の type-stripping や `tsgo` でも実行可能な TypeScript 構文に制限する (TS 5.8+)。`enum` / runtime namespace / parameter properties をエラー化。

既に `verbatimModuleSyntax: true` を採用しており、組み合わせ推奨と公式 blog が明記。

### 5. README 更新

`tsup` / `tsdown` / `esbuild` 系の利用例を簡素化 (base が `module: "preserve"` を提供するため `moduleResolution` / `module` の上書きが不要に)。`tsc` 例には base の `"preserve"` を `NodeNext` で上書きする必要がある旨を追記。

## consumer 影響評価 (BREAKING)

### 1. `erasableSyntaxOnly` の影響

- `enum` を使うコード → `const` オブジェクト + `as const` または union literal 型に書き換え
- runtime `namespace` (値) → ESM の `export` に書き換え
- parameter properties (`constructor(private x: T)`) → 通常のフィールド宣言に書き換え

### 2. `noUncheckedSideEffectImports` の影響

- 未解決の副作用 import → アンビエント宣言を追加 or 該当 import を削除
- 一般的な対処パターン:
  ```ts
  // global.d.ts
  declare module "*.css";
  declare module "*.svg";
  declare module "*.png";
  ```

### 3. `module: "preserve"` の影響

- `extends "@nozomiishii/tsconfig"` で `module` / `moduleResolution` を指定していなかった consumer:
  - bundler 系 (tsup / tsdown / esbuild / swc / vite) → そのまま動作
  - tsc 直接 transpile → consumer 側に `module: "NodeNext"` + `moduleResolution: "NodeNext"` を追加
  - tsc 直接 transpile + CommonJS → `module: "CommonJS"` + `moduleResolution: "Node10"` を追加

### 4. `target` / `lib` ES2024 の影響

- ランタイムが Node 22 未満 / 古いブラウザの場合は consumer 側で `target` / `lib` を上書きする必要あり

### Vercel ランタイム

ユーザー指摘どおり Vercel は Node 22 / Node 24 をサポート。両方 ES2024 ネイティブサポート。

## ワークスペース内検証

本リポジトリ内の packages はすべて影響なし:

- `enum` / `namespace` / parameter properties: 不使用 (grep 確認済)
- 未解決副作用 import: 不使用 (grep 確認済)
- `pnpm -r run build` ✅
- `pnpm -r --if-present run lint` ✅
- `tsc --noEmit` (prettier-config / eslint-config / postinstall) ✅

`packages/nozo` には pre-existing の型エラーが残っているが、本 PR の変更とは無関係 (main でも同じエラー)。

## 検証

- `pnpm format` ✅
- pre-push lint hook ✅
- `pnpm -r run build` ✅
- `pnpm -r --if-present run lint` ✅

## 関連 PR

- **PR A (非破壊的、別 PR)**: [#2144](https://github.com/nozomiishii/configs/pull/2144) — `tsconfig.lib.json` 派生プリセット追加 / `dom.iterable` 削除 / TS 6.0 strict 注記
