### PR TITLE
feat(postinstall): add nozo-postinstall-init bin

### DIFF
--- a/packages/postinstall/README.ja.md
+++ b/packages/postinstall/README.ja.md
@@ -14,30 +14,20 @@
 
 ## インストール
 
-```bash
-pnpm add -D @nozomiishii/postinstall
-```
-
-## 使い方
-
-pnpm CLI でこのパッケージをプロジェクトの postinstall スクリプトに追加します:
+[`nozo`](../nozo) CLI を使う:
 
 ```bash
-pnpm pkg set scripts.postinstall="postinstall"
+pnpx nozo init
 ```
 
-`package.json` は次の設定を含むはずです:
+これで `@nozomiishii/postinstall` が pin で `devDependencies` に追加され、`scripts.postinstall` が `"postinstall"` に設定される（毎回の `pnpm install` 時に本パッケージの postinstall スクリプトが起動する）。
 
 `package.json`
 
 ```json
 {
-  "postinstall": "postinstall"
+  "scripts": {
+    "postinstall": "postinstall"
+  }
 }
-```
-
-`pnpm install` を実行すると postinstall スクリプトが起動し、開発ツールがセットアップされます:
-
-```bash
-pnpm install
 ```

--- a/packages/postinstall/README.md
+++ b/packages/postinstall/README.md
@@ -14,30 +14,22 @@ English | [日本語](./README.ja.md)
 
 ## Install
 
-```bash
-pnpm add -D @nozomiishii/postinstall
-```
-
-## Usage
-
-Add this package to your project's postinstall script using pnpm CLI
+Use the [`nozo`](../nozo) CLI:
 
 ```bash
-pnpm pkg set scripts.postinstall="postinstall"
+pnpx nozo init
 ```
 
-Your package.json should contain this configuration
+This adds `@nozomiishii/postinstall` to your `devDependencies` (pinned)
+and sets `scripts.postinstall` to `"postinstall"` so the package's
+postinstall script runs on every `pnpm install`.
 
 `package.json`
 
 ```json
 {
-  "postinstall": "postinstall"
+  "scripts": {
+    "postinstall": "postinstall"
+  }
 }
-```
-
-Run install to trigger the postinstall script which sets up development tools
-
-```bash
-pnpm install
 ```

