### PR TITLE
chore: spell out conventional commit rules in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ pnpm postinstall
 
 ## Git・GitHub 運用ルール
 
-- PR タイトルは英語 semantic 形式で、CI の semantic pull request チェックに従う。詳細は [.github/workflows/_pull-request.yaml](.github/workflows/_pull-request.yaml) を参照。
+- PR タイトルは Conventional Commits 形式（英語）で `<type>: <subject>` と書く。許可 type は `feat` / `fix` / `chore` のみ。subject は小文字始まり / ASCII のみ / 末尾スペース禁止。違反すると CI（`amannn/action-semantic-pull-request`、`nozomiishii/workflows` 経由）が落ちる。詳細は [.github/workflows/_pull-request.yaml](.github/workflows/_pull-request.yaml) を参照。
 
 ## アーキテクチャ概要
 


### PR DESCRIPTION
## 概要

`CLAUDE.md` の Git・GitHub 運用ルールにある PR タイトル規則を、CI に従う旨の一文だけだったところから、実際の規則を明示的に書き出すよう更新した。

## 背景

PR タイトルは `nozomiishii/workflows` 経由の `amannn/action-semantic-pull-request` でチェックされているが、許可される `<type>` や `<subject>` の制約は CI ワークフローの中にしか書かれていなかった。そのため Claude（や開発者）が事前に規則を把握できず、PR を出してから CI で落ちて初めて気づくことがあった。`CLAUDE.md` に規則そのものを書き出すことで、PR を作る時点でルール違反を避けられるようにする。

## 変更内容

`Git・GitHub 運用ルール` セクションの PR タイトル箇条書きを、以下のように具体化:

- 形式: Conventional Commits（英語）で `<type>: <subject>`
- 許可 `type`: `feat` / `fix` / `chore` のみ
- `subject`: 小文字始まり / ASCII のみ / 末尾スペース禁止
- 違反時は CI（`amannn/action-semantic-pull-request`、`nozomiishii/workflows` 経由）が落ちる
- 既存の `.github/workflows/_pull-request.yaml` への参照リンクは維持

## 関連

`~/.claude/CLAUDE.md`（グローバル）と `/ta` skill にも同じ規則を追記する変更が dotfiles 側で別 PR として進んでいる。
