### PR TITLE
fix(prettier-config): pass plugin object directly to drop hoist dependency

### DIFF
--- a/packages/prettier-config/src/index.ts
+++ b/packages/prettier-config/src/index.ts
@@ -67,7 +67,8 @@ export default {
   objectWrap: "preserve",
 
   // plugin object を直渡し。string 指定だと consumer 側で publicHoistPattern: '*prettier*' が必要になる。
-  // {@link https://prettier.io/docs/plugins#using-plugins}
+  // {@link https://prettier.io/docs/plugins#using-plugins} import した plugin を渡す code example
+  // {@link https://prettier.io/docs/api} `plugins: (string | URL | Plugin)[]` の型注釈
   plugins: [packagejsonPlugin],
 
   overrides: [

--- a/packages/prettier-config/src/index.ts
+++ b/packages/prettier-config/src/index.ts
@@ -1,4 +1,5 @@
 import type { Config } from "prettier";
+import packagejsonPlugin from "prettier-plugin-packagejson";
 
 /**
  * Prettier options
@@ -65,7 +66,10 @@ export default {
   // Prettier default 複数行に分かれたオブジェクトの改行スタイルを保つ
   objectWrap: "preserve",
 
-  plugins: ["prettier-plugin-packagejson"],
+  // plugin object 直渡し。string で渡すと consumer の prettier コマンドの Node resolution に
+  // 依存するため publicHoistPattern: '*prettier*' が必要になる。import でこの shared config 自身の
+  // resolution に閉じれば consumer 側の hoist 設定は不要 (issue 2182)。
+  plugins: [packagejsonPlugin],
 
   overrides: [
     {

--- a/packages/prettier-config/src/index.ts
+++ b/packages/prettier-config/src/index.ts
@@ -66,9 +66,8 @@ export default {
   // Prettier default 複数行に分かれたオブジェクトの改行スタイルを保つ
   objectWrap: "preserve",
 
-  // plugin object 直渡し。string で渡すと consumer の prettier コマンドの Node resolution に
-  // 依存するため publicHoistPattern: '*prettier*' が必要になる。import でこの shared config 自身の
-  // resolution に閉じれば consumer 側の hoist 設定は不要 (issue 2182)。
+  // plugin object を直渡し。string 指定だと consumer 側で publicHoistPattern: '*prettier*' が必要になる。
+  // {@link https://prettier.io/docs/plugins#using-plugins}
   plugins: [packagejsonPlugin],
 
   overrides: [


### PR DESCRIPTION
## 概要

Closes [#2182](https://github.com/nozomiishii/configs/issues/2182)。

`packages/prettier-config/src/index.ts` の `plugins: ["prettier-plugin-packagejson"]` (string) を **plugin object 直渡し** に変更し、 consumer 側の `publicHoistPattern: '*prettier*'` 暗黙依存を排除する。

## 背景

string で渡すと、 plugin の解決は **consumer の `prettier` コマンドの Node resolution context** で行われる。 pnpm strict (`public-hoist-pattern=` 空) の consumer では `prettier-plugin-packagejson` は `node_modules/.pnpm/...` 配下にしか居ないため、 root から require できず `Cannot find module 'prettier-plugin-packagejson'` で fail する。

このリポジトリと [`nozomiishii/dev`](https://github.com/nozomiishii/dev) はどちらも `pnpm-workspace.yaml` に `publicHoistPattern: '*prettier*'` を書いているため動いていた。 素の pnpm consumer では動かなかった。

eslint-config は flat config 標準の import 形式 (`import pluginX from "..."`) で plugin object を直渡ししており、 shared config 自身の `.pnpm/<hash>/node_modules/` 内で resolution が完結するため consumer の hoist 設定に無依存。 prettier-config も同じパターンに揃える。

## 変更点

```diff
 import type { Config } from "prettier";
+import packagejsonPlugin from "prettier-plugin-packagejson";

 export default {
   ...
-  plugins: ["prettier-plugin-packagejson"],
+  plugins: [packagejsonPlugin],
   ...
 } satisfies Config;
```

prettier 3.x は plugin object 直渡しをサポートしている ([docs](https://prettier.io/docs/api#optionsplugins))。 tsdown で `dist/index.js` に bundle される時、 import の解決は dist 起点で固定されるので shared config 自身の `.pnpm/<hash>/node_modules/` 内で完結する。

## 動作検証

publicHoistPattern なしの consumer 環境で実機検証 (PASS):

```sh
$ TEST_DIR=/tmp/test-prettier-no-hoist
$ mkdir -p "$TEST_DIR" && cd "$TEST_DIR"
$ cat > package.json <<'EOF'
{"name":"test-prettier-import","version":"1.0.0","private":true,"type":"module"}
EOF
$ cat > .npmrc <<'EOF'
public-hoist-pattern=
node-linker=isolated
EOF
$ echo "export { default } from '@nozomiishii/prettier-config';" > prettier.config.ts
$ pnpm install /path/to/nozomiishii-prettier-config-0.9.0.tgz prettier@3.8.3 typescript@6.0.3
+ @nozomiishii/prettier-config 0.9.0
+ prettier 3.8.3
+ typescript 6.0.3
$ ls node_modules/
@nozomiishii
prettier -> .pnpm/prettier@3.8.3/node_modules/prettier
typescript -> .pnpm/typescript@6.0.3/node_modules/typescript
$ pnpm exec prettier --check package.json
Checking formatting...
All matched files use Prettier code style!
```

root `node_modules/` には direct dep だけが置かれ、 `prettier-plugin-packagejson` は `.pnpm/` 内に隔離されている状態でも plugin が解決されている (= shared config 自身の resolution context で完結している)。

## 関連

- [#2118](https://github.com/nozomiishii/configs/issues/2118) Phase 6 の片付け
- [#2182](https://github.com/nozomiishii/configs/issues/2182) Closes
