### PR TITLE
feat(lefthook-config)!: add nozo-lefthook-init bin and remove starter subpath

### DIFF
--- a/packages/lefthook-config/README.ja.md
+++ b/packages/lefthook-config/README.ja.md
@@ -18,9 +18,13 @@
 
 ## インストール
 
+[`nozo`](../nozo) CLI を使う:
+
 ```sh
-pnpm add -D lefthook @nozomiishii/lefthook-config
+pnpx nozo init
 ```
+
+これで `lefthook` と `@nozomiishii/lefthook-config` が pin で `devDependencies` に追加され、推奨プリセットを extend する `lefthook.yaml` が生成される。
 
 補助的なランタイム（現在は `cleanup-merged` post-merge フラグメントで使う `git-harvest`）は、このパッケージの `bin` フィールドが提供する shim でラップされており、利用側が直接 dependency に追加しなくても `node_modules/.bin/nozo-*` として公開されます。
 

--- a/packages/lefthook-config/README.md
+++ b/packages/lefthook-config/README.md
@@ -21,9 +21,15 @@ or cherry-pick individual fragments.
 
 ## Install
 
+Use the [`nozo`](../nozo) CLI:
+
 ```sh
-pnpm add -D lefthook @nozomiishii/lefthook-config
+pnpx nozo init
 ```
+
+This adds `lefthook` and `@nozomiishii/lefthook-config` to your
+`devDependencies` (pinned) and writes a `lefthook.yaml` that extends the
+recommended preset.
 
 Auxiliary runtimes (currently `git-harvest`, used by the `cleanup-merged`
 post-merge fragment) are wrapped by shims that this package ships under

