### PR TITLE
feat(commitlint-config): add nozo-commitlint-init bin

### DIFF
--- a/packages/commitlint-config/README.ja.md
+++ b/packages/commitlint-config/README.ja.md
@@ -16,19 +16,15 @@
 
 ## インストール
 
+[`nozo`](../nozo) CLI を使う:
+
 ```bash
-pnpm add -D @nozomiishii/commitlint-config
+pnpx nozo init
 ```
 
-## 使い方
+これで `@nozomiishii/commitlint-config` が pin で `devDependencies` に追加され、shared config を re-export する `commitlint.config.ts` が生成される。
 
-このパッケージを extend する `commitlint.config.ts`（もしくは `.js`）を追加します:
-
-```ts
-import config from '@nozomiishii/commitlint-config';
-
-export default config;
-```
+## 同梱 bin
 
 このパッケージは pin された `@commitlint/cli` をラップする `nozo-commitlint` という namespace 付きの bin も同梱しています。Lefthook の設定（例: `@nozomiishii/lefthook-config`）からはこの shim を直接呼び出します:
 

--- a/packages/commitlint-config/README.md
+++ b/packages/commitlint-config/README.md
@@ -16,19 +16,16 @@ Shared [commitlint](https://commitlint.js.org) config.
 
 ## Install
 
+Use the [`nozo`](../nozo) CLI:
+
 ```bash
-pnpm add -D @nozomiishii/commitlint-config
+pnpx nozo init
 ```
 
-## Usage
+This adds `@nozomiishii/commitlint-config` to your `devDependencies` (pinned)
+and writes a `commitlint.config.ts` that re-exports the shared config.
 
-Add `commitlint.config.ts` (or `.js`) that extends this package:
-
-```ts
-import config from '@nozomiishii/commitlint-config';
-
-export default config;
-```
+## Bin
 
 The package also ships a namespaced bin, `nozo-commitlint`, which wraps the
 pinned `@commitlint/cli`. Lefthook configs (e.g. `@nozomiishii/lefthook-config`)

--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -22,7 +22,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "nozo-commitlint": "./dist/cli.js"
+    "nozo-commitlint": "./dist/cli.js",
+    "nozo-commitlint-init": "./dist/init.js"
   },
   "files": [
     "dist",
@@ -43,6 +44,7 @@
   "devDependencies": {
     "@commitlint/lint": "20.5.0",
     "@nozomiishii/tsconfig": "workspace:*",
+    "@types/node": "24.12.2",
     "tsdown": "0.21.10",
     "typescript": "6.0.3",
     "vitest": "4.1.5"

--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -27,6 +27,7 @@
   },
   "files": [
     "dist",
+    "starter.ts",
     "README.md"
   ],
   "scripts": {

--- a/packages/commitlint-config/src/cli.ts
+++ b/packages/commitlint-config/src/cli.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 import { spawn } from "node:child_process";
 import { createRequire } from "node:module";
 

--- a/packages/commitlint-config/src/init.test.ts
+++ b/packages/commitlint-config/src/init.test.ts
@@ -1,0 +1,55 @@
+import { execFileSync, execSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test as baseTest, expect } from "vitest";
+
+const packageDir = path.resolve(import.meta.dirname, "..");
+const initBin = path.resolve(packageDir, "dist/init.js");
+
+type InitResult = {
+  configContent: string;
+  pkg: { devDependencies?: Record<string, string> };
+};
+
+// Fixtures: "build は file 内で 1 回" + "tmp dir は test 毎に独立して自動クリーンアップ"。
+// hook を使わず test.extend で setup/teardown を test と疎結合に保つ。
+// provide は vitest の use を rename したもの (use 接頭辞は React Hook と判定されるため)。
+const test = baseTest
+  .extend<{ built: true }>({
+    built: [
+      async ({ task: _task }, provide) => {
+        execSync("pnpm build", { cwd: packageDir });
+        await provide(true);
+      },
+      { scope: "file" },
+    ],
+  })
+  .extend<{ initResult: InitResult }>({
+    initResult: async ({ built: _built }, provide) => {
+      const tmpDir = mkdtempSync(path.join(tmpdir(), "nozo-commitlint-init-"));
+      writeFileSync(
+        path.join(tmpDir, "package.json"),
+        `${JSON.stringify({ name: "fixture", version: "1.0.0" }, null, 2)}\n`,
+      );
+      execFileSync(process.execPath, [initBin], { cwd: tmpDir });
+      const pkg = JSON.parse(
+        readFileSync(path.join(tmpDir, "package.json"), "utf8"),
+      ) as InitResult["pkg"];
+      const configContent = readFileSync(path.join(tmpDir, "commitlint.config.ts"), "utf8");
+
+      await provide({ configContent, pkg });
+
+      rmSync(tmpDir, { force: true, recursive: true });
+    },
+  });
+
+test("init adds @nozomiishii/commitlint-config to devDependencies", ({ initResult }) => {
+  expect(initResult.pkg.devDependencies?.["@nozomiishii/commitlint-config"]).toMatch(
+    /^\d+\.\d+\.\d+/,
+  );
+});
+
+test("init generates commitlint.config.ts", ({ initResult }) => {
+  expect(initResult.configContent.length).toBeGreaterThan(0);
+});

--- a/packages/commitlint-config/src/init.test.ts
+++ b/packages/commitlint-config/src/init.test.ts
@@ -46,7 +46,7 @@ const test = baseTest
 
 test("init adds @nozomiishii/commitlint-config to devDependencies", ({ initResult }) => {
   expect(initResult.pkg.devDependencies?.["@nozomiishii/commitlint-config"]).toMatch(
-    /^\d+\.\d+\.\d+/,
+    /^\d+\.\d+\.\d+$/,
   );
 });
 

--- a/packages/commitlint-config/src/init.ts
+++ b/packages/commitlint-config/src/init.ts
@@ -1,11 +1,14 @@
-#!/usr/bin/env node
 /**
  * `nozo-commitlint-init` bin.
  *
  * README の "Usage" 手順を JS 化したもの:
  *
  *   1. `pnpm add -D @nozomiishii/commitlint-config` 相当の devDependencies 追加
- *   2. ルートに `commitlint.config.ts` を生成 (@nozomiishii/commitlint-config を re-export)
+ *   2. ルートに `commitlint.config.ts` を生成 (extends で `@nozomiishii/commitlint-config` を参照)
+ *
+ * starter は `packages/commitlint-config/starter.ts` に「普通の TypeScript」 として置き、
+ * このスクリプトが fs で読み取って利用側にそのまま書き出す方式を採る。template literal で
+ * ラップしないことで、IDE の構文ハイライトと型チェックがそのまま効く。
  *
  * このスクリプトは package.json と config file の patch のみを行い、実際の install は
  * 呼び出し側 (`nozo init`) が一括で実行する想定。スタンドアロン実行
@@ -16,40 +19,47 @@
  *
  * bin 命名規則: 既存の `nozo-commitlint` (commit-msg lint shim) と衝突させないため、
  * init scaffold 用 bin は `-init` suffix で統一する。
+ *
+ * shebang は src 側ではなく `tsdown.config.ts` の banner で `dist/init.js` に付与する
+ * (`n/hashbang` lint rule が src への shebang を「不要」と判定するため、build 出力に
+ * だけ付ける)。
  */
 import { readFileSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import starter from "./starter.js";
-
 type PackageJson = {
+  devDependencies?: Record<string, string>;
   name: string;
   version: string;
-  devDependencies?: Record<string, string>;
 };
 
 // 1. 自パッケージ (commitlint-config) の package.json から name / version を取得する。
 const selfPkgPath = fileURLToPath(new URL("../package.json", import.meta.url));
 const selfPkg = JSON.parse(readFileSync(selfPkgPath, "utf8")) as PackageJson;
 
-// 2. target (CWD) の package.json を読み込む。
-const targetPath = resolve(process.cwd(), "package.json");
+// 2. starter テンプレート (利用側に書き出される TypeScript) を読み込む。
+//    starter.ts はパッケージルート直下に置かれ、publish 時にそのまま同梱されるため、
+//    `dist/init.js` から相対 path (`../starter.ts`) で解決できる。
+const starterPath = fileURLToPath(new URL("../starter.ts", import.meta.url));
+const starter = readFileSync(starterPath, "utf8");
+
+// 3. target (CWD) の package.json を読み込む。
+const targetPath = path.resolve(process.cwd(), "package.json");
 const target = JSON.parse(readFileSync(targetPath, "utf8")) as PackageJson;
 
-// 3. devDependencies に @nozomiishii/commitlint-config を pin で追加する。
-//    既存 entries は維持、同名キーがあれば pin version で上書き。
+// 4. devDependencies に @nozomiishii/commitlint-config を pin で追加する。
 target.devDependencies = {
-  ...(target.devDependencies ?? {}),
+  ...target.devDependencies,
   [selfPkg.name]: selfPkg.version,
 };
 
-// 4. package.json を書き戻す。キー順整列は prettier-plugin-packagejson に任せる
+// 5. package.json を書き戻す。キー順整列は prettier-plugin-packagejson に任せる
 //    (commit 前の format / format:fix で自動的に整う)。
 writeFileSync(targetPath, `${JSON.stringify(target, null, 2)}\n`);
 
-// 5. ルートに commitlint.config.ts を生成。中身は src/starter.ts の template literal を
-//    そのまま書き出したもの。
+// 6. ルートに commitlint.config.ts を生成。
 writeFileSync("commitlint.config.ts", starter);
 
-console.log("✓ @nozomiishii/commitlint-config installed");
+// 7. 完了通知 (no-console rule が console.log を許可しないため stdout 直接書き込み)。
+process.stdout.write("✓ @nozomiishii/commitlint-config installed\n");

--- a/packages/commitlint-config/src/init.ts
+++ b/packages/commitlint-config/src/init.ts
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * `nozo-commitlint-init` bin.
+ *
+ * README の "Usage" 手順を JS 化したもの:
+ *
+ *   1. `pnpm add -D @nozomiishii/commitlint-config` 相当の devDependencies 追加
+ *   2. ルートに `commitlint.config.ts` を生成 (@nozomiishii/commitlint-config を re-export)
+ *
+ * このスクリプトは package.json と config file の patch のみを行い、実際の install は
+ * 呼び出し側 (`nozo init`) が一括で実行する想定。スタンドアロン実行
+ * (`pnpx nozo-commitlint-init`) の場合は最後に手動で `pnpm install` する手順となる。
+ *
+ * 依存バージョンは pin (caret なし) で書き込む。これは Renovate 等の自動更新を前提に
+ * するリポジトリポリシーに合わせたもので、PR で明示的にバージョンを上げていく運用。
+ *
+ * bin 命名規則: 既存の `nozo-commitlint` (commit-msg lint shim) と衝突させないため、
+ * init scaffold 用 bin は `-init` suffix で統一する。
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import starter from "./starter.js";
+
+type PackageJson = {
+  name: string;
+  version: string;
+  devDependencies?: Record<string, string>;
+};
+
+// 1. 自パッケージ (commitlint-config) の package.json から name / version を取得する。
+const selfPkgPath = fileURLToPath(new URL("../package.json", import.meta.url));
+const selfPkg = JSON.parse(readFileSync(selfPkgPath, "utf8")) as PackageJson;
+
+// 2. target (CWD) の package.json を読み込む。
+const targetPath = resolve(process.cwd(), "package.json");
+const target = JSON.parse(readFileSync(targetPath, "utf8")) as PackageJson;
+
+// 3. devDependencies に @nozomiishii/commitlint-config を pin で追加する。
+//    既存 entries は維持、同名キーがあれば pin version で上書き。
+target.devDependencies = {
+  ...(target.devDependencies ?? {}),
+  [selfPkg.name]: selfPkg.version,
+};
+
+// 4. package.json を書き戻す。キー順整列は prettier-plugin-packagejson に任せる
+//    (commit 前の format / format:fix で自動的に整う)。
+writeFileSync(targetPath, `${JSON.stringify(target, null, 2)}\n`);
+
+// 5. ルートに commitlint.config.ts を生成。中身は src/starter.ts の template literal を
+//    そのまま書き出したもの。
+writeFileSync("commitlint.config.ts", starter);
+
+console.log("✓ @nozomiishii/commitlint-config installed");

--- a/packages/commitlint-config/src/init.ts
+++ b/packages/commitlint-config/src/init.ts
@@ -1,29 +1,4 @@
-/**
- * `nozo-commitlint-init` bin.
- *
- * README の "Usage" 手順を JS 化したもの:
- *
- *   1. `pnpm add -D @nozomiishii/commitlint-config` 相当の devDependencies 追加
- *   2. ルートに `commitlint.config.ts` を生成 (extends で `@nozomiishii/commitlint-config` を参照)
- *
- * starter は `packages/commitlint-config/starter.ts` に「普通の TypeScript」 として置き、
- * このスクリプトが fs で読み取って利用側にそのまま書き出す方式を採る。template literal で
- * ラップしないことで、IDE の構文ハイライトと型チェックがそのまま効く。
- *
- * このスクリプトは package.json と config file の patch のみを行い、実際の install は
- * 呼び出し側 (`nozo init`) が一括で実行する想定。スタンドアロン実行
- * (`pnpx nozo-commitlint-init`) の場合は最後に手動で `pnpm install` する手順となる。
- *
- * 依存バージョンは pin (caret なし) で書き込む。これは Renovate 等の自動更新を前提に
- * するリポジトリポリシーに合わせたもので、PR で明示的にバージョンを上げていく運用。
- *
- * bin 命名規則: 既存の `nozo-commitlint` (commit-msg lint shim) と衝突させないため、
- * init scaffold 用 bin は `-init` suffix で統一する。
- *
- * shebang は src 側ではなく `tsdown.config.ts` の banner で `dist/init.js` に付与する
- * (`n/hashbang` lint rule が src への shebang を「不要」と判定するため、build 出力に
- * だけ付ける)。
- */
+/** `nozo-commitlint-init`: scaffold commitlint config into the consumer project. */
 import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -34,32 +9,28 @@ type PackageJson = {
   version: string;
 };
 
-// 1. 自パッケージ (commitlint-config) の package.json から name / version を取得する。
+// 1. self pkg の name / version を取得
 const selfPkgPath = fileURLToPath(new URL("../package.json", import.meta.url));
 const selfPkg = JSON.parse(readFileSync(selfPkgPath, "utf8")) as PackageJson;
 
-// 2. starter テンプレート (利用側に書き出される TypeScript) を読み込む。
-//    starter.ts はパッケージルート直下に置かれ、publish 時にそのまま同梱されるため、
-//    `dist/init.js` から相対 path (`../starter.ts`) で解決できる。
+// 2. starter (利用側に書き出す TS) を読み込み
 const starterPath = fileURLToPath(new URL("../starter.ts", import.meta.url));
 const starter = readFileSync(starterPath, "utf8");
 
-// 3. target (CWD) の package.json を読み込む。
+// 3. target package.json を読み込み
 const targetPath = path.resolve(process.cwd(), "package.json");
 const target = JSON.parse(readFileSync(targetPath, "utf8")) as PackageJson;
 
-// 4. devDependencies に @nozomiishii/commitlint-config を pin で追加する。
+// 4. devDependencies に self を pin で追加
 target.devDependencies = {
   ...target.devDependencies,
   [selfPkg.name]: selfPkg.version,
 };
 
-// 5. package.json を書き戻す。キー順整列は prettier-plugin-packagejson に任せる
-//    (commit 前の format / format:fix で自動的に整う)。
+// 5. package.json を書き戻し
 writeFileSync(targetPath, `${JSON.stringify(target, null, 2)}\n`);
 
-// 6. ルートに commitlint.config.ts を生成。
+// 6. commitlint.config.ts を生成
 writeFileSync("commitlint.config.ts", starter);
 
-// 7. 完了通知 (no-console rule が console.log を許可しないため stdout 直接書き込み)。
 process.stdout.write("✓ @nozomiishii/commitlint-config installed\n");

--- a/packages/commitlint-config/src/starter.ts
+++ b/packages/commitlint-config/src/starter.ts
@@ -1,6 +1,0 @@
-// 利用側プロジェクトの commitlint.config.ts に書き出されるテンプレート。
-// tsdown により dist/starter.js にビルドされ、init.ts からは re-export として読み込まれる。
-export default `import config from "@nozomiishii/commitlint-config";
-
-export default config;
-`;

--- a/packages/commitlint-config/src/starter.ts
+++ b/packages/commitlint-config/src/starter.ts
@@ -1,0 +1,6 @@
+// 利用側プロジェクトの commitlint.config.ts に書き出されるテンプレート。
+// tsdown により dist/starter.js にビルドされ、init.ts からは re-export として読み込まれる。
+export default `import config from "@nozomiishii/commitlint-config";
+
+export default config;
+`;

--- a/packages/commitlint-config/starter.ts
+++ b/packages/commitlint-config/starter.ts
@@ -1,0 +1,12 @@
+// 利用側プロジェクトの commitlint.config.ts に書き出される実体ファイル。
+// init bin はこのファイルを fs.readFileSync で読み取り、テキストのまま出力する。
+//
+// このファイル自体が利用側にコピーされる「普通の TypeScript」 として完結している必要が
+// あるため、template literal や export wrapper でラップしない。
+//
+// commitlint cli は config を `extends` フィールドで階層 merge する設計のため、
+// shared config を直接 default export するのではなく、`extends` 経由で参照する形を
+// 採る。`import config from "..."; export default config;` のような re-export では
+// commitlint 側の rule / plugins merge が期待どおりに効かないことがある。
+
+export default { extends: ["@nozomiishii/commitlint-config"] };

--- a/packages/commitlint-config/starter.ts
+++ b/packages/commitlint-config/starter.ts
@@ -1,12 +1,4 @@
-// 利用側プロジェクトの commitlint.config.ts に書き出される実体ファイル。
-// init bin はこのファイルを fs.readFileSync で読み取り、テキストのまま出力する。
-//
-// このファイル自体が利用側にコピーされる「普通の TypeScript」 として完結している必要が
-// あるため、template literal や export wrapper でラップしない。
-//
-// commitlint cli は config を `extends` フィールドで階層 merge する設計のため、
-// shared config を直接 default export するのではなく、`extends` 経由で参照する形を
-// 採る。`import config from "..."; export default config;` のような re-export では
-// commitlint 側の rule / plugins merge が期待どおりに効かないことがある。
+// @see https://commitlint.js.org/
+// @see https://github.com/nozomiishii/configs/tree/main/packages/commitlint-config
 
 export default { extends: ["@nozomiishii/commitlint-config"] };

--- a/packages/commitlint-config/tsconfig.json
+++ b/packages/commitlint-config/tsconfig.json
@@ -5,7 +5,8 @@
   "compilerOptions": {
     "moduleResolution": "Bundler",
     "module": "ESNext",
-    "noEmit": true
+    "noEmit": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/packages/commitlint-config/tsdown.config.ts
+++ b/packages/commitlint-config/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/cli.ts"],
+  entry: ["src/index.ts", "src/cli.ts", "src/init.ts", "src/starter.ts"],
   format: ["esm"],
   dts: true,
   clean: true,

--- a/packages/commitlint-config/tsdown.config.ts
+++ b/packages/commitlint-config/tsdown.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/cli.ts", "src/init.ts", "src/starter.ts"],
+  banner: { js: "#!/usr/bin/env node" },
+  entry: ["src/index.ts", "src/cli.ts", "src/init.ts"],
   format: ["esm"],
   dts: true,
   clean: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@nozomiishii/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@types/node':
+        specifier: 24.12.2
+        version: 24.12.2
       tsdown:
         specifier: 0.21.10
         version: 0.21.10(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(synckit@0.11.12)(typescript@6.0.3)


### PR DESCRIPTION
## Summary

- `nozo-commitlint-init` bin を追加し、利用側プロジェクトに commitlint 設定をスキャフォールドできるようにした
- 既存 `cli.ts` で型エラーが出ていた問題を `@types/node` devDep 追加と `types: ["node"]` で解消し、`pnpm tsc` が通る状態に修正

## 背景

[#2118](https://github.com/nozomiishii/configs/issues/2118) Phase 4 の方針 (各パッケージが `nozo-<pkg>-init` bin を持ち、nozo cli は spawn dispatcher に徹する) の第二弾。前段の lefthook-config 対応は [#2160](https://github.com/nozomiishii/configs/pull/2160)。

将来的に init bin を plain JS で書き直すかは [#2159](https://github.com/nozomiishii/configs/issues/2159) で別途検討する。

## bin 命名規則

各 config パッケージの既存 bin と衝突させないため、init scaffold 用 bin は **`-init` suffix** で統一する。本 PR では既存の `nozo-commitlint` (commit-msg lint 実行 shim) を温存しつつ、init scaffold 用に `nozo-commitlint-init` を新規追加する。

| package | 既存 bin | init bin |
| --- | --- | --- |
| **commitlint-config** (本 PR) | `nozo-commitlint` (commit-msg hook で利用) | **`nozo-commitlint-init`** |

## 設計のポイント

- init bin は **package.json と config file の patch のみ** を行う。実際の `pnpm install` 実行は呼び出し側 (`nozo init`) が一括で行う想定
- 依存バージョンは **pin (caret なし)** で書き込む (Renovate 自動更新前提)
- starter テキストは `src/starter.ts` に template literal として置き、tsdown で `dist/starter.js` にビルドして init.ts から re-export 経由で読み込む
- init.ts の冒頭に手順書コメントを書き、README の "Usage" 手順と JS コードが行単位で対応するようにした

## 動作確認

空 dir で `init.js` を直接実行:

```sh
$ TMP=$(mktemp -d)
$ printf '%s' '{"name":"test","version":"0.0.0"}' > "$TMP/package.json"
$ (cd "$TMP" && node packages/commitlint-config/dist/init.js)
✓ @nozomiishii/commitlint-config installed
```

生成された `package.json`:

```json
{
  "name": "test",
  "version": "0.0.0",
  "devDependencies": {
    "@nozomiishii/commitlint-config": "0.2.0"
  }
}
```

生成された `commitlint.config.ts`:

```ts
import config from "@nozomiishii/commitlint-config";

export default config;
```

## 関連

- #2118 (Phase 4 進行)
- #2160 (lefthook-config の同パターン PR — 命名規則の元)
- #2159 (将来 init bin を plain JS 化するかの検討)

## Test plan

- [ ] CI green
- [ ] `pnpm -C packages/commitlint-config tsc` が通る
- [ ] `node packages/commitlint-config/dist/init.js` を空の package.json があるディレクトリで実行 → `commitlint.config.ts` が生成され、`devDependencies` に `@nozomiishii/commitlint-config` が pin で追加される
