### PR TITLE
fix: remove invalid changelog-path traversal from package configs

### DIFF
--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -39,48 +39,39 @@
     },
     "packages/commitlint-config": {
       "release-type": "node",
-      "component": "@nozomiishii/commitlint-config",
-      "changelog-path": "../../CHANGELOG.md"
+      "component": "@nozomiishii/commitlint-config"
     },
     "packages/cspell-config": {
       "release-type": "node",
-      "component": "@nozomiishii/cspell-config",
-      "changelog-path": "../../CHANGELOG.md"
+      "component": "@nozomiishii/cspell-config"
     },
     "packages/eslint-config": {
       "release-type": "node",
-      "component": "@nozomiishii/eslint-config",
-      "changelog-path": "../../CHANGELOG.md"
+      "component": "@nozomiishii/eslint-config"
     },
     "packages/lefthook-config": {
       "release-type": "node",
-      "component": "@nozomiishii/lefthook-config",
-      "changelog-path": "../../CHANGELOG.md"
+      "component": "@nozomiishii/lefthook-config"
     },
     "packages/markdownlint-cli2-config": {
       "release-type": "node",
-      "component": "@nozomiishii/markdownlint-cli2-config",
-      "changelog-path": "../../CHANGELOG.md"
+      "component": "@nozomiishii/markdownlint-cli2-config"
     },
     "packages/postinstall": {
       "release-type": "node",
-      "component": "@nozomiishii/postinstall",
-      "changelog-path": "../../CHANGELOG.md"
+      "component": "@nozomiishii/postinstall"
     },
     "packages/prettier-config": {
       "release-type": "node",
-      "component": "@nozomiishii/prettier-config",
-      "changelog-path": "../../CHANGELOG.md"
+      "component": "@nozomiishii/prettier-config"
     },
     "packages/tsconfig": {
       "release-type": "node",
-      "component": "@nozomiishii/tsconfig",
-      "changelog-path": "../../CHANGELOG.md"
+      "component": "@nozomiishii/tsconfig"
     },
     "packages/nozo": {
       "release-type": "node",
-      "component": "nozo",
-      "changelog-path": "../../CHANGELOG.md"
+      "component": "nozo"
     }
   }
 }


### PR DESCRIPTION
## 概要

[#2202](https://github.com/nozomiishii/configs/pull/2202) (Phase 5 graduate to v1.0.0) でマージした `changelog-path: "../../CHANGELOG.md"` を全 9 packages から削除する hotfix。

## 何が起きたか

[#2202](https://github.com/nozomiishii/configs/pull/2202) merge 後、 release-please workflow が以下のエラーで失敗:

```
illegal pathing characters in path: packages/commitlint-config/../../CHANGELOG.md
```

release-please の [`base.ts`](https://github.com/googleapis/release-please/blob/main/src/strategies/base.ts) には `..` 含む path を拒絶する正規表現 (`/((^|\/)\.{1,2}|^~|^\/*)+\//`) が組み込まれており、 multi-component manifest mode では `changelog-path` 経由で root file への redirect が実装上不可能。

## 設計時の前提誤り

事前調査で grafana/faro-web-sdk が `changelog-path: "../../CHANGELOG.md"` で root only を実現していると認識していたが、 実際の faro-web-sdk の [release-please-config.json](https://github.com/grafana/faro-web-sdk/blob/main/release-please-config.json) は **完全に別パターン** を採用していた:

- `packages` 配下は `.` (root) **1 つだけ**
- 9 packages の version は **`extra-files`** で root release 時に同期更新

これは single-component release-please であり、 multi-component manifest mode + linked-versions plugin の構成 (我々の選択) とは設計が違う。

## 本 PR の対応 (Option Q: grain-lang exact pattern)

9 packages から `changelog-path: "../../CHANGELOG.md"` を削除し、 release-please の default に戻す:

- 各 package: 自身の `packages/<x>/CHANGELOG.md` を default 通り生成
- `.` (umbrella component "configs"): root `CHANGELOG.md` を生成 (`.` path が全 commit にマッチするため、 root CHANGELOG が aggregate view になる)
- linked-versions / umbrella version / release.yaml simplification など [#2202](https://github.com/nozomiishii/configs/pull/2202) の他の変更は維持

これは [grain-lang/grain](https://github.com/grain-lang/grain/blob/main/release-please-config.json) と同じ pattern (実証済み)。

## 結果

- release PR (P5-B) が `chore: release v1.0.0` の title で生成可能になる
- 各 package の CHANGELOG.md が再生成される ([#2202](https://github.com/nozomiishii/configs/pull/2202) で削除した状態から復活、 git history は残存)
- root CHANGELOG.md にも v1.0.0 entries が書かれる (umbrella aggregation)

## 残課題 (本 PR 外)

ユーザー希望は「root only CHANGELOG」であり、 grain-lang pattern では完全には満たせない (per-package + root の duplication が発生)。 完全な root only を目指す場合は以下が必要:

- `commitlint-config` を `feat!:` で更新し commit scope を mandatory 化
- 9 packages に `skip-changelog: true` を追加して per-package CHANGELOG 生成を skip
- 結果: root CHANGELOG が `**eslint-config:** ...` 等の scope-prefix で grouping されたエントリで埋まる

これは BREAKING 変更を伴うため、 Phase 6+ で別途検討。

## 検証

- [x] `jq . .github/.release-please-config.json` が pass
- [x] diff は 9 packages の `changelog-path` 行のみ削除
- [ ] CI green
- [ ] merge 後の release-please workflow が成功し、 P5-B (release PR) が生成される