--- a/packages/lefthook-config/package.json
+++ b/packages/lefthook-config/package.json
@@ -19,7 +19,7 @@
   "main": "recommended.yaml",
   "bin": {
     "nozo-git-harvest": "./dist/cli.js",
-    "nozo-lefthook": "./dist/setup.js"
+    "nozo-lefthook-init": "./dist/setup.js"
   },
   "files": [
     "dist",

--- a/packages/lefthook-config/package.json
+++ b/packages/lefthook-config/package.json
@@ -36,18 +36,18 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "git-harvest": "0.1.23",
-    "lefthook": "2.1.6"
+    "git-harvest": "0.1.23"
   },
   "devDependencies": {
     "@nozomiishii/tsconfig": "workspace:*",
     "@types/node": "24.12.2",
+    "lefthook": "2.1.6",
     "tsdown": "0.21.10",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },
   "peerDependencies": {
-    "lefthook": ">=2.1.6"
+    "lefthook": "2.1.6"
   },
   "packageManager": "pnpm@10.33.2",
   "publishConfig": {

--- a/packages/lefthook-config/package.json
+++ b/packages/lefthook-config/package.json
@@ -32,6 +32,7 @@
     "build": "tsdown",
     "dev": "tsdown --watch --sourcemap",
     "prepublishOnly": "pnpm run build",
+    "test": "vitest run",
     "tsc": "tsc"
   },
   "dependencies": {
@@ -42,7 +43,8 @@
     "@nozomiishii/tsconfig": "workspace:*",
     "@types/node": "24.12.2",
     "tsdown": "0.21.10",
-    "typescript": "6.0.3"
+    "typescript": "6.0.3",
+    "vitest": "4.1.5"
   },
   "peerDependencies": {
     "lefthook": ">=2.1.6"

--- a/packages/lefthook-config/package.json
+++ b/packages/lefthook-config/package.json
@@ -16,15 +16,10 @@
   "license": "MIT",
   "author": "Nozomi Ishii",
   "type": "module",
-  "exports": {
-    "./starter": {
-      "types": "./dist/starter.d.ts",
-      "default": "./dist/starter.js"
-    }
-  },
   "main": "recommended.yaml",
   "bin": {
-    "nozo-git-harvest": "./dist/cli.js"
+    "nozo-git-harvest": "./dist/cli.js",
+    "nozo-lefthook": "./dist/setup.js"
   },
   "files": [
     "dist",
@@ -45,6 +40,7 @@
   },
   "devDependencies": {
     "@nozomiishii/tsconfig": "workspace:*",
+    "@types/node": "24.12.2",
     "tsdown": "0.21.10",
     "typescript": "6.0.3"
   },

--- a/packages/lefthook-config/package.json
+++ b/packages/lefthook-config/package.json
@@ -19,7 +19,7 @@
   "main": "recommended.yaml",
   "bin": {
     "nozo-git-harvest": "./dist/cli.js",
-    "nozo-lefthook-init": "./dist/setup.js"
+    "nozo-lefthook-init": "./dist/init.js"
   },
   "files": [
     "dist",

--- a/packages/lefthook-config/src/cli.ts
+++ b/packages/lefthook-config/src/cli.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 import { spawn } from "node:child_process";
 import { createRequire } from "node:module";
 

--- a/packages/lefthook-config/src/init.test.ts
+++ b/packages/lefthook-config/src/init.test.ts
@@ -45,11 +45,11 @@ const test = baseTest
   });
 
 test("init adds @nozomiishii/lefthook-config to devDependencies", ({ initResult }) => {
-  expect(initResult.pkg.devDependencies?.["@nozomiishii/lefthook-config"]).toMatch(/^\d+\.\d+\.\d+/);
+  expect(initResult.pkg.devDependencies?.["@nozomiishii/lefthook-config"]).toMatch(/^\d+\.\d+\.\d+$/);
 });
 
 test("init adds lefthook to devDependencies", ({ initResult }) => {
-  expect(initResult.pkg.devDependencies?.lefthook).toMatch(/^\d+\.\d+\.\d+/);
+  expect(initResult.pkg.devDependencies?.lefthook).toMatch(/^\d+\.\d+\.\d+$/);
 });
 
 test("init generates lefthook.yaml", ({ initResult }) => {

--- a/packages/lefthook-config/src/init.test.ts
+++ b/packages/lefthook-config/src/init.test.ts
@@ -1,0 +1,57 @@
+import { execFileSync, execSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test as baseTest, expect } from "vitest";
+
+const packageDir = path.resolve(import.meta.dirname, "..");
+const initBin = path.resolve(packageDir, "dist/init.js");
+
+type InitResult = {
+  pkg: { devDependencies?: Record<string, string> };
+  yamlContent: string;
+};
+
+// Fixtures: "build は file 内で 1 回" + "tmp dir は test 毎に独立して自動クリーンアップ"。
+// hook を使わず test.extend で setup/teardown を test と疎結合に保つ。
+// provide は vitest の use を rename したもの (use 接頭辞は React Hook と判定されるため)。
+const test = baseTest
+  .extend<{ built: true }>({
+    built: [
+      async ({ task: _task }, provide) => {
+        execSync("pnpm build", { cwd: packageDir });
+        await provide(true);
+      },
+      { scope: "file" },
+    ],
+  })
+  .extend<{ initResult: InitResult }>({
+    initResult: async ({ built: _built }, provide) => {
+      const tmpDir = mkdtempSync(path.join(tmpdir(), "nozo-lefthook-init-"));
+      writeFileSync(
+        path.join(tmpDir, "package.json"),
+        `${JSON.stringify({ name: "fixture", version: "1.0.0" }, null, 2)}\n`,
+      );
+      execFileSync(process.execPath, [initBin], { cwd: tmpDir });
+      const pkg = JSON.parse(
+        readFileSync(path.join(tmpDir, "package.json"), "utf8"),
+      ) as InitResult["pkg"];
+      const yamlContent = readFileSync(path.join(tmpDir, "lefthook.yaml"), "utf8");
+
+      await provide({ pkg, yamlContent });
+
+      rmSync(tmpDir, { force: true, recursive: true });
+    },
+  });
+
+test("init adds @nozomiishii/lefthook-config to devDependencies", ({ initResult }) => {
+  expect(initResult.pkg.devDependencies?.["@nozomiishii/lefthook-config"]).toMatch(/^\d+\.\d+\.\d+/);
+});
+
+test("init adds lefthook to devDependencies", ({ initResult }) => {
+  expect(initResult.pkg.devDependencies?.lefthook).toMatch(/^\d+\.\d+\.\d+/);
+});
+
+test("init generates lefthook.yaml", ({ initResult }) => {
+  expect(initResult.yamlContent.length).toBeGreaterThan(0);
+});

--- a/packages/lefthook-config/src/init.ts
+++ b/packages/lefthook-config/src/init.ts
@@ -8,14 +8,14 @@ import starter from "../starter.yaml";
 type PackageJson = {
   name: string;
   version: string;
-  dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
 };
 
 // 1. self pkg の name / version と lefthook の pin 値を取得
 const selfPkgPath = fileURLToPath(new URL("../package.json", import.meta.url));
 const selfPkg = JSON.parse(readFileSync(selfPkgPath, "utf8")) as PackageJson & {
-  dependencies: { lefthook: string };
+  peerDependencies: { lefthook: string };
 };
 
 // 2. target package.json を読み込み
@@ -26,7 +26,7 @@ const target = JSON.parse(readFileSync(targetPath, "utf8")) as PackageJson;
 target.devDependencies = {
   ...target.devDependencies,
   [selfPkg.name]: selfPkg.version,
-  lefthook: selfPkg.dependencies.lefthook,
+  lefthook: selfPkg.peerDependencies.lefthook,
 };
 
 // 4. package.json を書き戻し
@@ -35,4 +35,4 @@ writeFileSync(targetPath, `${JSON.stringify(target, null, 2)}\n`);
 // 5. lefthook.yaml を生成
 writeFileSync("lefthook.yaml", starter);
 
-console.log("✓ @nozomiishii/lefthook-config installed");
+process.stdout.write("✓ @nozomiishii/lefthook-config installed\n");

--- a/packages/lefthook-config/src/init.ts
+++ b/packages/lefthook-config/src/init.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /** `nozo-lefthook-init`: scaffold lefthook config into the consumer project. */
 import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";

--- a/packages/lefthook-config/src/init.ts
+++ b/packages/lefthook-config/src/init.ts
@@ -14,8 +14,9 @@ type PackageJson = {
 
 // 1. self pkg の name / version と lefthook の pin 値を取得
 const selfPkgPath = fileURLToPath(new URL("../package.json", import.meta.url));
-const selfPkg = JSON.parse(readFileSync(selfPkgPath, "utf8")) as PackageJson;
-const lefthookVersion = selfPkg.dependencies?.lefthook ?? "2.1.6";
+const selfPkg = JSON.parse(readFileSync(selfPkgPath, "utf8")) as PackageJson & {
+  dependencies: { lefthook: string };
+};
 
 // 2. target package.json を読み込み
 const targetPath = resolve(process.cwd(), "package.json");
@@ -25,7 +26,7 @@ const target = JSON.parse(readFileSync(targetPath, "utf8")) as PackageJson;
 target.devDependencies = {
   ...target.devDependencies,
   [selfPkg.name]: selfPkg.version,
-  lefthook: lefthookVersion,
+  lefthook: selfPkg.dependencies.lefthook,
 };
 
 // 4. package.json を書き戻し

--- a/packages/lefthook-config/src/init.ts
+++ b/packages/lefthook-config/src/init.ts
@@ -1,23 +1,5 @@
 #!/usr/bin/env node
-/**
- * `nozo-lefthook-init` bin.
- *
- * README の "Manual setup" を JS 化したもの:
- *
- *   1. `pnpm add -D lefthook @nozomiishii/lefthook-config` 相当の devDependencies 追加
- *   2. ルートに `lefthook.yaml` を生成 (recommended.yaml を extends する starter)
- *
- * このスクリプトは package.json と config file の patch のみを行い、実際の install は
- * 呼び出し側 (`nozo init`) が一括で実行する想定。スタンドアロン実行
- * (`pnpx nozo-lefthook-init`) の場合は最後に手動で `pnpm install` する手順となる。
- *
- * 依存バージョンは pin (caret なし) で書き込む。これは Renovate 等の自動更新を前提に
- * するリポジトリポリシーに合わせたもので、PR で明示的にバージョンを上げていく運用。
- *
- * bin 命名規則: 各 config パッケージの既存 bin (例: `nozo-commitlint` = commit-msg lint
- * 実行 shim、`nozo-git-harvest` = git-harvest shim) と衝突させないため、init scaffold
- * 用 bin は `-init` suffix で統一する。
- */
+/** `nozo-lefthook-init`: scaffold lefthook config into the consumer project. */
 import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -31,30 +13,26 @@ type PackageJson = {
   devDependencies?: Record<string, string>;
 };
 
-// 1. 自パッケージ (lefthook-config) の package.json から name / version、
-//    および peer 関係で導入する lefthook の pin version を取得する。
+// 1. self pkg の name / version と lefthook の pin 値を取得
 const selfPkgPath = fileURLToPath(new URL("../package.json", import.meta.url));
 const selfPkg = JSON.parse(readFileSync(selfPkgPath, "utf8")) as PackageJson;
 const lefthookVersion = selfPkg.dependencies?.lefthook ?? "2.1.6";
 
-// 2. target (CWD) の package.json を読み込む。
+// 2. target package.json を読み込み
 const targetPath = resolve(process.cwd(), "package.json");
 const target = JSON.parse(readFileSync(targetPath, "utf8")) as PackageJson;
 
-// 3. devDependencies に @nozomiishii/lefthook-config と lefthook を pin で追加する。
-//    既存 entries は維持、同名キーがあれば pin version で上書き。
+// 3. devDependencies に self / lefthook を pin で追加
 target.devDependencies = {
-  ...(target.devDependencies ?? {}),
+  ...target.devDependencies,
   [selfPkg.name]: selfPkg.version,
   lefthook: lefthookVersion,
 };
 
-// 4. package.json を書き戻す。キー順整列は prettier-plugin-packagejson に任せる
-//    (commit 前の format / format:fix で自動的に整う)。
+// 4. package.json を書き戻し
 writeFileSync(targetPath, `${JSON.stringify(target, null, 2)}\n`);
 
-// 5. ルートに lefthook.yaml を生成。中身は packages/lefthook-config/starter.yaml を
-//    tsdown loader (".yaml": "text") で string inline したもの。
+// 5. lefthook.yaml を生成
 writeFileSync("lefthook.yaml", starter);
 
 console.log("✓ @nozomiishii/lefthook-config installed");

--- a/packages/lefthook-config/src/init.ts
+++ b/packages/lefthook-config/src/init.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * `nozo-lefthook` setup bin.
+ * `nozo-lefthook-init` bin.
  *
  * README の "Manual setup" を JS 化したもの:
  *
@@ -8,11 +8,15 @@
  *   2. ルートに `lefthook.yaml` を生成 (recommended.yaml を extends する starter)
  *
  * このスクリプトは package.json と config file の patch のみを行い、実際の install は
- * 呼び出し側 (`nozo init`) が一括で実行する想定。スタンドアロン実行 (`pnpx nozo-lefthook`)
- * の場合は最後に手動で `pnpm install` する手順となる。
+ * 呼び出し側 (`nozo init`) が一括で実行する想定。スタンドアロン実行
+ * (`pnpx nozo-lefthook-init`) の場合は最後に手動で `pnpm install` する手順となる。
  *
  * 依存バージョンは pin (caret なし) で書き込む。これは Renovate 等の自動更新を前提に
  * するリポジトリポリシーに合わせたもので、PR で明示的にバージョンを上げていく運用。
+ *
+ * bin 命名規則: 各 config パッケージの既存 bin (例: `nozo-commitlint` = commit-msg lint
+ * 実行 shim、`nozo-git-harvest` = git-harvest shim) と衝突させないため、init scaffold
+ * 用 bin は `-init` suffix で統一する。
  */
 import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";

--- a/packages/lefthook-config/src/setup.ts
+++ b/packages/lefthook-config/src/setup.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * `nozo-lefthook` setup bin.
+ *
+ * README の "Manual setup" を JS 化したもの:
+ *
+ *   1. `pnpm add -D lefthook @nozomiishii/lefthook-config` 相当の devDependencies 追加
+ *   2. ルートに `lefthook.yaml` を生成 (recommended.yaml を extends する starter)
+ *
+ * このスクリプトは package.json と config file の patch のみを行い、実際の install は
+ * 呼び出し側 (`nozo init`) が一括で実行する想定。スタンドアロン実行 (`pnpx nozo-lefthook`)
+ * の場合は最後に手動で `pnpm install` する手順となる。
+ *
+ * 依存バージョンは pin (caret なし) で書き込む。これは Renovate 等の自動更新を前提に
+ * するリポジトリポリシーに合わせたもので、PR で明示的にバージョンを上げていく運用。
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import starter from "../starter.yaml";
+
+type PackageJson = {
+  name: string;
+  version: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+};
+
+// 1. 自パッケージ (lefthook-config) の package.json から name / version、
+//    および peer 関係で導入する lefthook の pin version を取得する。
+const selfPkgPath = fileURLToPath(new URL("../package.json", import.meta.url));
+const selfPkg = JSON.parse(readFileSync(selfPkgPath, "utf8")) as PackageJson;
+const lefthookVersion = selfPkg.dependencies?.lefthook ?? "2.1.6";
+
+// 2. target (CWD) の package.json を読み込む。
+const targetPath = resolve(process.cwd(), "package.json");
+const target = JSON.parse(readFileSync(targetPath, "utf8")) as PackageJson;
+
+// 3. devDependencies に @nozomiishii/lefthook-config と lefthook を pin で追加する。
+//    既存 entries は維持、同名キーがあれば pin version で上書き。
+target.devDependencies = {
+  ...(target.devDependencies ?? {}),
+  [selfPkg.name]: selfPkg.version,
+  lefthook: lefthookVersion,
+};
+
+// 4. package.json を書き戻す。キー順整列は prettier-plugin-packagejson に任せる
+//    (commit 前の format / format:fix で自動的に整う)。
+writeFileSync(targetPath, `${JSON.stringify(target, null, 2)}\n`);
+
+// 5. ルートに lefthook.yaml を生成。中身は packages/lefthook-config/starter.yaml を
+//    tsdown loader (".yaml": "text") で string inline したもの。
+writeFileSync("lefthook.yaml", starter);
+
+console.log("✓ @nozomiishii/lefthook-config installed");

--- a/packages/lefthook-config/src/starter.ts
+++ b/packages/lefthook-config/src/starter.ts
@@ -1,1 +1,0 @@
-export { default as starter } from "../starter.yaml";

--- a/packages/lefthook-config/tsconfig.json
+++ b/packages/lefthook-config/tsconfig.json
@@ -5,7 +5,8 @@
   "compilerOptions": {
     "moduleResolution": "Bundler",
     "module": "ESNext",
-    "noEmit": true
+    "noEmit": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/packages/lefthook-config/tsdown.config.ts
+++ b/packages/lefthook-config/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ["src/cli.ts", "src/setup.ts"],
+  entry: ["src/cli.ts", "src/init.ts"],
   format: ["esm"],
   clean: true,
   dts: true,

--- a/packages/lefthook-config/tsdown.config.ts
+++ b/packages/lefthook-config/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ["src/cli.ts", "src/starter.ts"],
+  entry: ["src/cli.ts", "src/setup.ts"],
   format: ["esm"],
   clean: true,
   dts: true,

--- a/packages/lefthook-config/tsdown.config.ts
+++ b/packages/lefthook-config/tsdown.config.ts
@@ -8,4 +8,5 @@ export default defineConfig({
   platform: "node",
   loader: { ".yaml": "text" },
   outExtensions: () => ({ js: ".js" }),
+  banner: { js: "#!/usr/bin/env node" },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,9 +197,6 @@ importers:
       git-harvest:
         specifier: 0.1.23
         version: 0.1.23
-      lefthook:
-        specifier: 2.1.6
-        version: 2.1.6
     devDependencies:
       '@nozomiishii/tsconfig':
         specifier: workspace:*
@@ -207,6 +204,9 @@ importers:
       '@types/node':
         specifier: 24.12.2
         version: 24.12.2
+      lefthook:
+        specifier: 2.1.6
+        version: 2.1.6
       tsdown:
         specifier: 0.21.10
         version: 0.21.10(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(synckit@0.11.12)(typescript@6.0.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,6 +213,9 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
+      vitest:
+        specifier: 4.1.5
+        version: 4.1.5(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
 
   packages/markdownlint-cli2-config:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,9 @@ importers:
       '@nozomiishii/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@types/node':
+        specifier: 24.12.2
+        version: 24.12.2
       tsdown:
         specifier: 0.21.10
         version: 0.21.10(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(synckit@0.11.12)(typescript@6.0.3)


### PR DESCRIPTION
## Summary

- `nozo-lefthook-init` bin を追加し、利用側プロジェクトに lefthook 設定をスキャフォールドできるようにした
- 既存の `./starter` subpath export を撤去。`starter.yaml` の中身は内部 init bin が tsdown の text loader で inline するため、外部公開する必要が無くなった
- 既存 `cli.ts` で型エラーが出ていた問題を `@types/node` devDep 追加と `types: ["node"]` で解消し、本パッケージで `pnpm tsc` が通る状態に修正

## 背景

[#2118](https://github.com/nozomiishii/configs/issues/2118) Phase 4 では当初 nozo cli 側の registry に各 tool の content を持たせる設計だったが、議論の結果「**各パッケージが自分の `nozo-<tool>-init` bin を持ち、nozo cli は spawn dispatcher に徹する**」方式に転換した。本 PR はその第一弾として lefthook-config を対応する。

将来的に init bin を plain JS で書き直すかは [#2159](https://github.com/nozomiishii/configs/issues/2159) で別途検討する。

## bin 命名規則

各 config パッケージの既存 bin (例: `nozo-commitlint` = commit-msg lint 実行 shim、`nozo-git-harvest` = git-harvest shim) と衝突させないため、init scaffold 用 bin は **`-init` suffix で統一** する。

| package | 既存 bin | init bin |
| --- | --- | --- |
| lefthook-config | `nozo-git-harvest` | `nozo-lefthook-init` (本 PR で追加) |
| commitlint-config (今後) | `nozo-commitlint` (commit-msg hook で利用) | `nozo-commitlint-init` |
| eslint-config (今後) | (なし) | `nozo-eslint-init` |
| prettier-config (今後) | (なし) | `nozo-prettier-init` |
| postinstall (今後) | `postinstall` | `nozo-postinstall-init` |

## 設計のポイント

- 各 init bin は **package.json と config file の patch のみ** を行う。実際の `pnpm install` 実行は呼び出し側 (`nozo init`) が一括で行う想定
- 依存バージョンは **pin (caret なし)** で書き込む。Renovate 等の自動更新前提のリポジトリポリシーに合わせる
- `starter.yaml` は引き続き SSOT として package に残し、tsdown の text loader (`{ ".yaml": "text" }`) で `dist/init.js` に文字列 inline される
- init.ts の冒頭に手順書コメントを書き、README の "Manual setup" と JS コードが行単位で対応するようにした

## 動作確認

空 dir で `init.js` を直接実行:

```sh
$ TMP=$(mktemp -d)
$ printf '%s' '{"name":"test","version":"0.0.0"}' > "$TMP/package.json"
$ (cd "$TMP" && node packages/lefthook-config/dist/init.js)
✓ @nozomiishii/lefthook-config installed
```

生成された `package.json`:

```json
{
  "name": "test",
  "version": "0.0.0",
  "devDependencies": {
    "@nozomiishii/lefthook-config": "0.5.0",
    "lefthook": "2.1.6"
  }
}
```

生成された `lefthook.yaml` は `recommended.yaml` を extends した starter (元の `starter.yaml` をそのまま inline したもの)。

## 関連

- #2118 (Phase 4 進行)
- #2159 (将来 init bin を plain JS 化するかの検討 issue)
- #2156 (`./starter` subpath を導入した PR — 本 PR で撤去)
- #2157 (nozo init の現状実装 — 本 PR と並行で spawn-dispatcher 方式に書き直し予定)

## Test plan

- [ ] CI green
- [ ] `pnpm -C packages/lefthook-config tsc` が通る
- [ ] `node packages/lefthook-config/dist/init.js` を空の package.json があるディレクトリで実行 → `lefthook.yaml` が生成され、`devDependencies` に `@nozomiishii/lefthook-config` と `lefthook` が pin で追加される

