### PR TITLE
feat(eslint-config): switch typegen API and add named rule exports

### DIFF
--- a/packages/eslint-config/eslint.config.ts
+++ b/packages/eslint-config/eslint.config.ts
@@ -90,4 +90,28 @@ export default defineConfig([
   // packageJson()
 ]);
 
+export {
+  betterTailwindcss,
+  deMorgan,
+  eslintComments,
+  importX,
+  javascript,
+  jsdoc,
+  jsxA11yX,
+  n,
+  nextjs,
+  perfectionist,
+  playwright,
+  prettier,
+  react,
+  reactHooks,
+  reactRefresh,
+  regexp,
+  storybook,
+  stylistic,
+  typescript,
+  unicorn,
+  viest,
+};
+
 export { defineConfig } from "eslint/config";

--- a/packages/eslint-config/rules/unicorn.ts
+++ b/packages/eslint-config/rules/unicorn.ts
@@ -29,6 +29,14 @@ export function unicorn() {
         "unicorn/no-null": "off",
 
         /**
+         * import + 同名 re-export の bulk pattern を許可（local でも使っている場合のみ）
+         * pure re-export は引き続き `export ... from` を強制
+         *
+         * @see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-export-from.md
+         */
+        "unicorn/prefer-export-from": ["error", { ignoreUsedVariables: true }],
+
+        /**
          * 略語の制限。やるなら明示的にreplacementを記載していく
          *
          * @see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prevent-abbreviations.md

--- a/packages/eslint-config/scripts/typegen.ts
+++ b/packages/eslint-config/scripts/typegen.ts
@@ -1,15 +1,7 @@
-import typegen from "eslint-typegen";
+import { flatConfigsToRulesDTS } from "eslint-typegen/core";
+import { writeFile } from "node:fs/promises";
 import configs from "../eslint.config";
 
-/**
- * import typegen from 'eslint-typegen'
- *
- * export default typegen([
- *   // ...your normal eslint flat config
- * ])
- *
- * 上みたいにしようとすると next build で次のエラーになるので postinstall で生成
- * Type error: This expression is not callable.
- *   Type 'typeof import("/Users/nozomiishii/Code/nozomiishii/dev/apps/home/eslint-typegen")' has no call signatures.
- */
-await typegen(configs);
+const dts = await flatConfigsToRulesDTS(configs);
+
+await writeFile("eslint-typegen.d.ts", dts);


### PR DESCRIPTION
## Summary

- `scripts/typegen.ts` を high-level `typegen()` から low-level `flatConfigsToRulesDTS` に切り替え。元の「`next build` で `has no call signatures` になるので postinstall で生成」というワークアラウンドコメントは構造的に解消したため削除
- `eslint.config.ts` に各 rule preset（`javascript`, `typescript`, `react`, `nextjs`, ...）の named export を追加。consumer が default の全部入りに頼らず piecewise に config を組み立てられるようにした（既存の default export はそのまま）
- `rules/unicorn.ts` に `unicorn/prefer-export-from` を `ignoreUsedVariables: true` で有効化。local でも使う import を bulk re-export するパターンを許容しつつ、pure re-export には引き続き `export ... from` を強制

## 背景

[#2163](https://github.com/nozomiishii/configs/pull/2163) の `scripts/typegen.ts` 冒頭ワークアラウンドコメントが TypeGen 周りを見直すきっかけ。

調査の結果:

- 「`next build` で has no call signatures」エラーは現在の `eslint-typegen@2.3.1` + Next 16 + TS 6 では再現しない（実 consumer の `dev/apps/home` で `next build` 通過確認済み）
- shared config publisher 側の慣習は `flatConfigsToRulesDTS`（low-level）を build-time script で呼び、生成物を package に同梱する形。antfu / sxzz / ntnyq / ariesclark / 9romise / christopher-buss / mastondzn / sj-distributor の 8 つで同パターン採用
- 公式 README の `typegen([...])` を `eslint.config` 本体で wrap するパターンは consumer 向けレシピであって publisher 向けではない（README 自身に「`@antfu/eslint-config` 使ってる人は不要」と明記）

## consumer 体験

既存の使い方は変更なし:

```ts
import eslintConfig, { defineConfig } from '@nozomiishii/eslint-config';
export default defineConfig([...eslintConfig]);
```

新しく piecewise 組み立てが可能:

```ts
import { defineConfig, typescript, react, nextjs, prettier } from '@nozomiishii/eslint-config';

export default defineConfig([
  typescript(),
  react(),
  nextjs(),
  prettier(),
]);
```

## 関連

- [#2163](https://github.com/nozomiishii/configs/pull/2163) — 本 PR の調査をきっかけに `scripts/` の publish 対象外化、`postinstall` → `prepare` 切替、`allowImportingTsExtensions` 撤去も別 commit で対応済

## Test plan

- [ ] `pnpm install` が完走する
- [ ] `pnpm -C packages/eslint-config typegen` で `eslint-typegen.d.ts` が再生成される
- [ ] `pnpm -C packages/eslint-config lint` pass
- [ ] `pnpm -C packages/eslint-config check:ts` pass
- [ ] `prettier --check` pass
- [ ] consumer (`dev/apps/home`) で `next build` 通過することを link 経由で確認（任意）
