### PR TITLE
feat(commitlint-config)!: rename body-ascii-only to commit-message-ascii-only

### DIFF
--- a/packages/commitlint-config/src/index.ts
+++ b/packages/commitlint-config/src/index.ts
@@ -12,17 +12,27 @@ const config: UserConfig = {
   plugins: [
     {
       rules: {
-        "body-ascii-only": ({ body }) => {
-          if (!body) return [true];
-          const valid = [...body].every((c) => c.charCodeAt(0) < 0x80);
-          return [valid, "body must contain ASCII characters only (write in English)"];
+        // Header 以外 (body + footer + BREAKING CHANGE notes) を ASCII のみに制限する。
+        // body のみを検査すると、本文 1 行目に `#issue-number` が含まれる場合に
+        // conventional-commits-parser がその行から footer 開始と判定し、
+        // body が空文字列となって ASCII チェックが素通りする問題があるため、
+        // footer / notes も検査対象に含める。
+        "commit-message-ascii-only": ({ body, footer, notes }) => {
+          const noteText = (notes ?? []).flatMap((n) => [n.title, n.text]).join("\n");
+          const text = [body, footer, noteText].filter(Boolean).join("\n");
+          if (!text) return [true];
+          const valid = [...text].every((c) => c.charCodeAt(0) < 0x80);
+          return [
+            valid,
+            "commit message body / footer / notes must contain ASCII characters only (write in English)",
+          ];
         },
       },
     },
   ],
   rules: {
     "type-enum": [2, "always", ["feat", "fix", "chore"]],
-    "body-ascii-only": [2, "always"],
+    "commit-message-ascii-only": [2, "always"],
   },
 };
 


### PR DESCRIPTION
## 概要

`@nozomiishii/commitlint-config` のカスタムルール `body-ascii-only` を **`commit-message-ascii-only` に改名し、検査対象を body のみから body / footer / BREAKING CHANGE notes 全体に拡張する**。

`@nozomiishii/commitlint-config` の major bump。

## 議論の経緯

[Issue #2126](https://github.com/nozomiishii/configs/issues/2126) 対応の PR #2145 で、commit body に日本語を含めたにもかかわらず commitlint が通過してしまう事故が発生。原因調査の結果、ルール側のロジックバグと判明したため修正する。

### 再現条件

commit message の **本文 1 行目に `#issue-number` を含み、かつ本文に非 ASCII (例: 日本語) が含まれる**:

```
feat(scope)!: subject

Issue #2126 のような本文。日本語混入。     ← 1 行目に #2126

BREAKING CHANGE: ...
```

### 根本原因

`conventional-commits-parser` の [`parseBodyAndFooter`](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-commits-parser/src/CommitParser.ts) は、行内に reference (`#nnn` 等) が見つかった瞬間に `isBody=false` に切り替え、以降の行をすべて `commit.footer` に振り分ける。本文 1 行目に `#2126` があると即この切り替えが発動し、日本語段落も含めた本文全体が `commit.footer` に流れ込む。

旧ルール:

```ts
"body-ascii-only": ({ body }) => {
  if (!body) return [true];   // ← body が空文字列なので即通過
  ...
}
```

`body` フィールドだけ見ていたため、`body === ""` (parser が footer に振り分けた結果) のときに早期 return してしまい、日本語が footer に潜んでも検出されない。

### 検証マトリクス

| 1 行目の本文 | 旧 `body-ascii-only` | 新 `commit-message-ascii-only` |
|---|---|---|
| `Issue #2126 の説明...` (日本語+#ref) | 通過 ❌ (バグ) | エラー ✅ |
| `日本語の本文。` (日本語のみ) | エラー ✅ | エラー ✅ |
| `English body. Refs #2126.` | 通過 ✅ | 通過 ✅ |
| `English body. BREAKING CHANGE: 日本語...` | 通過 ❌ (バグ) | エラー ✅ |

旧ルールは BREAKING CHANGE フッターの日本語も見逃していた (`body` フィールドにそれらは含まれないため)。

## 変更内容

### 1. ルール名変更

`body-ascii-only` → `commit-message-ascii-only`

理由: 検査対象が body だけでなく commit message 全体 (header 以外) になるため、名前と意味を一致させる。

### 2. 検査対象を拡張

```diff
- "body-ascii-only": ({ body }) => {
-   if (!body) return [true];
-   const valid = [...body].every((c) => c.charCodeAt(0) < 0x80);
-   return [valid, "body must contain ASCII characters only (write in English)"];
- },
+ "commit-message-ascii-only": ({ body, footer, notes }) => {
+   const noteText = (notes ?? []).flatMap((n) => [n.title, n.text]).join("\n");
+   const text = [body, footer, noteText].filter(Boolean).join("\n");
+   if (!text) return [true];
+   const valid = [...text].every((c) => c.charCodeAt(0) < 0x80);
+   return [
+     valid,
+     "commit message body / footer / notes must contain ASCII characters only (write in English)",
+   ];
+ },
```

`body` / `footer` / `notes[].title` / `notes[].text` を結合した上で ASCII 検査する。これにより parser の振り分け結果に依存せず、commit message のすべての非 header 部分を網羅する。

### 3. ソース側にコメントで根拠を残す

`packages/commitlint-config/src/index.ts` に再発防止のための解説コメントを追加。

## BREAKING (consumer 影響)

| 影響 | 詳細 |
|---|---|
| ルール key 改名 | consumer が `body-ascii-only` を **明示的に override / disable** していた場合、`commit-message-ascii-only` への書き換えが必要 (ただし extends のみの consumer には影響なし) |
| 検査範囲拡大 | 過去には通っていた「body 1 行目に `#issue-ref` + 日本語」「BREAKING CHANGE フッターに日本語」等の commit が新たにエラーとなる |

本リポジトリの `commitlint.config.ts` は extends のみなので影響なし。

## 検証

- `pnpm --filter @nozomiishii/commitlint-config run build` ✅
- `pnpm format` ✅
- pre-push lint hook ✅
- 手動 fixture テスト:
  - PR #2145 と同形式の日本語コミット → エラー ✅
  - 純英語コミット → 通過 ✅
  - 英語 + `BREAKING CHANGE: English` フッター → 通過 ✅
  - `#issue-ref` + 日本語混在 → エラー ✅

## 関連

- [Issue #2126](https://github.com/nozomiishii/configs/issues/2126) (audit 元)
- [PR #2144](https://github.com/nozomiishii/configs/pull/2144) (非破壊的 audit 対応)
- [PR #2145](https://github.com/nozomiishii/configs/pull/2145) (BREAKING audit 対応、本バグ顕在化のきっかけ)
