### PR TITLE
feat(eslint-config)!: ban eslint-disable comments via no-use rule

### DIFF
--- a/packages/eslint-config/rules/eslint-comments.ts
+++ b/packages/eslint-config/rules/eslint-comments.ts
@@ -19,6 +19,7 @@ export function eslintComments() {
           "error",
           { allowWholeFile: true },
         ],
+        "@eslint-community/eslint-comments/no-use": "error",
       },
     },
   ]);

--- a/packages/eslint-config/rules/jsx-a11y-x.ts
+++ b/packages/eslint-config/rules/jsx-a11y-x.ts
@@ -1,8 +1,12 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import type { Linter } from "eslint";
 // @ts-expect-error missing types 型がない
 import eslintPluginJsxA11yX from "eslint-plugin-jsx-a11y-x";
 import { defineConfig } from "eslint/config";
 import { name } from "../utils/name";
+
+const plugin = eslintPluginJsxA11yX as {
+  flatConfigs: { recommended: Linter.Config };
+};
 
 /**
  * @returns eslint-plugin-jsx-a11y-x
@@ -12,7 +16,7 @@ import { name } from "../utils/name";
 export function jsxA11yX() {
   return defineConfig([
     {
-      ...eslintPluginJsxA11yX.flatConfigs.recommended,
+      ...plugin.flatConfigs.recommended,
       name: name("jsx-a11y-x"),
     },
   ]);


### PR DESCRIPTION
## Summary

`@nozomiishii/eslint-config` に `@eslint-community/eslint-comments/no-use` ルールを `error` で追加し、`eslint-disable` 系のインラインコメント（`eslint-disable` / `eslint-disable-next-line` / `eslint-disable-line` / `eslint-enable`）を全面的に禁止します。

雑な disable コメントの抑制が動機。粒度を `eslint-disable-next-line` のみに絞る案 (Case A) も検討したが、行単位 disable は乱発されがちでブロック型 disable (`/* eslint-disable */ ... /* eslint-enable */`) は意図が明示しやすい — という観点で迷ったものの、最終的に **全面禁止 (Case B)** を選択。例外は flat config の per-files override で `"@eslint-community/eslint-comments/no-use": "off"` を当てる運用に統一する。

副次的な変更として `rules/jsx-a11y-x.ts` の冒頭にあった `/* eslint-disable @typescript-eslint/no-unsafe-member-access */` を、型アサーション (`as { flatConfigs: { recommended: Linter.Config } }`) に置き換えて構造的に不要化した。`@ts-expect-error missing types` のほうは [es-tooling/eslint-plugin-jsx-a11y-x#6 (Migrate to TypeScript)](https://github.com/es-tooling/eslint-plugin-jsx-a11y-x/issues/6) が解決されるまでの暫定対処として残置。

## Why BREAKING CHANGE

`@nozomiishii/eslint-config` を取り込んでいる consumer リポジトリでは、既存の `eslint-disable` コメントが新たに lint エラーになる。公開アセットの挙動互換性を破る変更なので、conventional commits の `feat(eslint-config)!:` を使い release-please に major bump させる前提。

回避方法（consumer 側）:

```ts
// eslint.config.ts
{
  files: ["src/legacy/**", "**/*.gen.ts"],
  rules: { "@eslint-community/eslint-comments/no-use": "off" },
},
```

## 検討時のメモ

- ESLint 10 公式 docs で `linterOptions` のキーは `noInlineConfig` / `reportUnusedDisableDirectives` / `reportUnusedInlineConfigs` のみで、`noInlineConfig: true` を採用する案 (Case C) も検討したが、`/* global */` などまで巻き添えで殺す副作用と、エラーメッセージが「disable コメント自身」ではなく「無視された結果として元ルールが復活する」という分かりにくい挙動になるため不採用。
- `eslint-plugin-jsx-a11y-x` の代替（本家 `eslint-plugin-jsx-a11y` への戻し / `@eslint-react` / 新興の `eslint-plugin-a11y` 等）も別途調査した。本家は ESLint 10 対応が単独メンテナのボトルネックで停滞中、`@eslint-react` は a11y を対象外、新興パッケージは stars 0・DL/week 18 で時期尚早 — のため、**現時点では `eslint-plugin-jsx-a11y-x` の継続が最善**との結論。本 PR ではコード変更を伴わない。

## Test plan

- [x] `packages/eslint-config` で `pnpm eslint` が pass すること（pre-push hook で自動検証済み）
- [x] `packages/eslint-config` で `pnpm check:ts` が pass すること
- [x] monorepo 全体で残存する `eslint-disable` コメントがないこと（`grep -rn 'eslint-disable' packages apps --include='*.ts' --include='*.tsx' --include='*.js' --include='*.jsx' --include='*.mjs' --include='*.cjs' | grep -v node_modules | grep -v eslint-typegen.d.ts` → 0 件）
- [ ] release-please が `feat(eslint-config)!:` を拾って `@nozomiishii/eslint-config` の major bump を出すこと
