### PR TITLE
chore(cspell-config): emit bin shebang via tsdown banner

### DIFF
--- a/packages/cspell-config/src/cli.ts
+++ b/packages/cspell-config/src/cli.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 

--- a/packages/cspell-config/tsdown.config.ts
+++ b/packages/cspell-config/tsdown.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
+  banner: { js: "#!/usr/bin/env node" },
   entry: ["src/index.ts", "src/cli.ts"],
   format: ["esm"],
   dts: true,


### PR DESCRIPTION
## Summary

- `packages/cspell-config/src/cli.ts` の `#!/usr/bin/env node` 直書きを削除
- `packages/cspell-config/tsdown.config.ts` に `banner: { js: "#!/usr/bin/env node" }` を追加
- 他の `*-config` パッケージ（commitlint / eslint / lefthook / prettier / postinstall）と同じ構成に揃えた

## Why

[PR #2160 のレビュー](https://github.com/nozomiishii/configs/pull/2160#discussion_r3178245915) で「shebang は tsdown 側で出せる」という指摘があった。横展開を確認したところ、cspell-config だけが古い形式（ソースに直書き）のまま残っていたので統一した。

## Test plan

- [x] `pnpm --filter @nozomiishii/cspell-config build` が通ること
- [x] `dist/cli.js` の先頭に `#!/usr/bin/env node` が付与されていること
- [x] `dist/cli.d.ts` に shebang が混入しないこと
- [x] `pnpm --filter @nozomiishii/cspell-config tsc` が通ること
