### PR TITLE
chore: trim derivable sections from claude.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,17 +10,9 @@
 
 `configs` は `pnpm` を使った共有設定モノレポです。`packages/` に各種ツール（commitlint / ESLint / lefthook / prettier / tsconfig など）の設定をパッケージとして提供します。
 
-主要ディレクトリ:
-
-- `packages/`: `@nozomiishii/*-config` 系
-- `apps/`: 設定やサンプル
-- `lefthook.yaml`: Git hooks の設定
-- `.github/workflows/`: CI（release-please 等）
-
 ## 重要なパターン
 
 - 設定変更は基本的に `packages/` 配下の設定・ドキュメント側を優先して更新する。
-- フォーマット・リントは `pnpm format` / `pnpm prettier` と `pnpm fix:md`（markdown）を使う。
 
 ## テスト配置
 


### PR DESCRIPTION
## Summary

`CLAUDE.md` の追加トリム第 2 弾。先行 PR でコマンドリストを削った後、見直して **「ファイル一覧 / ディレクトリ列挙 / format-lint コマンドの再記述」** など、`ls` / `package.json` / `Makefile` / `.github/workflows/` を読めば自明な記述をさらに削除する。

## 変更内容（repo によって異なる）

- 「アーキテクチャ概要」配下の主要ディレクトリ列挙
- 「重要なパターン」内の "format / lint コマンドを使え" 系の箇条書き
- workflow ファイル列挙（`.github/workflows/` を読めば自明）
- ファイル名と短い説明だけのリスト

## 動機

`package.json` scripts / `Makefile` / ファイル一覧を `CLAUDE.md` に重複して保持すると drift する。WHY や非自明な制約は残し、それ以外は正本（コード・スクリプト・設定）に一本化する。

## Test plan

- [ ] `CLAUDE.md` のレンダリングが崩れていない
- [ ] WHY (理由) を含む記述は残っている
