### PR TITLE
chore(lefthook-config): rename "C pattern" to "preset + fragments"

### DIFF
--- a/packages/lefthook-config/README.md
+++ b/packages/lefthook-config/README.md
@@ -2,9 +2,10 @@
 
 Nozomi's Recommended [lefthook](https://github.com/evilmartians/lefthook) config.
 
-This package follows the **C pattern**: a thin preset (`index.yaml`) that
-`extends` reusable fragments (`hooks/<hook>/<job>.yaml`). Consumers can
-either pull the whole preset or cherry-pick individual fragments.
+This package follows a **preset + fragments** layout: a thin preset
+(`index.yaml`) that `extends` reusable fragments
+(`hooks/<hook>/<job>.yaml`). Consumers can either pull the whole preset
+or cherry-pick individual fragments.
 
 <!-- Main Image -->
 <br>

--- a/packages/lefthook-config/index.yaml
+++ b/packages/lefthook-config/index.yaml
@@ -1,4 +1,4 @@
-# @nozomiishii/lefthook-config — recommended preset (C pattern)
+# @nozomiishii/lefthook-config — recommended preset (preset + fragments)
 #
 # This preset is composed of fragments via `extends`. Consumers can either
 # extend this file as-is, or cherry-pick individual fragments under hooks/.


### PR DESCRIPTION
## 概要

`packages/lefthook-config` の README と `index.yaml` 冒頭で使われていた **「C pattern」** という呼称を、構造をそのまま表す **「preset + fragments」** に置き換える。

## 背景

「C pattern」は [#2118](https://github.com/nozomiishii/configs/issues/2118) の brainstorming で 3 つの構造案（A/B/C 案）を比較検討した際の C 案を指す内部用語で、外部の読者にとっては由来不明な略称だった。実装そのものはごく一般的な「薄い preset が再利用可能な fragment を `extends` するレイアウト」なので、名前もその通り読み下せる形に揃える。

## 変更点

- `packages/lefthook-config/README.md` 冒頭の構造説明: `**C pattern**` → `**preset + fragments** layout`
- `packages/lefthook-config/index.yaml:1` のコメント: `(C pattern)` → `(preset + fragments)`

挙動変更なし、ドキュメント・コメントの文言のみ。

## 注意

- [#2118](https://github.com/nozomiishii/configs/issues/2118) 本文内の「C パターン」表記は、過去の議論記録としてそのまま残している。
- リリースされるパッケージの公開挙動に変更はないため `chore(lefthook-config):` で出している（`feat!` / `BREAKING CHANGE` には該当しない）。

## Test plan

- [ ] README プレビューで「preset + fragments」表記に置き換わっていることを目視確認
- [ ] `packages/lefthook-config/index.yaml` 冒頭コメントの差分を確認
- [ ] CI（semantic PR / lint / format）パス