--- a/packages/postinstall/package.json
+++ b/packages/postinstall/package.json
@@ -21,7 +21,8 @@
   },
   "types": "./dist/index.d.ts",
   "bin": {
-    "postinstall": "./dist/index.js"
+    "postinstall": "./dist/index.js",
+    "nozo-postinstall-init": "./dist/init.js"
   },
   "files": [
     "dist",

--- a/packages/postinstall/src/index.ts
+++ b/packages/postinstall/src/index.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 import { setupLefthook } from "./lefthook";
 import { setupVSCode } from "./vscode";
 import { welcome } from "./welcome";

--- a/packages/postinstall/src/init.test.ts
+++ b/packages/postinstall/src/init.test.ts
@@ -1,0 +1,54 @@
+import { execFileSync, execSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test as baseTest, expect } from "vitest";
+
+const packageDir = path.resolve(import.meta.dirname, "..");
+const initBin = path.resolve(packageDir, "dist/init.js");
+
+type InitResult = {
+  pkg: {
+    devDependencies?: Record<string, string>;
+    scripts?: Record<string, string>;
+  };
+};
+
+// Fixtures: "build は file 内で 1 回" + "tmp dir は test 毎に独立して自動クリーンアップ"。
+// hook を使わず test.extend で setup/teardown を test と疎結合に保つ。
+// provide は vitest の use を rename したもの (use 接頭辞は React Hook と判定されるため)。
+const test = baseTest
+  .extend<{ built: true }>({
+    built: [
+      async ({ task: _task }, provide) => {
+        execSync("pnpm build", { cwd: packageDir });
+        await provide(true);
+      },
+      { scope: "file" },
+    ],
+  })
+  .extend<{ initResult: InitResult }>({
+    initResult: async ({ built: _built }, provide) => {
+      const tmpDir = mkdtempSync(path.join(tmpdir(), "nozo-postinstall-init-"));
+      writeFileSync(
+        path.join(tmpDir, "package.json"),
+        `${JSON.stringify({ name: "fixture", version: "1.0.0" }, null, 2)}\n`,
+      );
+      execFileSync(process.execPath, [initBin], { cwd: tmpDir });
+      const pkg = JSON.parse(
+        readFileSync(path.join(tmpDir, "package.json"), "utf8"),
+      ) as InitResult["pkg"];
+
+      await provide({ pkg });
+
+      rmSync(tmpDir, { force: true, recursive: true });
+    },
+  });
+
+test("init adds @nozomiishii/postinstall to devDependencies", ({ initResult }) => {
+  expect(initResult.pkg.devDependencies?.["@nozomiishii/postinstall"]).toMatch(/^\d+\.\d+\.\d+/);
+});
+
+test("init adds postinstall script", ({ initResult }) => {
+  expect(initResult.pkg.scripts?.postinstall).toBe("postinstall");
+});

--- a/packages/postinstall/src/init.test.ts
+++ b/packages/postinstall/src/init.test.ts
@@ -46,7 +46,7 @@ const test = baseTest
   });
 
 test("init adds @nozomiishii/postinstall to devDependencies", ({ initResult }) => {
-  expect(initResult.pkg.devDependencies?.["@nozomiishii/postinstall"]).toMatch(/^\d+\.\d+\.\d+/);
+  expect(initResult.pkg.devDependencies?.["@nozomiishii/postinstall"]).toMatch(/^\d+\.\d+\.\d+$/);
 });
 
 test("init adds postinstall script", ({ initResult }) => {

--- a/packages/postinstall/src/init.ts
+++ b/packages/postinstall/src/init.ts
@@ -1,25 +1,4 @@
-/**
- * `nozo-postinstall-init` bin.
- *
- * README の "Usage" 手順を JS 化したもの:
- *
- *   1. `pnpm add -D @nozomiishii/postinstall` 相当の devDependencies 追加
- *   2. `package.json` の `scripts.postinstall` に `"postinstall"` を設定 (本パッケージが
- *      提供する `postinstall` bin が `pnpm install` のたびに走るようにする)
- *
- * このスクリプトは package.json の patch のみを行い、実際の install は呼び出し側
- * (`nozo init`) が一括で実行する想定。スタンドアロン実行
- * (`pnpx -p @nozomiishii/postinstall nozo-postinstall-init`) の場合は最後に手動で
- * `pnpm install` する手順となる。本パッケージは config file を生成しないため、
- * 他の `nozo-<pkg>-init` bin と異なり `starter.ts` は持たない。
- *
- * 依存バージョンは pin (caret なし) で書き込む。これは Renovate 等の自動更新を前提に
- * するリポジトリポリシーに合わせたもので、PR で明示的にバージョンを上げていく運用。
- *
- * shebang は src 側ではなく `tsdown.config.ts` の banner で `dist/init.js` に付与する
- * (`n/hashbang` lint rule が src への shebang を「不要」と判定するため、build 出力に
- * だけ付ける)。
- */
+/** `nozo-postinstall-init`: scaffold the postinstall hook into the consumer project. */
 import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -31,28 +10,27 @@ type PackageJson = {
   version: string;
 };
 
-// 1. 自パッケージ (postinstall) の package.json から name / version を取得する。
+// 1. self pkg の name / version を取得
 const selfPkgPath = fileURLToPath(new URL("../package.json", import.meta.url));
 const selfPkg = JSON.parse(readFileSync(selfPkgPath, "utf8")) as PackageJson;
 
-// 2. target (CWD) の package.json を読み込む。
+// 2. target package.json を読み込み
 const targetPath = path.resolve(process.cwd(), "package.json");
 const target = JSON.parse(readFileSync(targetPath, "utf8")) as PackageJson;
 
-// 3. devDependencies に @nozomiishii/postinstall を pin で追加する。
+// 3. devDependencies に self を pin で追加
 target.devDependencies = {
   ...target.devDependencies,
   [selfPkg.name]: selfPkg.version,
 };
 
-// 4. `scripts.postinstall` に `postinstall` (= 本パッケージの bin name) を設定する。
+// 4. scripts.postinstall を設定
 target.scripts = {
   ...target.scripts,
   postinstall: "postinstall",
 };
 
-// 5. package.json を書き戻す。キー順整列は prettier-plugin-packagejson に任せる。
+// 5. package.json を書き戻し
 writeFileSync(targetPath, `${JSON.stringify(target, null, 2)}\n`);
 
-// 6. 完了通知 (no-console rule が console.log を許可しないため stdout 直接書き込み)。
 process.stdout.write("✓ @nozomiishii/postinstall installed\n");

--- a/packages/postinstall/src/init.ts
+++ b/packages/postinstall/src/init.ts
@@ -1,0 +1,58 @@
+/**
+ * `nozo-postinstall-init` bin.
+ *
+ * README の "Usage" 手順を JS 化したもの:
+ *
+ *   1. `pnpm add -D @nozomiishii/postinstall` 相当の devDependencies 追加
+ *   2. `package.json` の `scripts.postinstall` に `"postinstall"` を設定 (本パッケージが
+ *      提供する `postinstall` bin が `pnpm install` のたびに走るようにする)
+ *
+ * このスクリプトは package.json の patch のみを行い、実際の install は呼び出し側
+ * (`nozo init`) が一括で実行する想定。スタンドアロン実行
+ * (`pnpx -p @nozomiishii/postinstall nozo-postinstall-init`) の場合は最後に手動で
+ * `pnpm install` する手順となる。本パッケージは config file を生成しないため、
+ * 他の `nozo-<pkg>-init` bin と異なり `starter.ts` は持たない。
+ *
+ * 依存バージョンは pin (caret なし) で書き込む。これは Renovate 等の自動更新を前提に
+ * するリポジトリポリシーに合わせたもので、PR で明示的にバージョンを上げていく運用。
+ *
+ * shebang は src 側ではなく `tsdown.config.ts` の banner で `dist/init.js` に付与する
+ * (`n/hashbang` lint rule が src への shebang を「不要」と判定するため、build 出力に
+ * だけ付ける)。
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+type PackageJson = {
+  devDependencies?: Record<string, string>;
+  name: string;
+  scripts?: Record<string, string>;
+  version: string;
+};
+
+// 1. 自パッケージ (postinstall) の package.json から name / version を取得する。
+const selfPkgPath = fileURLToPath(new URL("../package.json", import.meta.url));
+const selfPkg = JSON.parse(readFileSync(selfPkgPath, "utf8")) as PackageJson;
+
+// 2. target (CWD) の package.json を読み込む。
+const targetPath = path.resolve(process.cwd(), "package.json");
+const target = JSON.parse(readFileSync(targetPath, "utf8")) as PackageJson;
+
+// 3. devDependencies に @nozomiishii/postinstall を pin で追加する。
+target.devDependencies = {
+  ...target.devDependencies,
+  [selfPkg.name]: selfPkg.version,
+};
+
+// 4. `scripts.postinstall` に `postinstall` (= 本パッケージの bin name) を設定する。
+target.scripts = {
+  ...target.scripts,
+  postinstall: "postinstall",
+};
+
+// 5. package.json を書き戻す。キー順整列は prettier-plugin-packagejson に任せる。
+writeFileSync(targetPath, `${JSON.stringify(target, null, 2)}\n`);
+
+// 6. 完了通知 (no-console rule が console.log を許可しないため stdout 直接書き込み)。
+process.stdout.write("✓ @nozomiishii/postinstall installed\n");

--- a/packages/postinstall/tsconfig.json
+++ b/packages/postinstall/tsconfig.json
@@ -8,7 +8,8 @@
     // ----------------------------------------------------------------
     "moduleResolution": "Bundler",
     "module": "ESNext",
-    "noEmit": true
+    "noEmit": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/packages/postinstall/tsdown.config.ts
+++ b/packages/postinstall/tsdown.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  banner: { js: "#!/usr/bin/env node" },
+  entry: ["src/index.ts", "src/init.ts"],
   format: ["esm"],
   dts: true,
   clean: true,


### PR DESCRIPTION
## Summary

- `nozo-postinstall-init` bin を追加し、利用側プロジェクトに `postinstall` script のセットアップをスキャフォールドできるようにした
- 既存の `postinstall` bin (`./dist/index.js`、`pnpm install` の postinstall script として走る本体) は維持
- 本パッケージは config file を生成しないため、 他の `nozo-<pkg>-init` bin と異なり `starter.ts` は持たない

## 背景

[#2118](https://github.com/nozomiishii/configs/issues/2118) Phase 4 の方針 (各パッケージが `nozo-<pkg>-init` bin を持ち、nozo cli は spawn dispatcher に徹する) の最終 (configパッケージ側) 実装。前段は [#2160](https://github.com/nozomiishii/configs/pull/2160) (lefthook-config), [#2162](https://github.com/nozomiishii/configs/pull/2162) (commitlint-config), [#2163](https://github.com/nozomiishii/configs/pull/2163) (eslint-config), [#2164](https://github.com/nozomiishii/configs/pull/2164) (prettier-config)。

## bin の追加

| package | 既存 bin | init bin |
| --- | --- | --- |
| **postinstall** (本 PR) | `postinstall` (postinstall script 本体) | **`nozo-postinstall-init`** |

`nozo-postinstall-init` の呼び出しは `pnpx nozo init` 経由を想定。

## init bin が行う patch 内容

利用側 `package.json` に対して:

- `devDependencies` に `@nozomiishii/postinstall` を pin で追加
- `scripts.postinstall` に `"postinstall"` を設定 (本パッケージの bin を呼ぶ)

config file は生成しない。

## 設計のポイント

- init bin は **package.json の patch のみ** を行う (config file 生成も無し)。実際の `pnpm install` 実行は呼び出し側 (`nozo init`) が一括で行う想定
- 依存バージョンは **pin (caret なし)** で書き込む (Renovate 自動更新前提)
- shebang は src 側ではなく `tsdown.config.ts` の `banner` option で `dist/init.js` / `dist/index.js` 両方に付与する。 既存 `src/index.ts` の shebang は banner と重複するため削除した

## 動作確認

shim 経由で実行:

```sh
$ TMP=$(mktemp -d)
$ printf '%s' '{"name":"test","version":"0.0.0"}' > "$TMP/package.json"
$ (cd "$TMP" && node_modules/.bin/nozo-postinstall-init)
✓ @nozomiishii/postinstall installed
```

生成された `package.json`:

```json
{
  "name": "test",
  "version": "0.0.0",
  "devDependencies": {
    "@nozomiishii/postinstall": "0.1.0"
  },
  "scripts": {
    "postinstall": "postinstall"
  }
}
```

## 関連

- #2118 (Phase 4 進行)
- #2160 (lefthook-config の同パターン PR)
- #2162 (commitlint-config の同パターン PR)
- #2163 (eslint-config の同パターン PR)
- #2164 (prettier-config の同パターン PR)
- #2159 (将来 init bin を plain JS 化するかの検討)

## Test plan

- [ ] CI green
- [ ] `pnpm -C packages/postinstall tsc` が通る
- [ ] `node_modules/.bin/nozo-postinstall-init` を空の package.json があるディレクトリで実行 → `devDependencies` に `@nozomiishii/postinstall` が pin で追加され、`scripts.postinstall` に `"postinstall"` が設定される

