### PR TITLE
fix: add unit test collocation rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,13 @@ pnpm postinstall
 - 設定変更は基本的に `packages/` 配下の設定・ドキュメント側を優先して更新する。
 - フォーマット・リントは `pnpm format` / `pnpm prettier` と `pnpm fix:md`（markdown）を使う。
 
+## テスト配置
+
+- Unit Test はテスト対象のファイルと同じ階層に配置する（例: `src/init.ts` のテストは `src/init.test.ts`）。
+- `tests/` ディレクトリでまとめて分離するスタイルは採用しない。配置を見るだけで「どのファイルにテストがあるか」が分かるようにするのが狙い。
+- setup / teardown は `beforeEach` / `afterEach` などの hook を避け、vitest の [`test.extend`](https://vitest.dev/guide/test-context.html) による fixture で書く。各 test が context 経由で依存を明示的に受け取ることで、test 間の hidden state（密結合）を排除する。
+- 既存テストが `tests/` 配下にあるパッケージは、新規テストから順次同階層配置に移行する。
+
 ## packages/prettier-config: requirePragma による除外方針
 
 - `packages/prettier-config/src/index.ts` の `overrides` で `pnpm-lock.yaml` / `submodules/**` / `next-env.d.ts` / `*.md` / `*.mdx` を `requirePragma: true` で除外している。


### PR DESCRIPTION
## 概要

- Unit Test の配置規約を CLAUDE.md に追加。テスト対象ファイルと同じ階層に置く方針（`src/init.ts` のテストは `src/init.test.ts`）。
- `tests/` ディレクトリ分離スタイルは採用しない。
- setup / teardown は hook ではなく vitest の `test.extend` (fixture) を使う方針も明記。test 間の hidden state（密結合）を排除するため。
- 既存テストが `tests/` 配下にあるパッケージは、新規テストから順次同階層配置に移行する旨を明記。

## 背景

[#2160](https://github.com/nozomiishii/configs/pull/2160) / [#2162](https://github.com/nozomiishii/configs/pull/2162) / [#2163](https://github.com/nozomiishii/configs/pull/2163) / [#2164](https://github.com/nozomiishii/configs/pull/2164) / [#2165](https://github.com/nozomiishii/configs/pull/2165) で各 `init.ts` に Happy Path テストを追加する際に、配置規約とテスト書き方の方針を整理した。今後の判断基準として残す。

## Test plan

- [x] CLAUDE.md の差分が意図通りであることを目視確認
