### PR TITLE
feat(lefthook-config): expose starter.yaml for manual setup and tooling

### DIFF
--- a/packages/lefthook-config/package.json
+++ b/packages/lefthook-config/package.json
@@ -16,6 +16,12 @@
   "license": "MIT",
   "author": "Nozomi Ishii",
   "type": "module",
+  "exports": {
+    "./starter": {
+      "types": "./dist/starter.d.ts",
+      "default": "./dist/starter.js"
+    }
+  },
   "main": "recommended.yaml",
   "bin": {
     "nozo-git-harvest": "./dist/cli.js"
@@ -24,6 +30,7 @@
     "dist",
     "hooks",
     "recommended.yaml",
+    "starter.yaml",
     "README.md"
   ],
   "scripts": {
@@ -33,8 +40,8 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "lefthook": "2.1.6",
-    "git-harvest": "0.1.23"
+    "git-harvest": "0.1.23",
+    "lefthook": "2.1.6"
   },
   "devDependencies": {
     "@nozomiishii/tsconfig": "workspace:*",

--- a/packages/lefthook-config/src/starter.ts
+++ b/packages/lefthook-config/src/starter.ts
@@ -1,3 +1,1 @@
-import starter from "../starter.yaml";
-
-export { starter };
+export { default as starter } from "../starter.yaml";

--- a/packages/lefthook-config/src/starter.ts
+++ b/packages/lefthook-config/src/starter.ts
@@ -1,0 +1,3 @@
+import starter from "../starter.yaml";
+
+export { starter };

--- a/packages/lefthook-config/src/yaml.d.ts
+++ b/packages/lefthook-config/src/yaml.d.ts
@@ -1,0 +1,4 @@
+declare module "*.yaml" {
+  const content: string;
+  export default content;
+}

--- a/packages/lefthook-config/src/yaml.d.ts
+++ b/packages/lefthook-config/src/yaml.d.ts
@@ -1,4 +1,12 @@
+/**
+ * Treats every `*.yaml` import as the file's full UTF-8 contents.
+ *
+ * tsdown's `loader: { ".yaml": "text" }` inlines the YAML file as a
+ * string at build time; this declaration tells TypeScript to expose
+ * that string via the default export. The internal binding name is
+ * an implementation detail — consumers see only the default export.
+ */
 declare module "*.yaml" {
-  const content: string;
-  export default content;
+  const yaml: string;
+  export default yaml;
 }

--- a/packages/lefthook-config/starter.yaml
+++ b/packages/lefthook-config/starter.yaml
@@ -1,0 +1,12 @@
+# @see
+# https://github.com/evilmartians/lefthook
+#
+# Run the command to test:
+#   pnpx lefthook run [-v,--verbose] <hook-name>
+#
+# Examples:
+#   pnpx lefthook run --verbose pre-commit
+#   pnpx lefthook run --verbose commit-msg
+#   pnpx lefthook run --verbose post-merge
+extends:
+  - ./node_modules/@nozomiishii/lefthook-config/recommended.yaml

--- a/packages/lefthook-config/tsdown.config.ts
+++ b/packages/lefthook-config/tsdown.config.ts
@@ -1,9 +1,11 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ["src/cli.ts"],
+  entry: ["src/cli.ts", "src/starter.ts"],
   format: ["esm"],
   clean: true,
+  dts: true,
   platform: "node",
+  loader: { ".yaml": "text" },
   outExtensions: () => ({ js: ".js" }),
 });


### PR DESCRIPTION
## Summary

`@nozomiishii/lefthook-config` に **「consumer の `lefthook.yaml` 完成形」を 1 つの YAML ファイルとして公開**するパスを追加した。これにより:

- 手動セットアップする人 → README から `starter.yaml` のリンクを踏んで内容をコピペできる
- ツール（次 PR の `nozo init`）→ subpath export 経由で **同じ YAML 文字列を inline import** できる

→ 「手動セットアップ」と「自動セットアップ」が **完全に同じ single source of truth** から流れる構成になる。

## 変更点

- `starter.yaml`（新規）: package ルート直下。`recommended.yaml` を extends するだけの最小サンプル。lefthook docs URL とローカル実行コマンドのコメントヘッダー付き
- `src/starter.ts`（新規）: `starter.yaml` を `import starter from "../starter.yaml"` で読み込み、文字列として named export
- `src/yaml.d.ts`（新規）: `declare module "*.yaml"` の ambient declaration
- `tsdown.config.ts`: `loader: { ".yaml": "text" }` で yaml を text として inline、`dts: true` で `.d.ts` も emit
- `package.json`:
  - `exports` map を新設: `{ "./starter": { "types": "./dist/starter.d.ts", "default": "./dist/starter.js" } }`
  - `files` に `starter.yaml` 追加（publish 対象に含める）

## Why

`nozo init lefthook` の準備として、scaffolding する yaml の content を「lefthook-config パッケージ自身」が単一の物理ファイルとして所有するため。schema は consumer 側（nozo）に残し、**content は package 側に寄せる**ことで:

- schema 変更時のカスケード republish が起きない
- content 変更時の整合性は package 内で完結する
- yaml ファイルそのものが README から直接リンクできる

## Test plan

- [x] `pnpm --filter @nozomiishii/lefthook-config run build` → `dist/starter.js` に YAML が inline 化、`dist/starter.d.ts` 生成
- [x] `npm pack --dry-run` で `starter.yaml` が tarball に含まれることを確認
- [x] `node -e 'import("@nozomiishii/lefthook-config/starter").then(m => console.log(m.starter))'` で文字列 import が解決
