### PR TITLE
chore: revert phase 5 to redesign linked-versions strategy

### DIFF
--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -3,84 +3,51 @@
 
   "bootstrap-sha": "09c59ef0540b47e96916b8bb91c541ae53c5c72e",
 
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
+
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },
     { "type": "chore", "section": "Miscellaneous" }
   ],
 
-  "group-pull-request-title-pattern": "chore: release v${version}",
-  "separate-pull-requests": false,
-
-  "plugins": [
-    {
-      "type": "linked-versions",
-      "groupName": "configs",
-      "components": [
-        "configs",
-        "@nozomiishii/commitlint-config",
-        "@nozomiishii/cspell-config",
-        "@nozomiishii/eslint-config",
-        "@nozomiishii/lefthook-config",
-        "@nozomiishii/markdownlint-cli2-config",
-        "@nozomiishii/postinstall",
-        "@nozomiishii/prettier-config",
-        "@nozomiishii/tsconfig",
-        "nozo"
-      ]
-    }
-  ],
-
   "packages": {
-    ".": {
-      "release-type": "node",
-      "component": "configs",
-      "include-component-in-tag": false
-    },
     "packages/commitlint-config": {
       "release-type": "node",
-      "component": "@nozomiishii/commitlint-config",
-      "changelog-path": "../../CHANGELOG.md"
+      "component": "@nozomiishii/commitlint-config"
     },
     "packages/cspell-config": {
       "release-type": "node",
-      "component": "@nozomiishii/cspell-config",
-      "changelog-path": "../../CHANGELOG.md"
+      "component": "@nozomiishii/cspell-config"
     },
     "packages/eslint-config": {
       "release-type": "node",
-      "component": "@nozomiishii/eslint-config",
-      "changelog-path": "../../CHANGELOG.md"
+      "component": "@nozomiishii/eslint-config"
     },
     "packages/lefthook-config": {
       "release-type": "node",
-      "component": "@nozomiishii/lefthook-config",
-      "changelog-path": "../../CHANGELOG.md"
+      "component": "@nozomiishii/lefthook-config"
     },
     "packages/markdownlint-cli2-config": {
       "release-type": "node",
-      "component": "@nozomiishii/markdownlint-cli2-config",
-      "changelog-path": "../../CHANGELOG.md"
+      "component": "@nozomiishii/markdownlint-cli2-config"
     },
     "packages/postinstall": {
       "release-type": "node",
-      "component": "@nozomiishii/postinstall",
-      "changelog-path": "../../CHANGELOG.md"
+      "component": "@nozomiishii/postinstall"
     },
     "packages/prettier-config": {
       "release-type": "node",
-      "component": "@nozomiishii/prettier-config",
-      "changelog-path": "../../CHANGELOG.md"
+      "component": "@nozomiishii/prettier-config"
     },
     "packages/tsconfig": {
       "release-type": "node",
-      "component": "@nozomiishii/tsconfig",
-      "changelog-path": "../../CHANGELOG.md"
+      "component": "@nozomiishii/tsconfig"
     },
     "packages/nozo": {
       "release-type": "node",
-      "component": "nozo",
-      "changelog-path": "../../CHANGELOG.md"
+      "component": "nozo"
     }
   }
 }

--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -39,39 +39,48 @@
     },
     "packages/commitlint-config": {
       "release-type": "node",
-      "component": "@nozomiishii/commitlint-config"
+      "component": "@nozomiishii/commitlint-config",
+      "changelog-path": "../../CHANGELOG.md"
     },
     "packages/cspell-config": {
       "release-type": "node",
-      "component": "@nozomiishii/cspell-config"
+      "component": "@nozomiishii/cspell-config",
+      "changelog-path": "../../CHANGELOG.md"
     },
     "packages/eslint-config": {
       "release-type": "node",
-      "component": "@nozomiishii/eslint-config"
+      "component": "@nozomiishii/eslint-config",
+      "changelog-path": "../../CHANGELOG.md"
     },
     "packages/lefthook-config": {
       "release-type": "node",
-      "component": "@nozomiishii/lefthook-config"
+      "component": "@nozomiishii/lefthook-config",
+      "changelog-path": "../../CHANGELOG.md"
     },
     "packages/markdownlint-cli2-config": {
       "release-type": "node",
-      "component": "@nozomiishii/markdownlint-cli2-config"
+      "component": "@nozomiishii/markdownlint-cli2-config",
+      "changelog-path": "../../CHANGELOG.md"
     },
     "packages/postinstall": {
       "release-type": "node",
-      "component": "@nozomiishii/postinstall"
+      "component": "@nozomiishii/postinstall",
+      "changelog-path": "../../CHANGELOG.md"
     },
     "packages/prettier-config": {
       "release-type": "node",
-      "component": "@nozomiishii/prettier-config"
+      "component": "@nozomiishii/prettier-config",
+      "changelog-path": "../../CHANGELOG.md"
     },
     "packages/tsconfig": {
       "release-type": "node",
-      "component": "@nozomiishii/tsconfig"
+      "component": "@nozomiishii/tsconfig",
+      "changelog-path": "../../CHANGELOG.md"
     },
     "packages/nozo": {
       "release-type": "node",
-      "component": "nozo"
+      "component": "nozo",
+      "changelog-path": "../../CHANGELOG.md"
     }
   }
 }

--- a/.github/.release-please-manifest.json
+++ b/.github/.release-please-manifest.json
@@ -1,12 +1,11 @@
 {
-  ".": "0.0.0",
   "packages/commitlint-config": "0.2.3",
   "packages/cspell-config": "0.5.2",
   "packages/eslint-config": "0.9.1",
   "packages/lefthook-config": "0.7.1",
   "packages/markdownlint-cli2-config": "0.4.1",
-  "packages/postinstall": "0.1.2",
   "packages/prettier-config": "0.9.1",
   "packages/tsconfig": "0.1.1",
+  "packages/postinstall": "0.1.2",
   "packages/nozo": "0.4.4"
 }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,13 +67,17 @@ jobs:
   format:
     needs: release-please
 
-    if: needs.release-please.outputs.prs && needs.release-please.outputs.prs != '[]'
+    if: needs.release-please.outputs.prs
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
     permissions:
       contents: write # required to push the formatted CHANGELOG commit back to the release-please PR branch
+
+    strategy:
+      matrix:
+        pr: ${{ fromJson(needs.release-please.outputs.prs) }}
 
     steps:
       - name: Load secrets from 1Password
@@ -94,7 +98,7 @@ jobs:
       - name: Checkout release-please Pull Request
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ fromJson(needs.release-please.outputs.prs)[0].headBranchName }}
+          ref: ${{ matrix.pr.headBranchName }}
           persist-credentials: false # auth は後段の `gh auth setup-git` で配線する
 
       - name: Setup Node
@@ -128,10 +132,14 @@ jobs:
       id-token: write # Required for OIDC
       contents: read
 
-    if: needs.release-please.outputs.releases_created == 'true'
+    if: needs.release-please.outputs.releases_created == 'true' && needs.release-please.outputs.paths_released != '[]'
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
+
+    strategy:
+      matrix:
+        path: ${{ fromJson(needs.release-please.outputs.paths_released) }}
 
     steps:
       - name: Checkout
@@ -142,5 +150,7 @@ jobs:
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
-      - name: Publish all public packages
-        run: pnpm -r publish --no-git-checks
+      - name: Publish package
+        env:
+          MATRIX_PATH: ${{ matrix.path }}
+        run: pnpm --filter "./${MATRIX_PATH}" publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
-# Changelog
+# Changelogs
 
-> Per-package CHANGELOGs prior to v1.0.0 are available in git history (e.g., `git log packages/eslint-config/CHANGELOG.md`).
+- [cspell-config](packages/cspell-config/CHANGELOG.md)
+- [eslint-config](packages/eslint-config/CHANGELOG.md)
+- [lefthook-config](packages/lefthook-config/CHANGELOG.md)
+- [markdownlint-cli2-config](packages/markdownlint-cli2-config/CHANGELOG.md)
+- [nozo](packages/nozo/CHANGELOG.md)
+- [prettier-config](packages/prettier-config/CHANGELOG.md)
+
+## Version list
+
+See [release-please-manifest.json](.github/.release-please-manifest.json)

--- a/packages/commitlint-config/CHANGELOG.md
+++ b/packages/commitlint-config/CHANGELOG.md
@@ -1,0 +1,142 @@
+# Changelog
+
+## [0.2.3](https://github.com/nozomiishii/configs/compare/@nozomiishii/commitlint-config-v0.2.2...@nozomiishii/commitlint-config-v0.2.3) (2026-05-08)
+
+### Miscellaneous
+
+- update pnpm to v10.33.3 ([#2199](https://github.com/nozomiishii/configs/issues/2199)) ([6d610b4](https://github.com/nozomiishii/configs/commit/6d610b4ae99a16216c70737e5398d1670725e110))
+- update pnpm to v11 ([#2193](https://github.com/nozomiishii/configs/issues/2193)) ([e7c39d1](https://github.com/nozomiishii/configs/commit/e7c39d1183234ec9ebf2d8599535279b970222e9))
+
+## [0.2.2](https://github.com/nozomiishii/configs/compare/@nozomiishii/commitlint-config-v0.2.1...@nozomiishii/commitlint-config-v0.2.2) (2026-05-07)
+
+### Features
+
+- **commitlint-config:** add nozo-commitlint-init bin ([#2162](https://github.com/nozomiishii/configs/issues/2162)) ([5016610](https://github.com/nozomiishii/configs/commit/50166102d0a5f6be802af19f7a5418062cb32c1f))
+
+## [0.2.1](https://github.com/nozomiishii/configs/compare/@nozomiishii/commitlint-config-v0.2.0...@nozomiishii/commitlint-config-v0.2.1) (2026-05-03)
+
+### Miscellaneous
+
+- update commitlint monorepo to v20.5.3 ([#2170](https://github.com/nozomiishii/configs/issues/2170)) ([8eb0b69](https://github.com/nozomiishii/configs/commit/8eb0b6905c47b47fe993d6ace97c154f1a31f1b1))
+
+## [0.2.0](https://github.com/nozomiishii/configs/compare/@nozomiishii/commitlint-config-v0.1.0...@nozomiishii/commitlint-config-v0.2.0) (2026-05-01)
+
+### ⚠ BREAKING CHANGES
+
+- **commitlint-config:** rule renamed from `body-ascii-only` to `commit-message-ascii-only`. The new rule also fires when non-ASCII appears in the footer or in note text, not just the body.
+- **commitlint-config:** rule renamed from `body-ascii-only` to `commit-message-ascii-only`. The new rule also fires when non-ASCII appears in the footer or in note text, not just the body.
+- **prettier-config:** The singleQuote default is changed from true to false. Consumer repositories will see string literals re-formatted from single to double quotes.
+
+### Features
+
+- **commitlint-config:** rename body-ascii-only to commit-message-ascii-only ([#2147](https://github.com/nozomiishii/configs/issues/2147)) ([fc1bbf9](https://github.com/nozomiishii/configs/commit/fc1bbf95213eff33e03c842473bb84c516cef5bf))
+- **prettier-config:** revert singleQuote to Prettier default ([#2140](https://github.com/nozomiishii/configs/issues/2140)) ([c2f2ff5](https://github.com/nozomiishii/configs/commit/c2f2ff5ef8f68d53e7caf67206e95b8c16a10037))
+
+### Bug Fixes
+
+- add Japanese READMEs for shared config packages ([#2151](https://github.com/nozomiishii/configs/issues/2151)) ([b5e96f1](https://github.com/nozomiishii/configs/commit/b5e96f1cb4ad35725b44cf9b19cd01b02d798fa9))
+
+### Miscellaneous
+
+- **commitlint-config:** add vitest tests for commit-message-ascii-only ([#2148](https://github.com/nozomiishii/configs/issues/2148)) ([7f80831](https://github.com/nozomiishii/configs/commit/7f808312173fa771ee6e37a082afd7599a26cfc1))
+
+## [0.1.0](https://github.com/nozomiishii/configs/compare/@nozomiishii/commitlint-config-v0.0.11...@nozomiishii/commitlint-config-v0.1.0) (2026-04-28)
+
+### ⚠ BREAKING CHANGES
+
+- bin field changes from a single setup script ("bin": "bin/cli.sh") to a namespaced map ({ "nozo-commitlint": "bin/cli.mjs" }). Consumers who previously ran pnpx @nozomiishii/commitlint-config@latest to scaffold a commitlint config now need a different mechanism (planned for nozo init in a follow-up PR).
+
+### Features
+
+- modularize lefthook config + commitlint shim + nozo CLI rebuild ([#2119](https://github.com/nozomiishii/configs/issues/2119)) ([1140b62](https://github.com/nozomiishii/configs/commit/1140b62e3d0430f2383a5f683ea2583fa4ea7ee9)), closes [#2118](https://github.com/nozomiishii/configs/issues/2118)
+
+### Miscellaneous
+
+- update dependency @commitlint/cli to v20.5.2 ([#2120](https://github.com/nozomiishii/configs/issues/2120)) ([f127eab](https://github.com/nozomiishii/configs/commit/f127eab67e0c2a76c7d4b11edcdb67b92e12baaf))
+
+## [0.0.11](https://github.com/nozomiishii/configs/compare/@nozomiishii/commitlint-config-v0.0.10...@nozomiishii/commitlint-config-v0.0.11) (2026-04-27)
+
+### Features
+
+- **commitlint-config:** add body-ascii-only rule ([#2094](https://github.com/nozomiishii/configs/issues/2094)) ([cf870b9](https://github.com/nozomiishii/configs/commit/cf870b9cf722a01f6843ab4b536ac68ddd60010a))
+
+### Miscellaneous
+
+- **commitlint-config:** migrate to TypeScript source with tsdown build ([#2061](https://github.com/nozomiishii/configs/issues/2061)) ([b394ec0](https://github.com/nozomiishii/configs/commit/b394ec0b9e70624cc7311b72309e786315b9aed2))
+- release main ([#2031](https://github.com/nozomiishii/configs/issues/2031)) ([ba1c8b0](https://github.com/nozomiishii/configs/commit/ba1c8b0d0373eb1cc65bc89702ba1a41f5923e6b))
+- update dependency tsdown to v0.21.10 ([#2112](https://github.com/nozomiishii/configs/issues/2112)) ([21939bb](https://github.com/nozomiishii/configs/commit/21939bb55da1202f1e84eaed0f10a07c65c23e41))
+- update dependency tsdown to v0.21.8 ([#2070](https://github.com/nozomiishii/configs/issues/2070)) ([bdcdeab](https://github.com/nozomiishii/configs/commit/bdcdeab2a83cfef17629d63b621b431a9399cd56))
+- update dependency tsdown to v0.21.9 ([#2085](https://github.com/nozomiishii/configs/issues/2085)) ([eaeb311](https://github.com/nozomiishii/configs/commit/eaeb311df48848207f0a3ae5aa051eece4bfa278))
+- update dependency typescript to v6.0.3 ([#2088](https://github.com/nozomiishii/configs/issues/2088)) ([25e9e34](https://github.com/nozomiishii/configs/commit/25e9e34004a9069de68430008b4daca34bcac000))
+- update pnpm to v10.33.1 ([#2110](https://github.com/nozomiishii/configs/issues/2110)) ([5af1dc0](https://github.com/nozomiishii/configs/commit/5af1dc0b5d2ce5c49bc1f97a87d04f1e72aadd51))
+- update pnpm to v10.33.2 ([#2114](https://github.com/nozomiishii/configs/issues/2114)) ([de64989](https://github.com/nozomiishii/configs/commit/de64989ce298d538e759f980ab505030be9a3e24))
+
+## [0.0.10](https://github.com/nozomiishii/configs/compare/@nozomiishii/commitlint-config-v0.0.9...@nozomiishii/commitlint-config-v0.0.10) (2026-04-03)
+
+### Features
+
+- **commitlint-config:** restrict commit types to feat, fix, and chore ([#2027](https://github.com/nozomiishii/configs/issues/2027)) ([47ba00c](https://github.com/nozomiishii/configs/commit/47ba00c950861b2ca68e4e557f6264a3ad404e63))
+
+## [0.0.9](https://github.com/nozomiishii/configs/compare/@nozomiishii/commitlint-config-v0.0.8...@nozomiishii/commitlint-config-v0.0.9) (2026-01-19)
+
+### Bug Fixes
+
+- update installation commands in README files to use pnpx instead of npx ([d8c68bc](https://github.com/nozomiishii/configs/commit/d8c68bce6370baa876e773e4b64a9b24fdfca36f))
+
+## [0.0.8](https://github.com/nozomiishii/configs/compare/@nozomiishii/commitlint-config-v0.0.7...@nozomiishii/commitlint-config-v0.0.8) (2025-09-02)
+
+### Bug Fixes
+
+- remove node engine from package.json files ([b3ad146](https://github.com/nozomiishii/configs/commit/b3ad14646e733a4c7435544e76b8a7238f333388))
+
+## [0.0.7](https://github.com/nozomiishii/configs/compare/@nozomiishii/commitlint-config-v0.0.6...@nozomiishii/commitlint-config-v0.0.7) (2025-08-21)
+
+### Bug Fixes
+
+- devEngines in package.json ([02d57a3](https://github.com/nozomiishii/configs/commit/02d57a31f4d4d403b14ad223661c9531faeda296))
+- remove pnpm.executionEnv.nodeVersion ([9e2941a](https://github.com/nozomiishii/configs/commit/9e2941a0b00a83a5dc00391a533eccd3dd9b7824))
+
+## [0.0.6](https://github.com/nozomiishii/configs/compare/@nozomiishii/commitlint-config-v0.0.5...@nozomiishii/commitlint-config-v0.0.6) (2025-05-03)
+
+### Features
+
+- add TypeScript configuration for Commitlint ([abee5aa](https://github.com/nozomiishii/configs/commit/abee5aa94794cbf84e46125c04dff02d71344316))
+
+### Bug Fixes
+
+- conditionally remove @commitlint/config-conventional before adding custom config ([dceaf95](https://github.com/nozomiishii/configs/commit/dceaf958b143ec9d2f445eda3fb38aeeded3c825))
+- update release workflow condition and add package manager configuration to multiple packages ([958992c](https://github.com/nozomiishii/configs/commit/958992ccd8bdaf906a50bb769ec45459fab81210))
+
+## [0.0.5](https://github.com/nozomiishii/configs/compare/@nozomiishii/commitlint-config-v0.0.4...@nozomiishii/commitlint-config-v0.0.5) (2024-06-16)
+
+### Features
+
+- update commitlint install command ([26e256d](https://github.com/nozomiishii/configs/commit/26e256d2f9f4cff2afffd9ab93d99a21c472482f))
+
+### Bug Fixes
+
+- update commitlint version ([89b4158](https://github.com/nozomiishii/configs/commit/89b4158f8fd29f6b7d06dad89a4aa96d337cdfae))
+
+## [0.0.4](https://github.com/nozomiishii/configs/compare/@nozomiishii/commitlint-config-v0.0.3...@nozomiishii/commitlint-config-v0.0.4) (2024-02-18)
+
+### Features
+
+- create @nozomiishii/commitlint-config ([1751de2](https://github.com/nozomiishii/configs/commit/1751de2e367b935821d8645a535eeda562c5e1bc))
+- create @nozomiishii/commitlint-config ([#451](https://github.com/nozomiishii/configs/issues/451)) ([5ae75ef](https://github.com/nozomiishii/configs/commit/5ae75ef942eb7b486b890cb027515ee4e2b8fe14))
+
+### Bug Fixes
+
+- add script to remove @commitlint/config-conventional ([4d30566](https://github.com/nozomiishii/configs/commit/4d30566bdc823097cff015066fc40bd91e1be2e3))
+
+## [0.0.3](https://github.com/nozomiishii/configs/compare/@nozomiishii/commitlint-config-v0.0.2...@nozomiishii/commitlint-config-v0.0.3) (2024-02-18)
+
+### Bug Fixes
+
+- add script to remove @commitlint/config-conventional ([4d30566](https://github.com/nozomiishii/configs/commit/4d30566bdc823097cff015066fc40bd91e1be2e3))
+
+## [0.0.2](https://github.com/nozomiishii/configs/compare/@nozomiishii/commitlint-config-v0.0.1...@nozomiishii/commitlint-config-v0.0.2) (2024-02-18)
+
+### Features
+
+- create @nozomiishii/commitlint-config ([1751de2](https://github.com/nozomiishii/configs/commit/1751de2e367b935821d8645a535eeda562c5e1bc))
+- create @nozomiishii/commitlint-config ([#451](https://github.com/nozomiishii/configs/issues/451)) ([5ae75ef](https://github.com/nozomiishii/configs/commit/5ae75ef942eb7b486b890cb027515ee4e2b8fe14))

--- a/packages/cspell-config/CHANGELOG.md
+++ b/packages/cspell-config/CHANGELOG.md
@@ -1,0 +1,104 @@
+# Changelog
+
+## [0.5.2](https://github.com/nozomiishii/configs/compare/@nozomiishii/cspell-config-v0.5.1...@nozomiishii/cspell-config-v0.5.2) (2026-05-08)
+
+### Miscellaneous
+
+- update pnpm to v10.33.3 ([#2199](https://github.com/nozomiishii/configs/issues/2199)) ([6d610b4](https://github.com/nozomiishii/configs/commit/6d610b4ae99a16216c70737e5398d1670725e110))
+- update pnpm to v11 ([#2193](https://github.com/nozomiishii/configs/issues/2193)) ([e7c39d1](https://github.com/nozomiishii/configs/commit/e7c39d1183234ec9ebf2d8599535279b970222e9))
+
+## [0.5.1](https://github.com/nozomiishii/configs/compare/@nozomiishii/cspell-config-v0.5.0...@nozomiishii/cspell-config-v0.5.1) (2026-05-03)
+
+### Miscellaneous
+
+- **cspell-config:** emit bin shebang via tsdown banner ([#2177](https://github.com/nozomiishii/configs/issues/2177)) ([28e65f5](https://github.com/nozomiishii/configs/commit/28e65f50bf28960c9b85f380b6e4347ad34750cd))
+
+## [0.5.0](https://github.com/nozomiishii/configs/compare/@nozomiishii/cspell-config-v0.4.6...@nozomiishii/cspell-config-v0.5.0) (2026-05-01)
+
+### ⚠ BREAKING CHANGES
+
+- **prettier-config:** The printWidth default is changed from 119 to 100. Lines in the 100-119 range will be re-formatted in consumer codebases on the next format run.
+- **prettier-config:** The singleQuote default is changed from true to false. Consumer repositories will see string literals re-formatted from single to double quotes.
+
+### Features
+
+- **cspell-config:** ship nozo-cspell shim ([#2129](https://github.com/nozomiishii/configs/issues/2129)) ([9ad7963](https://github.com/nozomiishii/configs/commit/9ad7963693e62c8ac70fb4d6618c657ceb424158)), closes [#2118](https://github.com/nozomiishii/configs/issues/2118)
+- **prettier-config:** change printWidth default from 119 to 100 ([#2141](https://github.com/nozomiishii/configs/issues/2141)) ([949e037](https://github.com/nozomiishii/configs/commit/949e037f45d4ccfd8647fceeea4338bd5b6f697e))
+- **prettier-config:** revert singleQuote to Prettier default ([#2140](https://github.com/nozomiishii/configs/issues/2140)) ([c2f2ff5](https://github.com/nozomiishii/configs/commit/c2f2ff5ef8f68d53e7caf67206e95b8c16a10037))
+
+### Bug Fixes
+
+- add Japanese READMEs for shared config packages ([#2151](https://github.com/nozomiishii/configs/issues/2151)) ([b5e96f1](https://github.com/nozomiishii/configs/commit/b5e96f1cb4ad35725b44cf9b19cd01b02d798fa9))
+
+## [0.4.6](https://github.com/nozomiishii/configs/compare/@nozomiishii/cspell-config-v0.4.5...@nozomiishii/cspell-config-v0.4.6) (2026-04-27)
+
+### Bug Fixes
+
+- align tsdown to 0.21.8 in cspell-config and markdownlint-cli2-config ([#2076](https://github.com/nozomiishii/configs/issues/2076)) ([33b0a2e](https://github.com/nozomiishii/configs/commit/33b0a2e3e720fb4f07ec86fd94d34a5eb1579af9))
+
+### Miscellaneous
+
+- add provenance to publishConfig for all packages ([#1973](https://github.com/nozomiishii/configs/issues/1973)) ([165ef9b](https://github.com/nozomiishii/configs/commit/165ef9b1232b74a1e62222cf0683c2be413e8252))
+- **cspell-config:** migrate to TypeScript source with tsdown build ([#2067](https://github.com/nozomiishii/configs/issues/2067)) ([cac2488](https://github.com/nozomiishii/configs/commit/cac2488318b1f844c2c3085aa6c71d71979407c2))
+- release main ([#2031](https://github.com/nozomiishii/configs/issues/2031)) ([ba1c8b0](https://github.com/nozomiishii/configs/commit/ba1c8b0d0373eb1cc65bc89702ba1a41f5923e6b))
+- update dependency tsdown to v0.21.10 ([#2112](https://github.com/nozomiishii/configs/issues/2112)) ([21939bb](https://github.com/nozomiishii/configs/commit/21939bb55da1202f1e84eaed0f10a07c65c23e41))
+- update dependency tsdown to v0.21.9 ([#2085](https://github.com/nozomiishii/configs/issues/2085)) ([eaeb311](https://github.com/nozomiishii/configs/commit/eaeb311df48848207f0a3ae5aa051eece4bfa278))
+- update dependency typescript to v6.0.3 ([#2088](https://github.com/nozomiishii/configs/issues/2088)) ([25e9e34](https://github.com/nozomiishii/configs/commit/25e9e34004a9069de68430008b4daca34bcac000))
+- update pnpm to v10.28.1 ([#1783](https://github.com/nozomiishii/configs/issues/1783)) ([8ab851f](https://github.com/nozomiishii/configs/commit/8ab851f5b517d1a6aaf5f1a551712a9d08291fc8))
+- update pnpm to v10.28.2 [security] ([#1803](https://github.com/nozomiishii/configs/issues/1803)) ([3bf99c7](https://github.com/nozomiishii/configs/commit/3bf99c70bf15d71c797480c5fc213c83b42cd9a3))
+- update pnpm to v10.29.1 ([#1847](https://github.com/nozomiishii/configs/issues/1847)) ([331b504](https://github.com/nozomiishii/configs/commit/331b5045e0f62b613394d1a8bdd0da18c711399f))
+- update pnpm to v10.29.2 ([#1849](https://github.com/nozomiishii/configs/issues/1849)) ([180c37e](https://github.com/nozomiishii/configs/commit/180c37e71c139f6dabe0dc62a7e227095c263fb6))
+- update pnpm to v10.29.3 ([#1859](https://github.com/nozomiishii/configs/issues/1859)) ([a32b59f](https://github.com/nozomiishii/configs/commit/a32b59f56b170dd7f0dbf16718ed4806261e3910))
+- update pnpm to v10.30.0 ([#1872](https://github.com/nozomiishii/configs/issues/1872)) ([a03fd07](https://github.com/nozomiishii/configs/commit/a03fd07e69295164b6fa576b06e724848c3c0559))
+- update pnpm to v10.30.1 ([#1883](https://github.com/nozomiishii/configs/issues/1883)) ([233091d](https://github.com/nozomiishii/configs/commit/233091d278ab9b0271db6577aba1f13f29030fa6))
+- update pnpm to v10.30.2 ([#1901](https://github.com/nozomiishii/configs/issues/1901)) ([9b75ad0](https://github.com/nozomiishii/configs/commit/9b75ad06e6ea552d983313bf44fbac83c6ccca11))
+- update pnpm to v10.30.3 ([#1911](https://github.com/nozomiishii/configs/issues/1911)) ([bf0767e](https://github.com/nozomiishii/configs/commit/bf0767e66848eb142b058d11a5c8f2630e8809c8))
+- update pnpm to v10.31.0 ([#1936](https://github.com/nozomiishii/configs/issues/1936)) ([a70a929](https://github.com/nozomiishii/configs/commit/a70a929d39a07c6ad9df8a9ad70d1bf49f198310))
+- update pnpm to v10.32.0 ([#1943](https://github.com/nozomiishii/configs/issues/1943)) ([b2c305a](https://github.com/nozomiishii/configs/commit/b2c305a55fa6b3c48eb5bbb5011a22ed52cde7e0))
+- update pnpm to v10.32.1 ([#1945](https://github.com/nozomiishii/configs/issues/1945)) ([e263599](https://github.com/nozomiishii/configs/commit/e2635991025302bcc85dd1c61016365c392dfd79))
+- update pnpm to v10.33.0 ([#1995](https://github.com/nozomiishii/configs/issues/1995)) ([276cdda](https://github.com/nozomiishii/configs/commit/276cdda99f94f64e79eb87192e1e6d1b175c46b6))
+- update pnpm to v10.33.1 ([#2110](https://github.com/nozomiishii/configs/issues/2110)) ([5af1dc0](https://github.com/nozomiishii/configs/commit/5af1dc0b5d2ce5c49bc1f97a87d04f1e72aadd51))
+- update pnpm to v10.33.2 ([#2114](https://github.com/nozomiishii/configs/issues/2114)) ([de64989](https://github.com/nozomiishii/configs/commit/de64989ce298d538e759f980ab505030be9a3e24))
+
+## [0.4.5](https://github.com/nozomiishii/configs/compare/@nozomiishii/cspell-config-v0.4.4...@nozomiishii/cspell-config-v0.4.5) (2026-01-19)
+
+### Bug Fixes
+
+- update installation commands in README files to use pnpx instead of npx ([d8c68bc](https://github.com/nozomiishii/configs/commit/d8c68bce6370baa876e773e4b64a9b24fdfca36f))
+
+## [0.4.4](https://github.com/nozomiishii/configs/compare/@nozomiishii/cspell-config-v0.4.3...@nozomiishii/cspell-config-v0.4.4) (2025-09-02)
+
+### Bug Fixes
+
+- remove node engine from package.json files ([b3ad146](https://github.com/nozomiishii/configs/commit/b3ad14646e733a4c7435544e76b8a7238f333388))
+
+## [0.4.3](https://github.com/nozomiishii/configs/compare/@nozomiishii/cspell-config-v0.4.2...@nozomiishii/cspell-config-v0.4.3) (2025-08-21)
+
+### Bug Fixes
+
+- devEngines in package.json ([02d57a3](https://github.com/nozomiishii/configs/commit/02d57a31f4d4d403b14ad223661c9531faeda296))
+- remove pnpm.executionEnv.nodeVersion ([9e2941a](https://github.com/nozomiishii/configs/commit/9e2941a0b00a83a5dc00391a533eccd3dd9b7824))
+
+## [0.4.2](https://github.com/nozomiishii/configs/compare/@nozomiishii/cspell-config-v0.4.1...@nozomiishii/cspell-config-v0.4.2) (2025-05-04)
+
+### Bug Fixes
+
+- update release workflow condition and add package manager configuration to multiple packages ([958992c](https://github.com/nozomiishii/configs/commit/958992ccd8bdaf906a50bb769ec45459fab81210))
+
+## [0.4.1](https://github.com/nozomiishii/configs/compare/@nozomiishii/cspell-config-v0.4.0...@nozomiishii/cspell-config-v0.4.1) (2023-12-15)
+
+### Bug Fixes
+
+- cli execution of cspell ([f339442](https://github.com/nozomiishii/configs/commit/f339442e582517185d6a2f686bac29ff0b087f76))
+
+## [0.4.0](https://github.com/nozomiishii/configs/compare/@nozomiishii/cspell-config-v0.3.0...@nozomiishii/cspell-config-v0.4.0) (2023-12-15)
+
+### Features
+
+- change runtime from node to bash ([43fb4b3](https://github.com/nozomiishii/configs/commit/43fb4b39ee6748e44f10b2273b436fa6aa92c937))
+
+## [0.3.0](https://github.com/nozomiishii/configs/compare/@nozomiishii/cspell-config-v0.2.0...@nozomiishii/cspell-config-v0.3.0) (2023-08-06)
+
+### Features
+
+- add initial CHANGELOG ([9ce8c62](https://github.com/nozomiishii/configs/commit/9ce8c62626daccb52d6855312820188fbb069a18))

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -1,0 +1,392 @@
+# Changelog
+
+## [0.9.1](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.9.0...@nozomiishii/eslint-config-v0.9.1) (2026-05-08)
+
+### Miscellaneous
+
+- update dependency @eslint-react/eslint-plugin to v5.7.2 ([#2197](https://github.com/nozomiishii/configs/issues/2197)) ([c5f4bc0](https://github.com/nozomiishii/configs/commit/c5f4bc0d5b54299289e80006f5f011640d853592))
+- update dependency eslint-plugin-n to v18 ([#2200](https://github.com/nozomiishii/configs/issues/2200)) ([9af9de5](https://github.com/nozomiishii/configs/commit/9af9de5c1dc26df213076343e86a9825a1631fff))
+- update dependency typescript-eslint to v8.59.2 ([#2198](https://github.com/nozomiishii/configs/issues/2198)) ([443b58c](https://github.com/nozomiishii/configs/commit/443b58c420a9e11907d53566a36ac3b49e3cf1cb))
+- update pnpm to v10.33.3 ([#2199](https://github.com/nozomiishii/configs/issues/2199)) ([6d610b4](https://github.com/nozomiishii/configs/commit/6d610b4ae99a16216c70737e5398d1670725e110))
+- update pnpm to v11 ([#2193](https://github.com/nozomiishii/configs/issues/2193)) ([e7c39d1](https://github.com/nozomiishii/configs/commit/e7c39d1183234ec9ebf2d8599535279b970222e9))
+
+## [0.9.0](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.8.1...@nozomiishii/eslint-config-v0.9.0) (2026-05-07)
+
+### ⚠ BREAKING CHANGES
+
+- **eslint-config:** replace legacy bash scaffold with nozo-eslint-init bin ([#2163](https://github.com/nozomiishii/configs/issues/2163))
+
+### Features
+
+- **eslint-config:** replace legacy bash scaffold with nozo-eslint-init bin ([#2163](https://github.com/nozomiishii/configs/issues/2163)) ([60da90a](https://github.com/nozomiishii/configs/commit/60da90ab20d5f334983357ad52af34ecf5cf74f4))
+
+### Miscellaneous
+
+- update dependency @eslint-react/eslint-plugin to v5.6.4 ([#2180](https://github.com/nozomiishii/configs/issues/2180)) ([c0f8de6](https://github.com/nozomiishii/configs/commit/c0f8de6ae2dc6073acc85bb3847f20e2774578a3))
+- update dependency @eslint-react/eslint-plugin to v5.6.6 ([#2184](https://github.com/nozomiishii/configs/issues/2184)) ([f701a61](https://github.com/nozomiishii/configs/commit/f701a61f5bc4bec66d9884c1515db7295682b7f2))
+- update dependency @eslint-react/eslint-plugin to v5.7.0 ([#2188](https://github.com/nozomiishii/configs/issues/2188)) ([d4c700f](https://github.com/nozomiishii/configs/commit/d4c700f1e8f39267d2bb81e1801ec50b7d1901ca))
+- update dependency @eslint-react/eslint-plugin to v5.7.1 ([#2189](https://github.com/nozomiishii/configs/issues/2189)) ([5eeb01f](https://github.com/nozomiishii/configs/commit/5eeb01f9f9b9d0fde2fa2b654008a3a733485396))
+- update dependency eslint to v10.3.0 ([#2185](https://github.com/nozomiishii/configs/issues/2185)) ([0ecb904](https://github.com/nozomiishii/configs/commit/0ecb9046e502ed3af729586f4023e32382a864cd))
+- update dependency globals to v17.6.0 ([#2186](https://github.com/nozomiishii/configs/issues/2186)) ([5e6d2d7](https://github.com/nozomiishii/configs/commit/5e6d2d72d8b559d0cdf5c644ed77a7bdb2d745a4))
+
+## [0.8.1](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.8.0...@nozomiishii/eslint-config-v0.8.1) (2026-05-03)
+
+### Features
+
+- **eslint-config:** switch typegen API and add named rule exports ([#2171](https://github.com/nozomiishii/configs/issues/2171)) ([0cc65e5](https://github.com/nozomiishii/configs/commit/0cc65e5b37319612a843e029753ac284bc4f5ba9))
+
+### Miscellaneous
+
+- update dependency @eslint-react/eslint-plugin to v5.6.2 ([#2168](https://github.com/nozomiishii/configs/issues/2168)) ([07251fc](https://github.com/nozomiishii/configs/commit/07251fc2f3e44fd9d5374237cdb1582901603ab4))
+
+## [0.8.0](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.7.0...@nozomiishii/eslint-config-v0.8.0) (2026-05-02)
+
+### ⚠ BREAKING CHANGES
+
+- **eslint-config:** consumers will see new lint errors on any existing eslint-disable comments in their code. To opt out per file, add a flat config override that turns the no-use rule off for the matching files glob.
+
+### Features
+
+- **eslint-config:** ban eslint-disable comments via no-use rule ([#2158](https://github.com/nozomiishii/configs/issues/2158)) ([429edd0](https://github.com/nozomiishii/configs/commit/429edd00f3267d27359f66782559f04b426b6f25))
+
+### Miscellaneous
+
+- update dependency @eslint-react/eslint-plugin to v5 ([#2153](https://github.com/nozomiishii/configs/issues/2153)) ([8511913](https://github.com/nozomiishii/configs/commit/85119134f7ee3a58a23d617bf9b06700ff862d64))
+- update dependency eslint-plugin-storybook to v10.3.6 ([#2161](https://github.com/nozomiishii/configs/issues/2161)) ([daacc17](https://github.com/nozomiishii/configs/commit/daacc17508627b42489c987d745c38636ea2fdb7))
+
+## [0.7.0](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.6.14...@nozomiishii/eslint-config-v0.7.0) (2026-05-01)
+
+### ⚠ BREAKING CHANGES
+
+- **prettier-config:** The printWidth default is changed from 119 to 100. Lines in the 100-119 range will be re-formatted in consumer codebases on the next format run.
+- **prettier-config:** The singleQuote default is changed from true to false. Consumer repositories will see string literals re-formatted from single to double quotes.
+
+### Features
+
+- **eslint-config:** enforce .test.{ts,tsx} via vitest/consistent-test-filename ([#2130](https://github.com/nozomiishii/configs/issues/2130)) ([50cf240](https://github.com/nozomiishii/configs/commit/50cf24066671a4f80c2297aa44b198e60fdc0d08))
+- **prettier-config:** change printWidth default from 119 to 100 ([#2141](https://github.com/nozomiishii/configs/issues/2141)) ([949e037](https://github.com/nozomiishii/configs/commit/949e037f45d4ccfd8647fceeea4338bd5b6f697e))
+- **prettier-config:** revert singleQuote to Prettier default ([#2140](https://github.com/nozomiishii/configs/issues/2140)) ([c2f2ff5](https://github.com/nozomiishii/configs/commit/c2f2ff5ef8f68d53e7caf67206e95b8c16a10037))
+
+### Bug Fixes
+
+- add Japanese READMEs for shared config packages ([#2151](https://github.com/nozomiishii/configs/issues/2151)) ([b5e96f1](https://github.com/nozomiishii/configs/commit/b5e96f1cb4ad35725b44cf9b19cd01b02d798fa9))
+
+### Miscellaneous
+
+- update dependency eslint-plugin-better-tailwindcss to v4.5.0 ([#2138](https://github.com/nozomiishii/configs/issues/2138)) ([8674123](https://github.com/nozomiishii/configs/commit/8674123b1a2e0483d4aac17df42aeef531607797))
+- update dependency eslint-plugin-package-json to v0.91.2 ([#2137](https://github.com/nozomiishii/configs/issues/2137)) ([e803a96](https://github.com/nozomiishii/configs/commit/e803a96cbffc55e912e6d122900da5daebc6a14c))
+- update dependency typescript-eslint to v8.59.1 ([#2136](https://github.com/nozomiishii/configs/issues/2136)) ([0f6e369](https://github.com/nozomiishii/configs/commit/0f6e369a44062d8a9c11eb8962dce6b36b37bfd6))
+
+## [0.6.14](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.6.13...@nozomiishii/eslint-config-v0.6.14) (2026-04-27)
+
+### Miscellaneous
+
+- **commitlint-config:** migrate to TypeScript source with tsdown build ([#2061](https://github.com/nozomiishii/configs/issues/2061)) ([b394ec0](https://github.com/nozomiishii/configs/commit/b394ec0b9e70624cc7311b72309e786315b9aed2))
+- release main ([#2031](https://github.com/nozomiishii/configs/issues/2031)) ([ba1c8b0](https://github.com/nozomiishii/configs/commit/ba1c8b0d0373eb1cc65bc89702ba1a41f5923e6b))
+- update dependency @eslint-react/eslint-plugin to v4 ([#2036](https://github.com/nozomiishii/configs/issues/2036)) ([32eec90](https://github.com/nozomiishii/configs/commit/32eec902357f32f5044fcc5576b61feb34131448))
+- update dependency @eslint-react/eslint-plugin to v4.2.3 ([#2040](https://github.com/nozomiishii/configs/issues/2040)) ([f5405d8](https://github.com/nozomiishii/configs/commit/f5405d8ffac606b3ed5472829115c3b7517f6236))
+- update dependency @eslint/config-inspector to v2 ([#2087](https://github.com/nozomiishii/configs/issues/2087)) ([f5c7235](https://github.com/nozomiishii/configs/commit/f5c723504addd4e9f89d4ce06aaa13762e581c01))
+- update dependency @next/eslint-plugin-next to v16.2.2 ([#2034](https://github.com/nozomiishii/configs/issues/2034)) ([d83951d](https://github.com/nozomiishii/configs/commit/d83951d2668a6214f780f3d2d77fe46f84fa6257))
+- update dependency @next/eslint-plugin-next to v16.2.3 ([#2051](https://github.com/nozomiishii/configs/issues/2051)) ([12471f8](https://github.com/nozomiishii/configs/commit/12471f8529d677ae9def323bd73ef5cf83ab3b8e))
+- update dependency @next/eslint-plugin-next to v16.2.4 ([#2082](https://github.com/nozomiishii/configs/issues/2082)) ([6785bbd](https://github.com/nozomiishii/configs/commit/6785bbd3e354cd5826f49702f96c51fa72d652e8))
+- update dependency @types/node to v24.12.1 ([#2041](https://github.com/nozomiishii/configs/issues/2041)) ([d6f9a6d](https://github.com/nozomiishii/configs/commit/d6f9a6da6419e963ca3f343fc3108def95eafe84))
+- update dependency @types/node to v24.12.2 ([#2042](https://github.com/nozomiishii/configs/issues/2042)) ([12f3031](https://github.com/nozomiishii/configs/commit/12f3031d32a6adbac606dd999978cd18d6b37526))
+- update dependency @vitest/eslint-plugin to v1.6.14 ([#2028](https://github.com/nozomiishii/configs/issues/2028)) ([6d33eb3](https://github.com/nozomiishii/configs/commit/6d33eb304af2d8861ede329c75dd5dada38021f7))
+- update dependency @vitest/eslint-plugin to v1.6.15 ([#2052](https://github.com/nozomiishii/configs/issues/2052)) ([5805a30](https://github.com/nozomiishii/configs/commit/5805a30c2d32890d5006bb4a542cdeb93fb62238))
+- update dependency @vitest/eslint-plugin to v1.6.16 ([#2081](https://github.com/nozomiishii/configs/issues/2081)) ([9febc7e](https://github.com/nozomiishii/configs/commit/9febc7e21ee566540df031b4b2e80b6293c9b7a4))
+- update dependency eslint to v10.2.0 ([#2044](https://github.com/nozomiishii/configs/issues/2044)) ([435e5ac](https://github.com/nozomiishii/configs/commit/435e5acbaeaca91f50d05701088230cab0893cec))
+- update dependency eslint to v10.2.1 ([#2091](https://github.com/nozomiishii/configs/issues/2091)) ([1e41337](https://github.com/nozomiishii/configs/commit/1e41337b3f84fdcd92f84ed53ca2a08e84608921))
+- update dependency eslint-plugin-better-tailwindcss to v4.4.0 ([#2055](https://github.com/nozomiishii/configs/issues/2055)) ([c77b550](https://github.com/nozomiishii/configs/commit/c77b550e4029c99d53df338b7915e335bfff90d5))
+- update dependency eslint-plugin-better-tailwindcss to v4.4.1 ([#2062](https://github.com/nozomiishii/configs/issues/2062)) ([baa5677](https://github.com/nozomiishii/configs/commit/baa56776bcf6d9568cc144a7f0128f1d928b43e3))
+- update dependency eslint-plugin-jsdoc to v62.9.0 ([#2035](https://github.com/nozomiishii/configs/issues/2035)) ([5979dcb](https://github.com/nozomiishii/configs/commit/5979dcb5fd4b3ca20aa4fc1a95dcc112e7f9e004))
+- update dependency eslint-plugin-perfectionist to v5.8.0 ([#2038](https://github.com/nozomiishii/configs/issues/2038)) ([55b492b](https://github.com/nozomiishii/configs/commit/55b492ba659ebf14cd0871a1678151c13ce64763))
+- update dependency eslint-plugin-perfectionist to v5.9.0 ([#2092](https://github.com/nozomiishii/configs/issues/2092)) ([e976d9e](https://github.com/nozomiishii/configs/commit/e976d9e40a4e57121cadb9bb4d89ee8925ecf9af))
+- update dependency eslint-plugin-playwright to v2.10.2 ([#2095](https://github.com/nozomiishii/configs/issues/2095)) ([109274e](https://github.com/nozomiishii/configs/commit/109274eafaf5e772951a883561b306a6110e1d99))
+- update dependency eslint-plugin-react-hooks to v7.1.1 ([#2089](https://github.com/nozomiishii/configs/issues/2089)) ([f1838c3](https://github.com/nozomiishii/configs/commit/f1838c34fb81831ba684f55d57cf561ec3fccd33))
+- update dependency eslint-plugin-storybook to v10.3.4 ([#2037](https://github.com/nozomiishii/configs/issues/2037)) ([d71eb48](https://github.com/nozomiishii/configs/commit/d71eb48ef011559cd591ad02c61cdd278f24e043))
+- update dependency eslint-plugin-storybook to v10.3.5 ([#2047](https://github.com/nozomiishii/configs/issues/2047)) ([e9056c4](https://github.com/nozomiishii/configs/commit/e9056c4a7e583dcf8e83bc41b9d0743e23a27a94))
+- update dependency globals to v17.5.0 ([#2059](https://github.com/nozomiishii/configs/issues/2059)) ([ab618b7](https://github.com/nozomiishii/configs/commit/ab618b7f4b1a677683a4e77010b8e9b3ff5b4e26))
+- update dependency tailwindcss to v4.2.3 ([#2098](https://github.com/nozomiishii/configs/issues/2098)) ([f9b2f3d](https://github.com/nozomiishii/configs/commit/f9b2f3d830b522cd7784ab839d41fdbad667078e))
+- update dependency tailwindcss to v4.2.4 ([#2104](https://github.com/nozomiishii/configs/issues/2104)) ([fb7952c](https://github.com/nozomiishii/configs/commit/fb7952c7cae39626cc9c961d850e325a0d5e39f9))
+- update dependency typescript to v6.0.3 ([#2088](https://github.com/nozomiishii/configs/issues/2088)) ([25e9e34](https://github.com/nozomiishii/configs/commit/25e9e34004a9069de68430008b4daca34bcac000))
+- update dependency typescript-eslint to v8.58.0 ([#2026](https://github.com/nozomiishii/configs/issues/2026)) ([d933826](https://github.com/nozomiishii/configs/commit/d9338261de05ed76a4a27ac7cc2912fa922074b9))
+- update dependency typescript-eslint to v8.58.1 ([#2049](https://github.com/nozomiishii/configs/issues/2049)) ([993a2c2](https://github.com/nozomiishii/configs/commit/993a2c264bbb40b762151015aa64a6929ad6f8a6))
+- update dependency typescript-eslint to v8.58.2 ([#2078](https://github.com/nozomiishii/configs/issues/2078)) ([12c2375](https://github.com/nozomiishii/configs/commit/12c23753e9013b71d96fe03e4010e057a1d56659))
+- update dependency typescript-eslint to v8.59.0 ([#2097](https://github.com/nozomiishii/configs/issues/2097)) ([50f6d91](https://github.com/nozomiishii/configs/commit/50f6d9102bc543d2dfa7d87d2a602b860f07b93d))
+- update pnpm to v10.33.1 ([#2110](https://github.com/nozomiishii/configs/issues/2110)) ([5af1dc0](https://github.com/nozomiishii/configs/commit/5af1dc0b5d2ce5c49bc1f97a87d04f1e72aadd51))
+- update pnpm to v10.33.2 ([#2114](https://github.com/nozomiishii/configs/issues/2114)) ([de64989](https://github.com/nozomiishii/configs/commit/de64989ce298d538e759f980ab505030be9a3e24))
+
+## [0.6.13](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.6.12...@nozomiishii/eslint-config-v0.6.13) (2026-04-01)
+
+### Bug Fixes
+
+- **eslint-config:** remove completed defineConfig migration task from TODO ([#2017](https://github.com/nozomiishii/configs/issues/2017)) ([dc26fa3](https://github.com/nozomiishii/configs/commit/dc26fa3dee74304e5a68a4c2dd9c85cd2a65450e))
+
+## [0.6.12](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.6.11...@nozomiishii/eslint-config-v0.6.12) (2026-03-17)
+
+### Bug Fixes
+
+- switch from typescript-eslint to eslint/config in import-x configuration ([58f1f02](https://github.com/nozomiishii/configs/commit/58f1f02801f4e5aab331518f6b79f01de05f34bd))
+
+## [0.6.11](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.6.10...@nozomiishii/eslint-config-v0.6.11) (2026-02-11)
+
+### Bug Fixes
+
+- simplify react ESLint configuration by directly using recommended settings ([2a24259](https://github.com/nozomiishii/configs/commit/2a242594c5448c1aa511dafa44b28cc4e5a30b4f))
+- update eslint-plugin-better-tailwindcss to v4.1.1 ([#1826](https://github.com/nozomiishii/configs/issues/1826)) ([75d09a1](https://github.com/nozomiishii/configs/commit/75d09a1bba1bded64446b62b53d3500b834e1427))
+
+## [0.6.10](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.6.9...@nozomiishii/eslint-config-v0.6.10) (2026-01-21)
+
+### Bug Fixes
+
+- perfectionist/sort-imports error on eslint ([#1781](https://github.com/nozomiishii/configs/issues/1781)) ([387631d](https://github.com/nozomiishii/configs/commit/387631d6f1f3946ff9f26f1723ab27dece3775ae))
+
+## [0.6.9](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.6.8...@nozomiishii/eslint-config-v0.6.9) (2026-01-19)
+
+### Bug Fixes
+
+- update @eslint-community/eslint-plugin-eslint-comments to v4.6.0 ([ff9bcca](https://github.com/nozomiishii/configs/commit/ff9bcca540ed4942f21dedec64bbead25de0a43b))
+- update installation commands in README files to use pnpx instead of npx ([d8c68bc](https://github.com/nozomiishii/configs/commit/d8c68bce6370baa876e773e4b64a9b24fdfca36f))
+- update markdownlint and prettier configurations to improve formatting rules ([#1774](https://github.com/nozomiishii/configs/issues/1774)) ([de91846](https://github.com/nozomiishii/configs/commit/de91846585c60a28cba5f7a01e897201ea3d0ca3))
+- update storybook ESLint plugin links to point to the new repository structure ([b04cb40](https://github.com/nozomiishii/configs/commit/b04cb4058d2b7c558fcdd9d691b7f35a546b9f82))
+
+## [0.6.8](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.6.7...@nozomiishii/eslint-config-v0.6.8) (2025-12-11)
+
+### Bug Fixes
+
+- disable require-top-level-describe rule in viest config ([64da997](https://github.com/nozomiishii/configs/commit/64da99757c103d47888f3c59da509de1c628d453))
+- prefer-expect-assertions rule in viest config ([e796a1a](https://github.com/nozomiishii/configs/commit/e796a1aba93353589ddd3dfd337b18a00b2bd00a))
+
+## [0.6.7](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.6.6...@nozomiishii/eslint-config-v0.6.7) (2025-11-10)
+
+### Bug Fixes
+
+- remove reference to react-compiler in TODO.md in eslint-config ([193762c](https://github.com/nozomiishii/configs/commit/193762c0bfa1a0f6931cd113f86502c2db277b41))
+
+## [0.6.6](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.6.5...@nozomiishii/eslint-config-v0.6.6) (2025-11-10)
+
+### Bug Fixes
+
+- pnpm-lock file version in eslint-config ([6ce6c9b](https://github.com/nozomiishii/configs/commit/6ce6c9bf35476b492a13ad93debed7768328bc2f))
+
+## [0.6.5](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.6.4...@nozomiishii/eslint-config-v0.6.5) (2025-11-10)
+
+### Features
+
+- add @stylistic/eslint-plugin and integrate stylistic rules into eslint-config ([f9a7c4b](https://github.com/nozomiishii/configs/commit/f9a7c4be338240abfd08bdfb315d9a34c4165c7f))
+- enable react-refresh rule in ESLint configuration ([c82e546](https://github.com/nozomiishii/configs/commit/c82e546ca1f0b5bdf17295fba7399a88c7fff636))
+
+### Bug Fixes
+
+- disable deprecated 'vitest/no-done-callback' rule ([43c7de1](https://github.com/nozomiishii/configs/commit/43c7de1572f8121f24a9c105f4a3397cde680e4f))
+- eslint build error in nextjs rules ([971bced](https://github.com/nozomiishii/configs/commit/971bced409e11111c94b668f9150d920eb6f8110))
+- import-x rules tseslint.config ([2bda4c5](https://github.com/nozomiishii/configs/commit/2bda4c586a8f3780612b9b4933ab5bceb9e70580))
+- remove unused react-compiler rule from eslint configuration ([f74bf1f](https://github.com/nozomiishii/configs/commit/f74bf1fbadc158778a6daad9078244697e4a6ca0))
+- update dependency eslint-plugin-react-hooks to v7 ([71d83d9](https://github.com/nozomiishii/configs/commit/71d83d995dcb7a526f53b5d722a96d064b461616))
+- update renovate configuration and adjust Node.js engine version ([1eaa26e](https://github.com/nozomiishii/configs/commit/1eaa26ee3ad4e804c91b37411eeab709e9323eb5))
+- use defineConfig instead of tseslint.config in typescript eslint rules ([8a5e316](https://github.com/nozomiishii/configs/commit/8a5e316c6b018f3b8d252a08d819c683fde7a1a6))
+
+## [0.6.4](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.6.3...@nozomiishii/eslint-config-v0.6.4) (2025-09-02)
+
+### Bug Fixes
+
+- remove node engine from package.json files ([b3ad146](https://github.com/nozomiishii/configs/commit/b3ad14646e733a4c7435544e76b8a7238f333388))
+
+## [0.6.3](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.6.2...@nozomiishii/eslint-config-v0.6.3) (2025-08-21)
+
+### Bug Fixes
+
+- devEngines in package.json ([02d57a3](https://github.com/nozomiishii/configs/commit/02d57a31f4d4d403b14ad223661c9531faeda296))
+- remove pnpm.executionEnv.nodeVersion ([9e2941a](https://github.com/nozomiishii/configs/commit/9e2941a0b00a83a5dc00391a533eccd3dd9b7824))
+
+## [0.6.2](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.6.1...@nozomiishii/eslint-config-v0.6.2) (2025-08-12)
+
+### Bug Fixes
+
+- eslint Next.js configuration ([#1342](https://github.com/nozomiishii/configs/issues/1342)) ([ba4a1d7](https://github.com/nozomiishii/configs/commit/ba4a1d764a90ed3933b3dbdef9e09831219b91e7))
+
+## [0.6.1](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.6.0...@nozomiishii/eslint-config-v0.6.1) (2025-07-08)
+
+### Bug Fixes
+
+- turn off better-tailwindcss/enforce-consistent-line-wrapping ([e4894b0](https://github.com/nozomiishii/configs/commit/e4894b09fea3eb7c5eef7c47231996add25acebe))
+
+## [0.6.0](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.5.3...@nozomiishii/eslint-config-v0.6.0) (2025-07-06)
+
+### ⚠ BREAKING CHANGES
+
+- replace eslint-plugin-tailwindcss with eslint-plugin-better-tailwindcss
+
+### Features
+
+- replace eslint-plugin-tailwindcss with eslint-plugin-better-tailwindcss ([916d5ba](https://github.com/nozomiishii/configs/commit/916d5bae22fb7ee1fcd290cc236469303ef28784))
+
+### Bug Fixes
+
+- support pnpm.executionEnv.nodeVersion ([974aabe](https://github.com/nozomiishii/configs/commit/974aabe6961683189e612236e48513cd4acf0cd0))
+
+## [0.5.3](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.5.2...@nozomiishii/eslint-config-v0.5.3) (2025-07-01)
+
+### Bug Fixes
+
+- improve typescript eslint configuration ([465aeae](https://github.com/nozomiishii/configs/commit/465aeae461f81ca44ac79cc731de23c331eff2e7))
+
+## [0.5.2](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.5.1...@nozomiishii/eslint-config-v0.5.2) (2025-07-01)
+
+### Bug Fixes
+
+- eslint-plugin-storybook error ([a3c901f](https://github.com/nozomiishii/configs/commit/a3c901f0458d92b5dfc15ad2945b763e699b8981))
+- update eslint-plugin-vitest ([1a65fd5](https://github.com/nozomiishii/configs/commit/1a65fd56e86678b15cefa39bda66f2d4cbac77a7))
+
+## [0.5.1](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.5.0...@nozomiishii/eslint-config-v0.5.1) (2025-06-02)
+
+### Bug Fixes
+
+- typegen ([f28d097](https://github.com/nozomiishii/configs/commit/f28d097816bca578472efa19dcf4d13d0e999640))
+- update install command for Flat Config support ([cf24046](https://github.com/nozomiishii/configs/commit/cf240463990c674fbabd71c0c9a31bf15225924d))
+
+## [0.5.0](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.4.8...@nozomiishii/eslint-config-v0.5.0) (2025-06-02)
+
+### ⚠ BREAKING CHANGES
+
+- migrete to flat config
+
+### Features
+
+- migrete to flat config ([c5ff410](https://github.com/nozomiishii/configs/commit/c5ff4107999b678374aade48327d45fb509a4d15))
+
+### Bug Fixes
+
+- replace eslint-plugin-eslint-comments to @eslint-community/eslint-plugin-eslint-comments ([46dccbb](https://github.com/nozomiishii/configs/commit/46dccbbc49088118f2d0776b61676aa04b7cd42d))
+- update release workflow condition and add package manager configuration to multiple packages ([958992c](https://github.com/nozomiishii/configs/commit/958992ccd8bdaf906a50bb769ec45459fab81210))
+
+## [0.4.8](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.4.7...@nozomiishii/eslint-config-v0.4.8) (2025-01-02)
+
+### Features
+
+- add playwright/max-expects ([13d269b](https://github.com/nozomiishii/configs/commit/13d269be4a0b2ffa62df22244625fb33dcc87dff))
+- add playwright/max-nested-describe ([f7f91c6](https://github.com/nozomiishii/configs/commit/f7f91c6dc0464da210bc9968c6d602d60e7a6197))
+- increase max-nested-describe limit to 2 in eslint playwright ([d30da99](https://github.com/nozomiishii/configs/commit/d30da996b099d85ffcbf519a39db55631e6b6e20))
+
+### Bug Fixes
+
+- add expiring-todo-comments rule and adjust consistent-function-scoping for test files ([5c5cdfc](https://github.com/nozomiishii/configs/commit/5c5cdfc8a521ced130ec74f81ab5d3bab82f1877))
+- ignore .playwright and .storybook from vitest lint ([fe0adb8](https://github.com/nozomiishii/configs/commit/fe0adb8f207b01650e2023f2f18003c5609de31e))
+- turn off require-top-level-describe ([8ba2d54](https://github.com/nozomiishii/configs/commit/8ba2d54eb3bfc1b5b69ad1c863c89f1ced0cca28))
+- update internal-pattern regex for module resolution ([a746239](https://github.com/nozomiishii/configs/commit/a746239fe3e0c11b58c5c7802bfd095f5ad44f66))
+
+## [0.4.7](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.4.6...@nozomiishii/eslint-config-v0.4.7) (2024-08-04)
+
+### Features
+
+- update eslint-config for playwright rules ([eacbbdc](https://github.com/nozomiishii/configs/commit/eacbbdc888e222f8752b935073bee15030feb7db))
+
+### Bug Fixes
+
+- add description to perfectionist/sort-imports ([092d6db](https://github.com/nozomiishii/configs/commit/092d6db962fbc6e161b9f66fb3ab63b922dc8254))
+- turn off jsdoc/require-jsdoc rules in test files ([432af76](https://github.com/nozomiishii/configs/commit/432af767db8336a32d217d29f9d8586195ff2999))
+
+## [0.4.6](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.4.5...@nozomiishii/eslint-config-v0.4.6) (2024-06-16)
+
+### Features
+
+- add @typescript-eslint/method-signature-style ([63cdd79](https://github.com/nozomiishii/configs/commit/63cdd79b721c415bc69219e13c31a789245bb164))
+- add eslint-plugin-jsx-no-leaked-render rule ([ae1c1a9](https://github.com/nozomiishii/configs/commit/ae1c1a93e72e0bad1ad2c68eb788f23343b981e6))
+
+### Bug Fixes
+
+- update peerDependencies version ([bd65911](https://github.com/nozomiishii/configs/commit/bd65911bcd93b907565f00ac9aace0a60e560a5e))
+- update storybook configuration for @storybook/test usage ([7c1ed0f](https://github.com/nozomiishii/configs/commit/7c1ed0f155c4ee3e618581b1685bf1a3b40d2873))
+
+## [0.4.5](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.4.4...@nozomiishii/eslint-config-v0.4.5) (2024-02-18)
+
+### Features
+
+- add eslint rule for @tanstack/eslint-plugin-query ([b527faf](https://github.com/nozomiishii/configs/commit/b527faf7b640edc268a987f60739cff7bab75cc2))
+- add initial CHANGELOG ([9ce8c62](https://github.com/nozomiishii/configs/commit/9ce8c62626daccb52d6855312820188fbb069a18))
+- add jsdoc rules to eslint ([992efc5](https://github.com/nozomiishii/configs/commit/992efc59a2cf6246fcb68159e044fc7168d446bb))
+- add padding-line-between-statements for switch, throw, and while ([1338f0f](https://github.com/nozomiishii/configs/commit/1338f0f25a763e6d9b37f6a97af6846c5ce564e8))
+- apply eslint-plugin-perfectionist instead of eslint-plugin-sort to sorting rules ([beabc83](https://github.com/nozomiishii/configs/commit/beabc83ead3749270477d036f874f7507459e191))
+- **eslint:** restrict the usage of global variables from @types/jest ([ac7fa84](https://github.com/nozomiishii/configs/commit/ac7fa84623ff0ed7dad21524ef4ab0777e82d767))
+- **prettier:** update prettier version to v3 ([3ca3f49](https://github.com/nozomiishii/configs/commit/3ca3f49e8418f0507084983740bab3596a9f6460))
+- **prettier:** update prettier version to v3 ([26239c9](https://github.com/nozomiishii/configs/commit/26239c9361d60734a5a13f635c4161de80bffbaa))
+
+### Bug Fixes
+
+- add line break rule for "for" statement ([44d705f](https://github.com/nozomiishii/configs/commit/44d705f736646b59ce2ea0445e39b29a9582800d))
+- add line break rules ([d6aaab5](https://github.com/nozomiishii/configs/commit/d6aaab5256481eb6e2928375ba672c187f678bea))
+- add testing library rules for react hooks ([8cb8203](https://github.com/nozomiishii/configs/commit/8cb8203e9cbc0a2eb1f2cf6b5e124acba82e578e))
+- **deps:** update dependency @next/eslint-plugin-next to v13.4.10 ([#116](https://github.com/nozomiishii/configs/issues/116)) ([9b0a9a1](https://github.com/nozomiishii/configs/commit/9b0a9a1b011836e9ea649d0e558a14f495d0e5a6))
+- **deps:** update dependency @next/eslint-plugin-next to v13.4.11 ([#126](https://github.com/nozomiishii/configs/issues/126)) ([d600ded](https://github.com/nozomiishii/configs/commit/d600ded73ede27d1a992a1930e3b4d6f41d65da3))
+- **deps:** update dependency @next/eslint-plugin-next to v13.4.12 ([#127](https://github.com/nozomiishii/configs/issues/127)) ([18e3e12](https://github.com/nozomiishii/configs/commit/18e3e125c16d0402114917cdd155f6e84053208a))
+- **deps:** update dependency @next/eslint-plugin-next to v13.4.9 ([#104](https://github.com/nozomiishii/configs/issues/104)) ([94037f0](https://github.com/nozomiishii/configs/commit/94037f0c5ceb329ec5b5873b873ea69f634d6f5e))
+- **deps:** update dependency eslint to v8.44.0 ([#96](https://github.com/nozomiishii/configs/issues/96)) ([93351d8](https://github.com/nozomiishii/configs/commit/93351d82827143e0cf0a1aa50e9591c9c1b07b16))
+- **deps:** update dependency eslint to v8.45.0 ([#117](https://github.com/nozomiishii/configs/issues/117)) ([a54f123](https://github.com/nozomiishii/configs/commit/a54f1237d89988b5897b8cbce94464a5bed52111))
+- **deps:** update dependency eslint to v8.46.0 ([#138](https://github.com/nozomiishii/configs/issues/138)) ([6c7562c](https://github.com/nozomiishii/configs/commit/6c7562ca0d73fa09e1c78e822d8e96f613e8e667))
+- **deps:** update dependency eslint-config-airbnb-typescript to v17.1.0 ([#114](https://github.com/nozomiishii/configs/issues/114)) ([584268b](https://github.com/nozomiishii/configs/commit/584268bc3b04d6bd605ed68fd920b48d97dd8da9))
+- **deps:** update dependency eslint-config-prettier to v8.9.0 ([#136](https://github.com/nozomiishii/configs/issues/136)) ([4b734bf](https://github.com/nozomiishii/configs/commit/4b734bf1ebc8d43baa0173348d27c2b07eddc850))
+- **deps:** update dependency eslint-define-config to v1.22.0 ([#140](https://github.com/nozomiishii/configs/issues/140)) ([d1bf499](https://github.com/nozomiishii/configs/commit/d1bf499c42439500750b644b969ffd48e8d45ffb))
+- **deps:** update dependency eslint-plugin-import to v2.28.0 ([#137](https://github.com/nozomiishii/configs/issues/137)) ([7aa46be](https://github.com/nozomiishii/configs/commit/7aa46be7e20fd331adedcb1294f4e00eaa7f64ec))
+- **deps:** update dependency eslint-plugin-playwright to v0.15.3 ([#100](https://github.com/nozomiishii/configs/issues/100)) ([65cb772](https://github.com/nozomiishii/configs/commit/65cb772617b906bd8572b029a76b6181705f9032))
+- **deps:** update dependency eslint-plugin-react to v7.33.0 ([#125](https://github.com/nozomiishii/configs/issues/125)) ([2a005cf](https://github.com/nozomiishii/configs/commit/2a005cfee8d35aefdbd33634a7fbe75127a3fb70))
+- **deps:** update dependency eslint-plugin-react to v7.33.1 ([#139](https://github.com/nozomiishii/configs/issues/139)) ([9659aed](https://github.com/nozomiishii/configs/commit/9659aed88fadb4e8934d67697c99eca3aee0ac35))
+- **deps:** update dependency eslint-plugin-storybook to v0.6.13 ([#124](https://github.com/nozomiishii/configs/issues/124)) ([7e9d311](https://github.com/nozomiishii/configs/commit/7e9d31199d08bf7df1d12c206134c61b42c1112b))
+- **deps:** update dependency eslint-plugin-unicorn to v48 ([#118](https://github.com/nozomiishii/configs/issues/118)) ([44db7de](https://github.com/nozomiishii/configs/commit/44db7de74d87fcf1811ed8a69b73d7f04c1f0261))
+- **deps:** update dependency eslint-plugin-unicorn to v48.0.1 ([#134](https://github.com/nozomiishii/configs/issues/134)) ([1613680](https://github.com/nozomiishii/configs/commit/161368030e06bb483e40bcf2316e24748368ccb3))
+- **deps:** update dependency eslint-plugin-vitest to v0.2.8 ([#135](https://github.com/nozomiishii/configs/issues/135)) ([68ff75c](https://github.com/nozomiishii/configs/commit/68ff75cc19403f4160f2a69b70e1664a09fa55b5))
+- **deps:** update eslint ([#98](https://github.com/nozomiishii/configs/issues/98)) ([865aee5](https://github.com/nozomiishii/configs/commit/865aee5cf7b0636f00a01aba621cbf5a09febefa))
+- **deps:** update eslint to v5.62.0 ([#109](https://github.com/nozomiishii/configs/issues/109)) ([25a6bfc](https://github.com/nozomiishii/configs/commit/25a6bfc52c97180b5af77bec61473910def8def7))
+- **deps:** update eslint to v6.2.0 ([#132](https://github.com/nozomiishii/configs/issues/132)) ([4199bde](https://github.com/nozomiishii/configs/commit/4199bde472aba2ed3fcb6a4f130cbffe4c519788))
+- **deps:** update eslint to v6.2.1 ([#143](https://github.com/nozomiishii/configs/issues/143)) ([2c4606f](https://github.com/nozomiishii/configs/commit/2c4606f0dd9b0db2617f8cfc3862c53ea9254b93))
+- downgrade eslint-plugin-tailwindcss to 3.13.1 ([87e3599](https://github.com/nozomiishii/configs/commit/87e3599c55fefde76bfff9ed9f2f6e07929c4289))
+- import/no-extraneous-dependencies in storybook ([4377b92](https://github.com/nozomiishii/configs/commit/4377b92167d97a96071018aab9a54c60193c9b7f))
+- remove testing-library from eslint default config ([7ed25fa](https://github.com/nozomiishii/configs/commit/7ed25fa5b12234e1d7464086f69653523a1bfff0))
+- remove unused eslint plugins and update README.md ([bb1161f](https://github.com/nozomiishii/configs/commit/bb1161f1611946e17f1ce2f0813621cc6f581ce6))
+- set "unicorn/no-null: off" in eslint unicorn ([745398b](https://github.com/nozomiishii/configs/commit/745398bff74182f3671852c68fdfe4e8421aece9))
+- support @storybook/test ([445d307](https://github.com/nozomiishii/configs/commit/445d3078497d64e836810b912f5e7bd2741e5806))
+- typo in playwright eslint rule description ([55eb4f1](https://github.com/nozomiishii/configs/commit/55eb4f1a4c552b8ee1ac76c36e1545fe740da273))
+- vitest/prefer-expect-assertions setup ([0f71382](https://github.com/nozomiishii/configs/commit/0f71382cd8db963240ccf86197a942be0a85899a))
+
+## [0.4.4](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.4.3...@nozomiishii/eslint-config-v0.4.4) (2024-02-18)
+
+### Bug Fixes
+
+- downgrade eslint-plugin-tailwindcss to 3.13.1 ([87e3599](https://github.com/nozomiishii/configs/commit/87e3599c55fefde76bfff9ed9f2f6e07929c4289))
+
+## [0.4.3](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.4.2...@nozomiishii/eslint-config-v0.4.3) (2024-02-18)
+
+### Features
+
+- add eslint rule for @tanstack/eslint-plugin-query ([b527faf](https://github.com/nozomiishii/configs/commit/b527faf7b640edc268a987f60739cff7bab75cc2))
+- add jsdoc rules to eslint ([992efc5](https://github.com/nozomiishii/configs/commit/992efc59a2cf6246fcb68159e044fc7168d446bb))
+- add padding-line-between-statements for switch, throw, and while ([1338f0f](https://github.com/nozomiishii/configs/commit/1338f0f25a763e6d9b37f6a97af6846c5ce564e8))
+- apply eslint-plugin-perfectionist instead of eslint-plugin-sort to sorting rules ([beabc83](https://github.com/nozomiishii/configs/commit/beabc83ead3749270477d036f874f7507459e191))
+
+### Bug Fixes
+
+- add line break rule for "for" statement ([44d705f](https://github.com/nozomiishii/configs/commit/44d705f736646b59ce2ea0445e39b29a9582800d))
+- add line break rules ([d6aaab5](https://github.com/nozomiishii/configs/commit/d6aaab5256481eb6e2928375ba672c187f678bea))
+- add testing library rules for react hooks ([8cb8203](https://github.com/nozomiishii/configs/commit/8cb8203e9cbc0a2eb1f2cf6b5e124acba82e578e))
+- remove testing-library from eslint default config ([7ed25fa](https://github.com/nozomiishii/configs/commit/7ed25fa5b12234e1d7464086f69653523a1bfff0))
+- remove unused eslint plugins and update README.md ([bb1161f](https://github.com/nozomiishii/configs/commit/bb1161f1611946e17f1ce2f0813621cc6f581ce6))
+- vitest/prefer-expect-assertions setup ([0f71382](https://github.com/nozomiishii/configs/commit/0f71382cd8db963240ccf86197a942be0a85899a))
+
+## [0.4.2](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.4.1...@nozomiishii/eslint-config-v0.4.2) (2023-12-05)
+
+### Bug Fixes
+
+- import/no-extraneous-dependencies in storybook ([4377b92](https://github.com/nozomiishii/configs/commit/4377b92167d97a96071018aab9a54c60193c9b7f))
+
+## [0.4.1](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.4.0...@nozomiishii/eslint-config-v0.4.1) (2023-12-05)
+
+### Bug Fixes
+
+- set "unicorn/no-null: off" in eslint unicorn ([745398b](https://github.com/nozomiishii/configs/commit/745398bff74182f3671852c68fdfe4e8421aece9))
+- support @storybook/test ([445d307](https://github.com/nozomiishii/configs/commit/445d3078497d64e836810b912f5e7bd2741e5806))
+- typo in playwright eslint rule description ([55eb4f1](https://github.com/nozomiishii/configs/commit/55eb4f1a4c552b8ee1ac76c36e1545fe740da273))
+
+## [0.4.0](https://github.com/nozomiishii/configs/compare/@nozomiishii/eslint-config-v0.3.0...@nozomiishii/eslint-config-v0.4.0) (2023-08-06)
+
+### Features
+
+- add initial CHANGELOG ([9ce8c62](https://github.com/nozomiishii/configs/commit/9ce8c62626daccb52d6855312820188fbb069a18))

--- a/packages/lefthook-config/CHANGELOG.md
+++ b/packages/lefthook-config/CHANGELOG.md
@@ -1,0 +1,184 @@
+# Changelog
+
+## [0.7.1](https://github.com/nozomiishii/configs/compare/@nozomiishii/lefthook-config-v0.7.0...@nozomiishii/lefthook-config-v0.7.1) (2026-05-08)
+
+### Miscellaneous
+
+- update pnpm to v10.33.3 ([#2199](https://github.com/nozomiishii/configs/issues/2199)) ([6d610b4](https://github.com/nozomiishii/configs/commit/6d610b4ae99a16216c70737e5398d1670725e110))
+- update pnpm to v11 ([#2193](https://github.com/nozomiishii/configs/issues/2193)) ([e7c39d1](https://github.com/nozomiishii/configs/commit/e7c39d1183234ec9ebf2d8599535279b970222e9))
+
+## [0.7.0](https://github.com/nozomiishii/configs/compare/@nozomiishii/lefthook-config-v0.6.0...@nozomiishii/lefthook-config-v0.7.0) (2026-05-07)
+
+### ⚠ BREAKING CHANGES
+
+- **lefthook-config:** add nozo-lefthook-init bin and remove starter subpath ([#2160](https://github.com/nozomiishii/configs/issues/2160))
+
+### Features
+
+- **lefthook-config:** add nozo-lefthook-init bin and remove starter subpath ([#2160](https://github.com/nozomiishii/configs/issues/2160)) ([062414d](https://github.com/nozomiishii/configs/commit/062414dfb8bce77178498fed9185c6f9dc006282))
+
+## [0.6.0](https://github.com/nozomiishii/configs/compare/@nozomiishii/lefthook-config-v0.5.0...@nozomiishii/lefthook-config-v0.6.0) (2026-05-02)
+
+### ⚠ BREAKING CHANGES
+
+- **lefthook-config:** Consumers must replace node_modules/@nozomiishii/lefthook-config/index.yaml with node_modules/@nozomiishii/lefthook-config/recommended.yaml in their lefthook.yaml extends list.
+
+### Features
+
+- **lefthook-config:** expose starter.yaml for manual setup and tooling ([#2156](https://github.com/nozomiishii/configs/issues/2156)) ([a20db41](https://github.com/nozomiishii/configs/commit/a20db419988977e507f6a738f58cad0d7fed1b1f))
+- **lefthook-config:** rename index.yaml to recommended.yaml ([#2155](https://github.com/nozomiishii/configs/issues/2155)) ([dee24d0](https://github.com/nozomiishii/configs/commit/dee24d08c1d4f85a48d30c8b7cfa0af593094ed8))
+
+## [0.5.0](https://github.com/nozomiishii/configs/compare/@nozomiishii/lefthook-config-v0.4.1...@nozomiishii/lefthook-config-v0.5.0) (2026-05-01)
+
+### ⚠ BREAKING CHANGES
+
+- **lefthook-config:** pre-commit fragments for prettier, markdown, storybook and the .spec-test guard are removed. Consumers cherry- picking those paths must point at their own project hooks. The yaml extension fragment moved from hooks/pre-commit/lint/file-extension/yaml.yaml to hooks/pre-commit/yaml.yaml and is now included by default when extending index.yaml.
+- **prettier-config:** The printWidth default is changed from 119 to 100. Lines in the 100-119 range will be re-formatted in consumer codebases on the next format run.
+- **prettier-config:** The singleQuote default is changed from true to false. Consumer repositories will see string literals re-formatted from single to double quotes.
+
+### Features
+
+- **lefthook-config:** tighten preset and drop redundant pre-commit fragments ([#2149](https://github.com/nozomiishii/configs/issues/2149)) ([7557145](https://github.com/nozomiishii/configs/commit/755714524f4f0d03407bd4a538225819d1ab302d)), closes [#2118](https://github.com/nozomiishii/configs/issues/2118)
+- **prettier-config:** change printWidth default from 119 to 100 ([#2141](https://github.com/nozomiishii/configs/issues/2141)) ([949e037](https://github.com/nozomiishii/configs/commit/949e037f45d4ccfd8647fceeea4338bd5b6f697e))
+- **prettier-config:** revert singleQuote to Prettier default ([#2140](https://github.com/nozomiishii/configs/issues/2140)) ([c2f2ff5](https://github.com/nozomiishii/configs/commit/c2f2ff5ef8f68d53e7caf67206e95b8c16a10037))
+
+### Bug Fixes
+
+- add Japanese READMEs for shared config packages ([#2151](https://github.com/nozomiishii/configs/issues/2151)) ([b5e96f1](https://github.com/nozomiishii/configs/commit/b5e96f1cb4ad35725b44cf9b19cd01b02d798fa9))
+
+### Miscellaneous
+
+- drop cspell from repo root and lefthook ([#2127](https://github.com/nozomiishii/configs/issues/2127)) ([bd17bca](https://github.com/nozomiishii/configs/commit/bd17bcab853fd4691c64e0d7a45bb38e51642229)), closes [#2118](https://github.com/nozomiishii/configs/issues/2118)
+- **lefthook-config:** rename "C pattern" to "preset + fragments" ([#2150](https://github.com/nozomiishii/configs/issues/2150)) ([0889b7a](https://github.com/nozomiishii/configs/commit/0889b7a2da715ea2ce559bce00a0460f17345ec0))
+- update dependency git-harvest to v0.1.23 ([#2135](https://github.com/nozomiishii/configs/issues/2135)) ([5210d59](https://github.com/nozomiishii/configs/commit/5210d590ed0b5b704b20e34ff72c39a1dd2d6739))
+
+## [0.4.1](https://github.com/nozomiishii/configs/compare/@nozomiishii/lefthook-config-v0.4.0...@nozomiishii/lefthook-config-v0.4.1) (2026-04-29)
+
+### Features
+
+- **lefthook-config:** ship nozo-git-harvest shim ([#2124](https://github.com/nozomiishii/configs/issues/2124)) ([256ae89](https://github.com/nozomiishii/configs/commit/256ae8918527fd7c86ca118be332a808b75f5095)), closes [#2118](https://github.com/nozomiishii/configs/issues/2118)
+
+## [0.4.0](https://github.com/nozomiishii/configs/compare/@nozomiishii/lefthook-config-v0.3.7...@nozomiishii/lefthook-config-v0.4.0) (2026-04-28)
+
+### ⚠ BREAKING CHANGES
+
+- bin field changes from a single setup script ("bin": "bin/cli.sh") to a namespaced map ({ "nozo-commitlint": "bin/cli.mjs" }). Consumers who previously ran pnpx @nozomiishii/commitlint-config@latest to scaffold a commitlint config now need a different mechanism (planned for nozo init in a follow-up PR).
+
+### Features
+
+- modularize lefthook config + commitlint shim + nozo CLI rebuild ([#2119](https://github.com/nozomiishii/configs/issues/2119)) ([1140b62](https://github.com/nozomiishii/configs/commit/1140b62e3d0430f2383a5f683ea2583fa4ea7ee9)), closes [#2118](https://github.com/nozomiishii/configs/issues/2118)
+
+## [0.3.7](https://github.com/nozomiishii/configs/compare/@nozomiishii/lefthook-config-v0.3.6...@nozomiishii/lefthook-config-v0.3.7) (2026-04-27)
+
+### Miscellaneous
+
+- **lefthook-config:** remove pre-push format-check job ([#2117](https://github.com/nozomiishii/configs/issues/2117)) ([3febb99](https://github.com/nozomiishii/configs/commit/3febb99a767923e071e592cc67a7a3af0e32fc9c))
+- release main ([#2031](https://github.com/nozomiishii/configs/issues/2031)) ([ba1c8b0](https://github.com/nozomiishii/configs/commit/ba1c8b0d0373eb1cc65bc89702ba1a41f5923e6b))
+- update dependency lefthook to v2.1.5 ([#2045](https://github.com/nozomiishii/configs/issues/2045)) ([36a86c7](https://github.com/nozomiishii/configs/commit/36a86c71ac524c87d5a223f1af2b13cd4a5b7d0f))
+- update dependency lefthook to v2.1.6 ([#2083](https://github.com/nozomiishii/configs/issues/2083)) ([c98897a](https://github.com/nozomiishii/configs/commit/c98897aa4437c0e97e4c2bbeb75efb09b86e85c1))
+- update pnpm to v10.33.1 ([#2110](https://github.com/nozomiishii/configs/issues/2110)) ([5af1dc0](https://github.com/nozomiishii/configs/commit/5af1dc0b5d2ce5c49bc1f97a87d04f1e72aadd51))
+- update pnpm to v10.33.2 ([#2114](https://github.com/nozomiishii/configs/issues/2114)) ([de64989](https://github.com/nozomiishii/configs/commit/de64989ce298d538e759f980ab505030be9a3e24))
+
+## [0.3.6](https://github.com/nozomiishii/configs/compare/@nozomiishii/lefthook-config-v0.3.5...@nozomiishii/lefthook-config-v0.3.6) (2026-04-01)
+
+### Bug Fixes
+
+- add pre-push format check and scope format CI to all PRs ([#2015](https://github.com/nozomiishii/configs/issues/2015)) ([9553977](https://github.com/nozomiishii/configs/commit/955397758214088e7808d81fab5056f132ca3337))
+- **lefthook-config:** add --frozen-lockfile to post-merge pnpm install ([#1999](https://github.com/nozomiishii/configs/issues/1999)) ([ab9fc5e](https://github.com/nozomiishii/configs/commit/ab9fc5efc025e4bc6103a7e53308b4dad789fec1))
+
+## [0.3.5](https://github.com/nozomiishii/configs/compare/@nozomiishii/lefthook-config-v0.3.4...@nozomiishii/lefthook-config-v0.3.5) (2026-03-26)
+
+### Bug Fixes
+
+- **lefthook-config:** resolve exit status 1 and improve squash merge detection ([#1987](https://github.com/nozomiishii/configs/issues/1987)) ([6ff2334](https://github.com/nozomiishii/configs/commit/6ff23340356e73d99beb4dbed84116ff86e46368))
+
+## [0.3.4](https://github.com/nozomiishii/configs/compare/@nozomiishii/lefthook-config-v0.3.3...@nozomiishii/lefthook-config-v0.3.4) (2026-03-26)
+
+### Bug Fixes
+
+- **lefthook-config:** resolve exit status 1 in cleanup-merged script ([#1983](https://github.com/nozomiishii/configs/issues/1983)) ([08caae1](https://github.com/nozomiishii/configs/commit/08caae155b6b8dd29ce33b9b009d06f1a458334c))
+
+## [0.3.3](https://github.com/nozomiishii/configs/compare/@nozomiishii/lefthook-config-v0.3.2...@nozomiishii/lefthook-config-v0.3.3) (2026-03-26)
+
+### Bug Fixes
+
+- **lefthook-config:** detect squash-merged branches in cleanup-merged script ([#1980](https://github.com/nozomiishii/configs/issues/1980)) ([308ddf8](https://github.com/nozomiishii/configs/commit/308ddf83aee855d4c247d929e2798cef9d4787e6))
+
+## [0.3.2](https://github.com/nozomiishii/configs/compare/@nozomiishii/lefthook-config-v0.3.1...@nozomiishii/lefthook-config-v0.3.2) (2026-03-25)
+
+### Features
+
+- **lefthook-config:** extract cleanup-merged into external shell script ([#1978](https://github.com/nozomiishii/configs/issues/1978)) ([2707166](https://github.com/nozomiishii/configs/commit/2707166fc38f41a64522e2a592403065febdb022))
+
+## [0.3.1](https://github.com/nozomiishii/configs/compare/@nozomiishii/lefthook-config-v0.3.0...@nozomiishii/lefthook-config-v0.3.1) (2026-01-19)
+
+### Bug Fixes
+
+- update installation commands in README files to use pnpx instead of npx ([d8c68bc](https://github.com/nozomiishii/configs/commit/d8c68bce6370baa876e773e4b64a9b24fdfca36f))
+
+## [0.3.0](https://github.com/nozomiishii/configs/compare/@nozomiishii/lefthook-config-v0.2.8...@nozomiishii/lefthook-config-v0.3.0) (2025-12-10)
+
+### ⚠ BREAKING CHANGES
+
+- replace @evilmartians/lefthook with lefthook
+
+### Features
+
+- replace @evilmartians/lefthook with lefthook ([ecd44c9](https://github.com/nozomiishii/configs/commit/ecd44c98cefed5bd5b6d109145bded1389bc33d5))
+
+## [0.2.8](https://github.com/nozomiishii/configs/compare/@nozomiishii/lefthook-config-v0.2.7...@nozomiishii/lefthook-config-v0.2.8) (2025-09-02)
+
+### Bug Fixes
+
+- remove node engine from package.json files ([b3ad146](https://github.com/nozomiishii/configs/commit/b3ad14646e733a4c7435544e76b8a7238f333388))
+
+## [0.2.7](https://github.com/nozomiishii/configs/compare/@nozomiishii/lefthook-config-v0.2.6...@nozomiishii/lefthook-config-v0.2.7) (2025-08-21)
+
+### Bug Fixes
+
+- devEngines in package.json ([02d57a3](https://github.com/nozomiishii/configs/commit/02d57a31f4d4d403b14ad223661c9531faeda296))
+- remove pnpm.executionEnv.nodeVersion ([9e2941a](https://github.com/nozomiishii/configs/commit/9e2941a0b00a83a5dc00391a533eccd3dd9b7824))
+
+## [0.2.6](https://github.com/nozomiishii/configs/compare/@nozomiishii/lefthook-config-v0.2.5...@nozomiishii/lefthook-config-v0.2.6) (2025-07-22)
+
+### Bug Fixes
+
+- fail to release ([df126af](https://github.com/nozomiishii/configs/commit/df126af8c9653c75fe4dc34136d166ead03ed742))
+
+## [0.2.5](https://github.com/nozomiishii/configs/compare/@nozomiishii/lefthook-config-v0.2.4...@nozomiishii/lefthook-config-v0.2.5) (2025-07-12)
+
+### Features
+
+- replace npx with pnpx for commitlint command ([ddcb0a7](https://github.com/nozomiishii/configs/commit/ddcb0a7236161ac66bf7392b49bdb13909135c69))
+
+## [0.2.4](https://github.com/nozomiishii/configs/compare/@nozomiishii/lefthook-config-v0.2.3...@nozomiishii/lefthook-config-v0.2.4) (2025-06-02)
+
+### Features
+
+- add pre-commit script to check for 'link:' in package.json ([45b30f4](https://github.com/nozomiishii/configs/commit/45b30f45747c3cc7f77762972f0ba6b18c67a574))
+
+## [0.2.3](https://github.com/nozomiishii/configs/compare/@nozomiishii/lefthook-config-v0.2.2...@nozomiishii/lefthook-config-v0.2.3) (2025-05-04)
+
+### Bug Fixes
+
+- streamline pnpm install command in post-merge hook ([df5b75c](https://github.com/nozomiishii/configs/commit/df5b75cb3ecebbac7e632160d69f38c5e8fb53a1))
+- update release workflow condition and add package manager configuration to multiple packages ([958992c](https://github.com/nozomiishii/configs/commit/958992ccd8bdaf906a50bb769ec45459fab81210))
+
+## [0.2.2](https://github.com/nozomiishii/configs/compare/@nozomiishii/lefthook-config-v0.2.1...@nozomiishii/lefthook-config-v0.2.2) (2024-06-16)
+
+### Features
+
+- add LEFTHOOK_VERBOSE true to update-node-modules ([8e05b51](https://github.com/nozomiishii/configs/commit/8e05b5192afacccf4ebc75ce979bde3355a77d97))
+
+## [0.2.1](https://github.com/nozomiishii/configs/compare/@nozomiishii/lefthook-config-v0.2.0...@nozomiishii/lefthook-config-v0.2.1) (2024-02-18)
+
+### Features
+
+- create @nozomiishii/commitlint-config ([1751de2](https://github.com/nozomiishii/configs/commit/1751de2e367b935821d8645a535eeda562c5e1bc))
+- create @nozomiishii/commitlint-config ([#451](https://github.com/nozomiishii/configs/issues/451)) ([5ae75ef](https://github.com/nozomiishii/configs/commit/5ae75ef942eb7b486b890cb027515ee4e2b8fe14))
+
+## [0.2.0](https://github.com/nozomiishii/configs/compare/@nozomiishii/lefthook-config-v0.1.0...@nozomiishii/lefthook-config-v0.2.0) (2023-08-06)
+
+### Features
+
+- add initial CHANGELOG ([9ce8c62](https://github.com/nozomiishii/configs/commit/9ce8c62626daccb52d6855312820188fbb069a18))

--- a/packages/markdownlint-cli2-config/CHANGELOG.md
+++ b/packages/markdownlint-cli2-config/CHANGELOG.md
@@ -1,0 +1,93 @@
+# Changelog
+
+## [0.4.1](https://github.com/nozomiishii/configs/compare/@nozomiishii/markdownlint-cli2-config-v0.4.0...@nozomiishii/markdownlint-cli2-config-v0.4.1) (2026-05-08)
+
+### Miscellaneous
+
+- update pnpm to v10.33.3 ([#2199](https://github.com/nozomiishii/configs/issues/2199)) ([6d610b4](https://github.com/nozomiishii/configs/commit/6d610b4ae99a16216c70737e5398d1670725e110))
+- update pnpm to v11 ([#2193](https://github.com/nozomiishii/configs/issues/2193)) ([e7c39d1](https://github.com/nozomiishii/configs/commit/e7c39d1183234ec9ebf2d8599535279b970222e9))
+
+## [0.4.0](https://github.com/nozomiishii/configs/compare/@nozomiishii/markdownlint-cli2-config-v0.3.6...@nozomiishii/markdownlint-cli2-config-v0.4.0) (2026-05-01)
+
+### ⚠ BREAKING CHANGES
+
+- **prettier-config:** The singleQuote default is changed from true to false. Consumer repositories will see string literals re-formatted from single to double quotes.
+
+### Features
+
+- **prettier-config:** revert singleQuote to Prettier default ([#2140](https://github.com/nozomiishii/configs/issues/2140)) ([c2f2ff5](https://github.com/nozomiishii/configs/commit/c2f2ff5ef8f68d53e7caf67206e95b8c16a10037))
+
+### Bug Fixes
+
+- add Japanese READMEs for shared config packages ([#2151](https://github.com/nozomiishii/configs/issues/2151)) ([b5e96f1](https://github.com/nozomiishii/configs/commit/b5e96f1cb4ad35725b44cf9b19cd01b02d798fa9))
+
+## [0.3.6](https://github.com/nozomiishii/configs/compare/@nozomiishii/markdownlint-cli2-config-v0.3.5...@nozomiishii/markdownlint-cli2-config-v0.3.6) (2026-04-27)
+
+### Bug Fixes
+
+- align tsdown to 0.21.8 in cspell-config and markdownlint-cli2-config ([#2076](https://github.com/nozomiishii/configs/issues/2076)) ([33b0a2e](https://github.com/nozomiishii/configs/commit/33b0a2e3e720fb4f07ec86fd94d34a5eb1579af9))
+
+### Miscellaneous
+
+- add provenance to publishConfig for all packages ([#1973](https://github.com/nozomiishii/configs/issues/1973)) ([165ef9b](https://github.com/nozomiishii/configs/commit/165ef9b1232b74a1e62222cf0683c2be413e8252))
+- **markdownlint-cli2-config:** migrate to TypeScript source with tsdown build ([#2066](https://github.com/nozomiishii/configs/issues/2066)) ([7cf2abd](https://github.com/nozomiishii/configs/commit/7cf2abd4c7c9e42b271b728a9b660a41092b17c9))
+- release main ([#2031](https://github.com/nozomiishii/configs/issues/2031)) ([ba1c8b0](https://github.com/nozomiishii/configs/commit/ba1c8b0d0373eb1cc65bc89702ba1a41f5923e6b))
+- update dependency markdownlint-cli2 to v0.21.0 ([#1868](https://github.com/nozomiishii/configs/issues/1868)) ([043c83f](https://github.com/nozomiishii/configs/commit/043c83f83b5c8b754b9c6d4c67231b40eec15147))
+- update dependency markdownlint-cli2 to v0.22.0 ([#1977](https://github.com/nozomiishii/configs/issues/1977)) ([b5929e4](https://github.com/nozomiishii/configs/commit/b5929e42c1c22b1dffe6a122ec179ad5ad645260))
+- update dependency markdownlint-cli2 to v0.22.1 ([#2107](https://github.com/nozomiishii/configs/issues/2107)) ([3c6cb83](https://github.com/nozomiishii/configs/commit/3c6cb836e120575a7c9dc7ab75281c47d0105168))
+- update dependency tsdown to v0.21.10 ([#2112](https://github.com/nozomiishii/configs/issues/2112)) ([21939bb](https://github.com/nozomiishii/configs/commit/21939bb55da1202f1e84eaed0f10a07c65c23e41))
+- update dependency tsdown to v0.21.9 ([#2085](https://github.com/nozomiishii/configs/issues/2085)) ([eaeb311](https://github.com/nozomiishii/configs/commit/eaeb311df48848207f0a3ae5aa051eece4bfa278))
+- update dependency typescript to v6.0.3 ([#2088](https://github.com/nozomiishii/configs/issues/2088)) ([25e9e34](https://github.com/nozomiishii/configs/commit/25e9e34004a9069de68430008b4daca34bcac000))
+- update pnpm to v10.28.1 ([#1783](https://github.com/nozomiishii/configs/issues/1783)) ([8ab851f](https://github.com/nozomiishii/configs/commit/8ab851f5b517d1a6aaf5f1a551712a9d08291fc8))
+- update pnpm to v10.28.2 [security] ([#1803](https://github.com/nozomiishii/configs/issues/1803)) ([3bf99c7](https://github.com/nozomiishii/configs/commit/3bf99c70bf15d71c797480c5fc213c83b42cd9a3))
+- update pnpm to v10.29.1 ([#1847](https://github.com/nozomiishii/configs/issues/1847)) ([331b504](https://github.com/nozomiishii/configs/commit/331b5045e0f62b613394d1a8bdd0da18c711399f))
+- update pnpm to v10.29.2 ([#1849](https://github.com/nozomiishii/configs/issues/1849)) ([180c37e](https://github.com/nozomiishii/configs/commit/180c37e71c139f6dabe0dc62a7e227095c263fb6))
+- update pnpm to v10.29.3 ([#1859](https://github.com/nozomiishii/configs/issues/1859)) ([a32b59f](https://github.com/nozomiishii/configs/commit/a32b59f56b170dd7f0dbf16718ed4806261e3910))
+- update pnpm to v10.30.0 ([#1872](https://github.com/nozomiishii/configs/issues/1872)) ([a03fd07](https://github.com/nozomiishii/configs/commit/a03fd07e69295164b6fa576b06e724848c3c0559))
+- update pnpm to v10.30.1 ([#1883](https://github.com/nozomiishii/configs/issues/1883)) ([233091d](https://github.com/nozomiishii/configs/commit/233091d278ab9b0271db6577aba1f13f29030fa6))
+- update pnpm to v10.30.2 ([#1901](https://github.com/nozomiishii/configs/issues/1901)) ([9b75ad0](https://github.com/nozomiishii/configs/commit/9b75ad06e6ea552d983313bf44fbac83c6ccca11))
+- update pnpm to v10.30.3 ([#1911](https://github.com/nozomiishii/configs/issues/1911)) ([bf0767e](https://github.com/nozomiishii/configs/commit/bf0767e66848eb142b058d11a5c8f2630e8809c8))
+- update pnpm to v10.31.0 ([#1936](https://github.com/nozomiishii/configs/issues/1936)) ([a70a929](https://github.com/nozomiishii/configs/commit/a70a929d39a07c6ad9df8a9ad70d1bf49f198310))
+- update pnpm to v10.32.0 ([#1943](https://github.com/nozomiishii/configs/issues/1943)) ([b2c305a](https://github.com/nozomiishii/configs/commit/b2c305a55fa6b3c48eb5bbb5011a22ed52cde7e0))
+- update pnpm to v10.32.1 ([#1945](https://github.com/nozomiishii/configs/issues/1945)) ([e263599](https://github.com/nozomiishii/configs/commit/e2635991025302bcc85dd1c61016365c392dfd79))
+- update pnpm to v10.33.0 ([#1995](https://github.com/nozomiishii/configs/issues/1995)) ([276cdda](https://github.com/nozomiishii/configs/commit/276cdda99f94f64e79eb87192e1e6d1b175c46b6))
+- update pnpm to v10.33.1 ([#2110](https://github.com/nozomiishii/configs/issues/2110)) ([5af1dc0](https://github.com/nozomiishii/configs/commit/5af1dc0b5d2ce5c49bc1f97a87d04f1e72aadd51))
+- update pnpm to v10.33.2 ([#2114](https://github.com/nozomiishii/configs/issues/2114)) ([de64989](https://github.com/nozomiishii/configs/commit/de64989ce298d538e759f980ab505030be9a3e24))
+
+## [0.3.5](https://github.com/nozomiishii/configs/compare/@nozomiishii/markdownlint-cli2-config-v0.3.4...@nozomiishii/markdownlint-cli2-config-v0.3.5) (2026-01-19)
+
+### Bug Fixes
+
+- update installation commands in README files to use pnpx instead of npx ([d8c68bc](https://github.com/nozomiishii/configs/commit/d8c68bce6370baa876e773e4b64a9b24fdfca36f))
+- update markdownlint and prettier configurations to improve formatting rules ([#1774](https://github.com/nozomiishii/configs/issues/1774)) ([de91846](https://github.com/nozomiishii/configs/commit/de91846585c60a28cba5f7a01e897201ea3d0ca3))
+
+## [0.3.4](https://github.com/nozomiishii/configs/compare/@nozomiishii/markdownlint-cli2-config-v0.3.3...@nozomiishii/markdownlint-cli2-config-v0.3.4) (2025-09-02)
+
+### Bug Fixes
+
+- remove node engine from package.json files ([b3ad146](https://github.com/nozomiishii/configs/commit/b3ad14646e733a4c7435544e76b8a7238f333388))
+
+## [0.3.3](https://github.com/nozomiishii/configs/compare/@nozomiishii/markdownlint-cli2-config-v0.3.2...@nozomiishii/markdownlint-cli2-config-v0.3.3) (2025-08-21)
+
+### Bug Fixes
+
+- devEngines in package.json ([02d57a3](https://github.com/nozomiishii/configs/commit/02d57a31f4d4d403b14ad223661c9531faeda296))
+- remove pnpm.executionEnv.nodeVersion ([9e2941a](https://github.com/nozomiishii/configs/commit/9e2941a0b00a83a5dc00391a533eccd3dd9b7824))
+
+## [0.3.2](https://github.com/nozomiishii/configs/compare/@nozomiishii/markdownlint-cli2-config-v0.3.1...@nozomiishii/markdownlint-cli2-config-v0.3.2) (2025-05-04)
+
+### Bug Fixes
+
+- update release workflow condition and add package manager configuration to multiple packages ([958992c](https://github.com/nozomiishii/configs/commit/958992ccd8bdaf906a50bb769ec45459fab81210))
+
+## [0.3.1](https://github.com/nozomiishii/configs/compare/@nozomiishii/markdownlint-cli2-config-v0.3.0...@nozomiishii/markdownlint-cli2-config-v0.3.1) (2024-02-18)
+
+### Bug Fixes
+
+- change allow_different_nesting to siblings_only in markdownlint-cli2-config ([48ad6ad](https://github.com/nozomiishii/configs/commit/48ad6ad2a28c93461f44567e0cc0cf8635ebf93b))
+
+## [0.3.0](https://github.com/nozomiishii/configs/compare/@nozomiishii/markdownlint-cli2-config-v0.2.0...@nozomiishii/markdownlint-cli2-config-v0.3.0) (2023-08-06)
+
+### Features
+
+- add initial CHANGELOG ([9ce8c62](https://github.com/nozomiishii/configs/commit/9ce8c62626daccb52d6855312820188fbb069a18))

--- a/packages/nozo/CHANGELOG.md
+++ b/packages/nozo/CHANGELOG.md
@@ -1,0 +1,74 @@
+# Changelog
+
+## [0.4.4](https://github.com/nozomiishii/configs/compare/nozo-v0.4.3...nozo-v0.4.4) (2026-05-08)
+
+### Features
+
+- **nozo:** switch init command to spawn dispatcher and cover all configs ([#2192](https://github.com/nozomiishii/configs/issues/2192)) ([41e25b1](https://github.com/nozomiishii/configs/commit/41e25b13fbaa496e9294e6398cfb5aeecce12577))
+
+### Miscellaneous
+
+- update pnpm to v10.33.3 ([#2199](https://github.com/nozomiishii/configs/issues/2199)) ([6d610b4](https://github.com/nozomiishii/configs/commit/6d610b4ae99a16216c70737e5398d1670725e110))
+- update pnpm to v11 ([#2193](https://github.com/nozomiishii/configs/issues/2193)) ([e7c39d1](https://github.com/nozomiishii/configs/commit/e7c39d1183234ec9ebf2d8599535279b970222e9))
+
+## [0.4.3](https://github.com/nozomiishii/configs/compare/nozo-v0.4.2...nozo-v0.4.3) (2026-05-07)
+
+### Miscellaneous
+
+- update dependency eslint to v10.3.0 ([#2185](https://github.com/nozomiishii/configs/issues/2185)) ([0ecb904](https://github.com/nozomiishii/configs/commit/0ecb9046e502ed3af729586f4023e32382a864cd))
+
+## [0.4.2](https://github.com/nozomiishii/configs/compare/nozo-v0.4.1...nozo-v0.4.2) (2026-05-03)
+
+### Miscellaneous
+
+- update dependency @clack/prompts to v1.3.0 ([#2166](https://github.com/nozomiishii/configs/issues/2166)) ([09f6f2b](https://github.com/nozomiishii/configs/commit/09f6f2bedee6428bf77539b3689786076b947eb7))
+
+## [0.4.1](https://github.com/nozomiishii/configs/compare/nozo-v0.4.0...nozo-v0.4.1) (2026-05-02)
+
+### Features
+
+- **nozo:** implement init command for lefthook scaffolding ([#2157](https://github.com/nozomiishii/configs/issues/2157)) ([85a00fe](https://github.com/nozomiishii/configs/commit/85a00febcfbea39e04a1283c54683e1265b37660))
+
+## [0.4.0](https://github.com/nozomiishii/configs/compare/nozo-v0.3.0...nozo-v0.4.0) (2026-05-01)
+
+### ⚠ BREAKING CHANGES
+
+- **prettier-config:** The singleQuote default is changed from true to false. Consumer repositories will see string literals re-formatted from single to double quotes.
+
+### Features
+
+- **prettier-config:** revert singleQuote to Prettier default ([#2140](https://github.com/nozomiishii/configs/issues/2140)) ([c2f2ff5](https://github.com/nozomiishii/configs/commit/c2f2ff5ef8f68d53e7caf67206e95b8c16a10037))
+
+### Bug Fixes
+
+- add Japanese READMEs for shared config packages ([#2151](https://github.com/nozomiishii/configs/issues/2151)) ([b5e96f1](https://github.com/nozomiishii/configs/commit/b5e96f1cb4ad35725b44cf9b19cd01b02d798fa9))
+
+## [0.3.0](https://github.com/nozomiishii/configs/compare/nozo-v0.2.2...nozo-v0.3.0) (2026-04-28)
+
+### ⚠ BREAKING CHANGES
+
+- bin field changes from a single setup script ("bin": "bin/cli.sh") to a namespaced map ({ "nozo-commitlint": "bin/cli.mjs" }). Consumers who previously ran pnpx @nozomiishii/commitlint-config@latest to scaffold a commitlint config now need a different mechanism (planned for nozo init in a follow-up PR).
+
+### Features
+
+- modularize lefthook config + commitlint shim + nozo CLI rebuild ([#2119](https://github.com/nozomiishii/configs/issues/2119)) ([1140b62](https://github.com/nozomiishii/configs/commit/1140b62e3d0430f2383a5f683ea2583fa4ea7ee9)), closes [#2118](https://github.com/nozomiishii/configs/issues/2118)
+
+## [0.2.2](https://github.com/nozomiishii/configs/compare/nozo-v0.2.1...nozo-v0.2.2) (2026-04-27)
+
+### Miscellaneous
+
+- release main ([#2031](https://github.com/nozomiishii/configs/issues/2031)) ([ba1c8b0](https://github.com/nozomiishii/configs/commit/ba1c8b0d0373eb1cc65bc89702ba1a41f5923e6b))
+- update Node.js version to 24.11.0 ([dfe7067](https://github.com/nozomiishii/configs/commit/dfe70673dea75db5967d267483aa03c99bc14630))
+
+## [0.2.1](https://github.com/nozomiishii/configs/compare/nozo-v0.2.0...nozo-v0.2.1) (2025-08-21)
+
+### Bug Fixes
+
+- devEngines in package.json ([02d57a3](https://github.com/nozomiishii/configs/commit/02d57a31f4d4d403b14ad223661c9531faeda296))
+- remove pnpm.executionEnv.nodeVersion ([9e2941a](https://github.com/nozomiishii/configs/commit/9e2941a0b00a83a5dc00391a533eccd3dd9b7824))
+
+## [0.2.0](https://github.com/nozomiishii/configs/compare/nozo-v0.1.0...nozo-v0.2.0) (2023-08-06)
+
+### Features
+
+- add initial CHANGELOG ([9ce8c62](https://github.com/nozomiishii/configs/commit/9ce8c62626daccb52d6855312820188fbb069a18))

--- a/packages/postinstall/CHANGELOG.md
+++ b/packages/postinstall/CHANGELOG.md
@@ -1,0 +1,91 @@
+# Changelog
+
+## [0.1.2](https://github.com/nozomiishii/configs/compare/@nozomiishii/postinstall-v0.1.1...@nozomiishii/postinstall-v0.1.2) (2026-05-08)
+
+### Miscellaneous
+
+- update pnpm to v10.33.3 ([#2199](https://github.com/nozomiishii/configs/issues/2199)) ([6d610b4](https://github.com/nozomiishii/configs/commit/6d610b4ae99a16216c70737e5398d1670725e110))
+- update pnpm to v11 ([#2193](https://github.com/nozomiishii/configs/issues/2193)) ([e7c39d1](https://github.com/nozomiishii/configs/commit/e7c39d1183234ec9ebf2d8599535279b970222e9))
+
+## [0.1.1](https://github.com/nozomiishii/configs/compare/@nozomiishii/postinstall-v0.1.0...@nozomiishii/postinstall-v0.1.1) (2026-05-07)
+
+### Features
+
+- **postinstall:** add nozo-postinstall-init bin ([#2165](https://github.com/nozomiishii/configs/issues/2165)) ([31bd58d](https://github.com/nozomiishii/configs/commit/31bd58dd9c64e14cad6cf89f118dcc0ca28ca5b2))
+
+## [0.1.0](https://github.com/nozomiishii/configs/compare/@nozomiishii/postinstall-v0.0.8...@nozomiishii/postinstall-v0.1.0) (2026-05-01)
+
+### ⚠ BREAKING CHANGES
+
+- **prettier-config:** The singleQuote default is changed from true to false. Consumer repositories will see string literals re-formatted from single to double quotes.
+
+### Features
+
+- **prettier-config:** revert singleQuote to Prettier default ([#2140](https://github.com/nozomiishii/configs/issues/2140)) ([c2f2ff5](https://github.com/nozomiishii/configs/commit/c2f2ff5ef8f68d53e7caf67206e95b8c16a10037))
+
+### Bug Fixes
+
+- add Japanese READMEs for shared config packages ([#2151](https://github.com/nozomiishii/configs/issues/2151)) ([b5e96f1](https://github.com/nozomiishii/configs/commit/b5e96f1cb4ad35725b44cf9b19cd01b02d798fa9))
+- **postinstall:** always use --force on lefthook install ([#2133](https://github.com/nozomiishii/configs/issues/2133)) ([53beef0](https://github.com/nozomiishii/configs/commit/53beef0693879f28a99bbf88fc3f6a12ebf97de6))
+
+## [0.0.8](https://github.com/nozomiishii/configs/compare/@nozomiishii/postinstall-v0.0.7...@nozomiishii/postinstall-v0.0.8) (2026-04-27)
+
+### Bug Fixes
+
+- **postinstall:** increase build test timeout to avoid CI flakiness ([#2096](https://github.com/nozomiishii/configs/issues/2096)) ([a88ffb9](https://github.com/nozomiishii/configs/commit/a88ffb9c75e83e16f5a69998169cd71abf336fe6))
+
+### Miscellaneous
+
+- release main ([#2031](https://github.com/nozomiishii/configs/issues/2031)) ([ba1c8b0](https://github.com/nozomiishii/configs/commit/ba1c8b0d0373eb1cc65bc89702ba1a41f5923e6b))
+- update dependency @types/node to v24.12.1 ([#2041](https://github.com/nozomiishii/configs/issues/2041)) ([d6f9a6d](https://github.com/nozomiishii/configs/commit/d6f9a6da6419e963ca3f343fc3108def95eafe84))
+- update dependency @types/node to v24.12.2 ([#2042](https://github.com/nozomiishii/configs/issues/2042)) ([12f3031](https://github.com/nozomiishii/configs/commit/12f3031d32a6adbac606dd999978cd18d6b37526))
+- update dependency tsdown to v0.21.10 ([#2112](https://github.com/nozomiishii/configs/issues/2112)) ([21939bb](https://github.com/nozomiishii/configs/commit/21939bb55da1202f1e84eaed0f10a07c65c23e41))
+- update dependency tsdown to v0.21.8 ([#2070](https://github.com/nozomiishii/configs/issues/2070)) ([bdcdeab](https://github.com/nozomiishii/configs/commit/bdcdeab2a83cfef17629d63b621b431a9399cd56))
+- update dependency tsdown to v0.21.9 ([#2085](https://github.com/nozomiishii/configs/issues/2085)) ([eaeb311](https://github.com/nozomiishii/configs/commit/eaeb311df48848207f0a3ae5aa051eece4bfa278))
+- update dependency typescript to v6.0.3 ([#2088](https://github.com/nozomiishii/configs/issues/2088)) ([25e9e34](https://github.com/nozomiishii/configs/commit/25e9e34004a9069de68430008b4daca34bcac000))
+- update dependency vitest to v4.1.3 ([#2046](https://github.com/nozomiishii/configs/issues/2046)) ([7def3a2](https://github.com/nozomiishii/configs/commit/7def3a2812952fa668a1f0f6d5813f8055d15bf5))
+- update dependency vitest to v4.1.4 ([#2053](https://github.com/nozomiishii/configs/issues/2053)) ([1bc6ffa](https://github.com/nozomiishii/configs/commit/1bc6ffa4ccf1765d598c82af09ed9c9480a0fa0f))
+- update dependency vitest to v4.1.5 ([#2102](https://github.com/nozomiishii/configs/issues/2102)) ([152ecfd](https://github.com/nozomiishii/configs/commit/152ecfd3682c7204f36c77b283a7e5f5221b6f06))
+- update pnpm to v10.33.1 ([#2110](https://github.com/nozomiishii/configs/issues/2110)) ([5af1dc0](https://github.com/nozomiishii/configs/commit/5af1dc0b5d2ce5c49bc1f97a87d04f1e72aadd51))
+- update pnpm to v10.33.2 ([#2114](https://github.com/nozomiishii/configs/issues/2114)) ([de64989](https://github.com/nozomiishii/configs/commit/de64989ce298d538e759f980ab505030be9a3e24))
+
+## [0.0.7](https://github.com/nozomiishii/configs/compare/@nozomiishii/postinstall-v0.0.6...@nozomiishii/postinstall-v0.0.7) (2026-04-01)
+
+### Bug Fixes
+
+- **postinstall:** disable sourcemap in production build ([#2013](https://github.com/nozomiishii/configs/issues/2013)) ([801065b](https://github.com/nozomiishii/configs/commit/801065bfc22116339e911635f26a4451b926d496))
+
+## [0.0.6](https://github.com/nozomiishii/configs/compare/@nozomiishii/postinstall-v0.0.5...@nozomiishii/postinstall-v0.0.6) (2025-09-02)
+
+### Bug Fixes
+
+- remove node engine from package.json files ([b3ad146](https://github.com/nozomiishii/configs/commit/b3ad14646e733a4c7435544e76b8a7238f333388))
+
+## [0.0.5](https://github.com/nozomiishii/configs/compare/@nozomiishii/postinstall-v0.0.4...@nozomiishii/postinstall-v0.0.5) (2025-08-21)
+
+### Bug Fixes
+
+- devEngines in package.json ([02d57a3](https://github.com/nozomiishii/configs/commit/02d57a31f4d4d403b14ad223661c9531faeda296))
+- remove pnpm.executionEnv.nodeVersion ([9e2941a](https://github.com/nozomiishii/configs/commit/9e2941a0b00a83a5dc00391a533eccd3dd9b7824))
+
+## [0.0.4](https://github.com/nozomiishii/configs/compare/@nozomiishii/postinstall-v0.0.3...@nozomiishii/postinstall-v0.0.4) (2025-06-20)
+
+### Features
+
+- add git setup functionality to postinstall script ([b1e03d1](https://github.com/nozomiishii/configs/commit/b1e03d149b9695ad1d44e917fd1568e2fe8ad675))
+
+## [0.0.3](https://github.com/nozomiishii/configs/compare/@nozomiishii/postinstall-v0.0.2...@nozomiishii/postinstall-v0.0.3) (2025-05-04)
+
+### Bug Fixes
+
+- use @nozomiishii/tsconfig ([5eacdc9](https://github.com/nozomiishii/configs/commit/5eacdc9e7ea6823fd2dfffadd118194a04f906c7))
+
+## [0.0.2](https://github.com/nozomiishii/configs/compare/@nozomiishii/postinstall-v0.0.1...@nozomiishii/postinstall-v0.0.2) (2025-05-02)
+
+### Features
+
+- create @nozomiishii/postinstall package ([#1128](https://github.com/nozomiishii/configs/issues/1128)) ([f197bbf](https://github.com/nozomiishii/configs/commit/f197bbf88ce37fc30f82053b24ca1c7731e41acc))
+
+### Bug Fixes
+
+- update release workflow condition and add package manager configuration to multiple packages ([958992c](https://github.com/nozomiishii/configs/commit/958992ccd8bdaf906a50bb769ec45459fab81210))

--- a/packages/prettier-config/CHANGELOG.md
+++ b/packages/prettier-config/CHANGELOG.md
@@ -1,0 +1,143 @@
+# Changelog
+
+## [0.9.1](https://github.com/nozomiishii/configs/compare/@nozomiishii/prettier-config-v0.9.0...@nozomiishii/prettier-config-v0.9.1) (2026-05-08)
+
+### Bug Fixes
+
+- **prettier-config:** pass plugin object directly to drop hoist dependency ([#2195](https://github.com/nozomiishii/configs/issues/2195)) ([3fad67a](https://github.com/nozomiishii/configs/commit/3fad67a2ca5aa8591cc21ced4bf7b7da8ce87f3b))
+
+### Miscellaneous
+
+- update pnpm to v10.33.3 ([#2199](https://github.com/nozomiishii/configs/issues/2199)) ([6d610b4](https://github.com/nozomiishii/configs/commit/6d610b4ae99a16216c70737e5398d1670725e110))
+- update pnpm to v11 ([#2193](https://github.com/nozomiishii/configs/issues/2193)) ([e7c39d1](https://github.com/nozomiishii/configs/commit/e7c39d1183234ec9ebf2d8599535279b970222e9))
+
+## [0.9.0](https://github.com/nozomiishii/configs/compare/@nozomiishii/prettier-config-v0.8.0...@nozomiishii/prettier-config-v0.9.0) (2026-05-07)
+
+### ⚠ BREAKING CHANGES
+
+- **prettier-config:** replace legacy bash scaffold with nozo-prettier-init bin ([#2164](https://github.com/nozomiishii/configs/issues/2164))
+
+### Features
+
+- **prettier-config:** replace legacy bash scaffold with nozo-prettier-init bin ([#2164](https://github.com/nozomiishii/configs/issues/2164)) ([c54e969](https://github.com/nozomiishii/configs/commit/c54e969fe3799487deb5991d1b1785b9bbd99210))
+
+## [0.8.0](https://github.com/nozomiishii/configs/compare/@nozomiishii/prettier-config-v0.7.3...@nozomiishii/prettier-config-v0.8.0) (2026-05-01)
+
+### ⚠ BREAKING CHANGES
+
+- **prettier-config:** The printWidth default is changed from 119 to 100. Lines in the 100-119 range will be re-formatted in consumer codebases on the next format run.
+- **prettier-config:** The singleQuote default is changed from true to false. Consumer repositories will see string literals re-formatted from single to double quotes.
+
+### Features
+
+- **prettier-config:** apply config audit findings ([#2123](https://github.com/nozomiishii/configs/issues/2123)) ([75ad0db](https://github.com/nozomiishii/configs/commit/75ad0db0c635412d8e687afdef34452a28fca677))
+- **prettier-config:** apply config audit findings ([#2139](https://github.com/nozomiishii/configs/issues/2139)) ([75ad0db](https://github.com/nozomiishii/configs/commit/75ad0db0c635412d8e687afdef34452a28fca677))
+- **prettier-config:** change printWidth default from 119 to 100 ([#2141](https://github.com/nozomiishii/configs/issues/2141)) ([949e037](https://github.com/nozomiishii/configs/commit/949e037f45d4ccfd8647fceeea4338bd5b6f697e))
+- **prettier-config:** revert singleQuote to Prettier default ([#2140](https://github.com/nozomiishii/configs/issues/2140)) ([c2f2ff5](https://github.com/nozomiishii/configs/commit/c2f2ff5ef8f68d53e7caf67206e95b8c16a10037))
+
+### Bug Fixes
+
+- add Japanese READMEs for shared config packages ([#2151](https://github.com/nozomiishii/configs/issues/2151)) ([b5e96f1](https://github.com/nozomiishii/configs/commit/b5e96f1cb4ad35725b44cf9b19cd01b02d798fa9))
+
+## [0.7.3](https://github.com/nozomiishii/configs/compare/@nozomiishii/prettier-config-v0.7.2...@nozomiishii/prettier-config-v0.7.3) (2026-04-27)
+
+### Bug Fixes
+
+- **prettier-config:** migrate to TypeScript source with tsdown build ([#2063](https://github.com/nozomiishii/configs/issues/2063)) ([124a344](https://github.com/nozomiishii/configs/commit/124a344b674b272130b8634738cafc401644d559))
+
+### Miscellaneous
+
+- add provenance to publishConfig for all packages ([#1973](https://github.com/nozomiishii/configs/issues/1973)) ([165ef9b](https://github.com/nozomiishii/configs/commit/165ef9b1232b74a1e62222cf0683c2be413e8252))
+- release main ([#2031](https://github.com/nozomiishii/configs/issues/2031)) ([ba1c8b0](https://github.com/nozomiishii/configs/commit/ba1c8b0d0373eb1cc65bc89702ba1a41f5923e6b))
+- update dependency prettier to v3.8.2 ([#2057](https://github.com/nozomiishii/configs/issues/2057)) ([30033bb](https://github.com/nozomiishii/configs/commit/30033bbd32e16e936d49e18c90a8da78d6ca4216))
+- update dependency prettier to v3.8.3 ([#2079](https://github.com/nozomiishii/configs/issues/2079)) ([dae6f45](https://github.com/nozomiishii/configs/commit/dae6f455cfd151c936c3cff37a1fd533a9bd0837))
+- update dependency prettier-plugin-packagejson to v3.0.2 ([#1928](https://github.com/nozomiishii/configs/issues/1928)) ([3dd694c](https://github.com/nozomiishii/configs/commit/3dd694cc8243a6dccd23ab1132810cc83cd8a41a))
+- update dependency tsdown to v0.21.10 ([#2112](https://github.com/nozomiishii/configs/issues/2112)) ([21939bb](https://github.com/nozomiishii/configs/commit/21939bb55da1202f1e84eaed0f10a07c65c23e41))
+- update dependency tsdown to v0.21.8 ([#2070](https://github.com/nozomiishii/configs/issues/2070)) ([bdcdeab](https://github.com/nozomiishii/configs/commit/bdcdeab2a83cfef17629d63b621b431a9399cd56))
+- update dependency tsdown to v0.21.9 ([#2085](https://github.com/nozomiishii/configs/issues/2085)) ([eaeb311](https://github.com/nozomiishii/configs/commit/eaeb311df48848207f0a3ae5aa051eece4bfa278))
+- update dependency typescript to v6.0.3 ([#2088](https://github.com/nozomiishii/configs/issues/2088)) ([25e9e34](https://github.com/nozomiishii/configs/commit/25e9e34004a9069de68430008b4daca34bcac000))
+- update pnpm to v10.29.2 ([#1849](https://github.com/nozomiishii/configs/issues/1849)) ([180c37e](https://github.com/nozomiishii/configs/commit/180c37e71c139f6dabe0dc62a7e227095c263fb6))
+- update pnpm to v10.29.3 ([#1859](https://github.com/nozomiishii/configs/issues/1859)) ([a32b59f](https://github.com/nozomiishii/configs/commit/a32b59f56b170dd7f0dbf16718ed4806261e3910))
+- update pnpm to v10.30.0 ([#1872](https://github.com/nozomiishii/configs/issues/1872)) ([a03fd07](https://github.com/nozomiishii/configs/commit/a03fd07e69295164b6fa576b06e724848c3c0559))
+- update pnpm to v10.30.1 ([#1883](https://github.com/nozomiishii/configs/issues/1883)) ([233091d](https://github.com/nozomiishii/configs/commit/233091d278ab9b0271db6577aba1f13f29030fa6))
+- update pnpm to v10.30.2 ([#1901](https://github.com/nozomiishii/configs/issues/1901)) ([9b75ad0](https://github.com/nozomiishii/configs/commit/9b75ad06e6ea552d983313bf44fbac83c6ccca11))
+- update pnpm to v10.30.3 ([#1911](https://github.com/nozomiishii/configs/issues/1911)) ([bf0767e](https://github.com/nozomiishii/configs/commit/bf0767e66848eb142b058d11a5c8f2630e8809c8))
+- update pnpm to v10.31.0 ([#1936](https://github.com/nozomiishii/configs/issues/1936)) ([a70a929](https://github.com/nozomiishii/configs/commit/a70a929d39a07c6ad9df8a9ad70d1bf49f198310))
+- update pnpm to v10.32.0 ([#1943](https://github.com/nozomiishii/configs/issues/1943)) ([b2c305a](https://github.com/nozomiishii/configs/commit/b2c305a55fa6b3c48eb5bbb5011a22ed52cde7e0))
+- update pnpm to v10.32.1 ([#1945](https://github.com/nozomiishii/configs/issues/1945)) ([e263599](https://github.com/nozomiishii/configs/commit/e2635991025302bcc85dd1c61016365c392dfd79))
+- update pnpm to v10.33.0 ([#1995](https://github.com/nozomiishii/configs/issues/1995)) ([276cdda](https://github.com/nozomiishii/configs/commit/276cdda99f94f64e79eb87192e1e6d1b175c46b6))
+- update pnpm to v10.33.1 ([#2110](https://github.com/nozomiishii/configs/issues/2110)) ([5af1dc0](https://github.com/nozomiishii/configs/commit/5af1dc0b5d2ce5c49bc1f97a87d04f1e72aadd51))
+- update pnpm to v10.33.2 ([#2114](https://github.com/nozomiishii/configs/issues/2114)) ([de64989](https://github.com/nozomiishii/configs/commit/de64989ce298d538e759f980ab505030be9a3e24))
+
+## [0.7.2](https://github.com/nozomiishii/configs/compare/@nozomiishii/prettier-config-v0.7.1...@nozomiishii/prettier-config-v0.7.2) (2026-02-11)
+
+### Features
+
+- add TypeScript definitions and update package.json for prettier-config ([c5c3505](https://github.com/nozomiishii/configs/commit/c5c350537e7f22dbffd579f2871899706e6109b0))
+
+## [0.7.1](https://github.com/nozomiishii/configs/compare/@nozomiishii/prettier-config-v0.7.0...@nozomiishii/prettier-config-v0.7.1) (2026-01-19)
+
+### Bug Fixes
+
+- update installation commands in README files to use pnpx instead of npx ([d8c68bc](https://github.com/nozomiishii/configs/commit/d8c68bce6370baa876e773e4b64a9b24fdfca36f))
+- update markdownlint and prettier configurations to improve formatting rules ([#1774](https://github.com/nozomiishii/configs/issues/1774)) ([de91846](https://github.com/nozomiishii/configs/commit/de91846585c60a28cba5f7a01e897201ea3d0ca3))
+
+## [0.7.0](https://github.com/nozomiishii/configs/compare/@nozomiishii/prettier-config-v0.6.6...@nozomiishii/prettier-config-v0.7.0) (2025-12-11)
+
+### ⚠ BREAKING CHANGES
+
+- update prettier config to exclude markdown files from formatting
+
+### Bug Fixes
+
+- update prettier config to exclude markdown files from formatting ([f4ea664](https://github.com/nozomiishii/configs/commit/f4ea664548843959924bd46c99d6f299581d2c28))
+
+## [0.6.6](https://github.com/nozomiishii/configs/compare/@nozomiishii/prettier-config-v0.6.5...@nozomiishii/prettier-config-v0.6.6) (2025-12-09)
+
+### Bug Fixes
+
+- update prettier config to exclude next-env.d.ts from formatting ([d197443](https://github.com/nozomiishii/configs/commit/d19744359733a09bc9a64d1d60bedff52e265366))
+
+## [0.6.5](https://github.com/nozomiishii/configs/compare/@nozomiishii/prettier-config-v0.6.4...@nozomiishii/prettier-config-v0.6.5) (2025-09-02)
+
+### Bug Fixes
+
+- remove node engine from package.json files ([b3ad146](https://github.com/nozomiishii/configs/commit/b3ad14646e733a4c7435544e76b8a7238f333388))
+
+## [0.6.4](https://github.com/nozomiishii/configs/compare/@nozomiishii/prettier-config-v0.6.3...@nozomiishii/prettier-config-v0.6.4) (2025-08-21)
+
+### Bug Fixes
+
+- devEngines in package.json ([02d57a3](https://github.com/nozomiishii/configs/commit/02d57a31f4d4d403b14ad223661c9531faeda296))
+- remove pnpm.executionEnv.nodeVersion ([9e2941a](https://github.com/nozomiishii/configs/commit/9e2941a0b00a83a5dc00391a533eccd3dd9b7824))
+
+## [0.6.3](https://github.com/nozomiishii/configs/compare/@nozomiishii/prettier-config-v0.6.2...@nozomiishii/prettier-config-v0.6.3) (2025-05-04)
+
+### Bug Fixes
+
+- update prettier CLI commands for improved functionality ([67c93dd](https://github.com/nozomiishii/configs/commit/67c93dd2d734fe703abb774ebabd15e38e21dd95))
+- update release workflow condition and add package manager configuration to multiple packages ([958992c](https://github.com/nozomiishii/configs/commit/958992ccd8bdaf906a50bb769ec45459fab81210))
+
+## [0.6.2](https://github.com/nozomiishii/configs/compare/@nozomiishii/prettier-config-v0.6.1...@nozomiishii/prettier-config-v0.6.2) (2024-02-18)
+
+### Bug Fixes
+
+- remove d.ts from prettier ([3834e87](https://github.com/nozomiishii/configs/commit/3834e87284bcd1962c93f202f6280dad9cf12cad))
+
+## [0.6.1](https://github.com/nozomiishii/configs/compare/@nozomiishii/prettier-config-v0.6.0...@nozomiishii/prettier-config-v0.6.1) (2024-02-18)
+
+### Bug Fixes
+
+- update prettier to v3.2.4 ([60809ce](https://github.com/nozomiishii/configs/commit/60809ce6684cb834633017eb27a95c010c8ca2f1))
+
+## [0.6.0](https://github.com/nozomiishii/configs/compare/@nozomiishii/prettier-config-v0.5.0...@nozomiishii/prettier-config-v0.6.0) (2023-12-05)
+
+### Features
+
+- add type declare file to prettier-config ([a3892f1](https://github.com/nozomiishii/configs/commit/a3892f13a71179c41adb05494645f1e0e9178faf))
+
+## [0.5.0](https://github.com/nozomiishii/configs/compare/@nozomiishii/prettier-config-v0.4.0...@nozomiishii/prettier-config-v0.5.0) (2023-08-06)
+
+### Features
+
+- add initial CHANGELOG ([9ce8c62](https://github.com/nozomiishii/configs/commit/9ce8c62626daccb52d6855312820188fbb069a18))

--- a/packages/tsconfig/CHANGELOG.md
+++ b/packages/tsconfig/CHANGELOG.md
@@ -1,0 +1,98 @@
+# Changelog
+
+## [0.1.1](https://github.com/nozomiishii/configs/compare/@nozomiishii/tsconfig-v0.1.0...@nozomiishii/tsconfig-v0.1.1) (2026-05-08)
+
+### Miscellaneous
+
+- update pnpm to v10.33.3 ([#2199](https://github.com/nozomiishii/configs/issues/2199)) ([6d610b4](https://github.com/nozomiishii/configs/commit/6d610b4ae99a16216c70737e5398d1670725e110))
+- update pnpm to v11 ([#2193](https://github.com/nozomiishii/configs/issues/2193)) ([e7c39d1](https://github.com/nozomiishii/configs/commit/e7c39d1183234ec9ebf2d8599535279b970222e9))
+
+## [0.1.0](https://github.com/nozomiishii/configs/compare/@nozomiishii/tsconfig-v0.0.8...@nozomiishii/tsconfig-v0.1.0) (2026-05-01)
+
+### ⚠ BREAKING CHANGES
+
+- **tsconfig:** 以下により consumer 側で型エラーが発生しうる。
+
+### Features
+
+- **tsconfig:** apply config audit findings (breaking) ([#2145](https://github.com/nozomiishii/configs/issues/2145)) ([44918fe](https://github.com/nozomiishii/configs/commit/44918fe25cc9e601b834dfb5b0f667f9e5032e14)), closes [#2126](https://github.com/nozomiishii/configs/issues/2126)
+- **tsconfig:** apply config audit findings (non-breaking) ([#2144](https://github.com/nozomiishii/configs/issues/2144)) ([96093d1](https://github.com/nozomiishii/configs/commit/96093d12da961607bcc6eb2007a84234a35a1a94)), closes [#2126](https://github.com/nozomiishii/configs/issues/2126)
+
+### Bug Fixes
+
+- add Japanese READMEs for shared config packages ([#2151](https://github.com/nozomiishii/configs/issues/2151)) ([b5e96f1](https://github.com/nozomiishii/configs/commit/b5e96f1cb4ad35725b44cf9b19cd01b02d798fa9))
+
+## [0.0.8](https://github.com/nozomiishii/configs/compare/@nozomiishii/tsconfig-v0.0.7...@nozomiishii/tsconfig-v0.0.8) (2026-04-27)
+
+### Miscellaneous
+
+- add provenance to publishConfig for all packages ([#1973](https://github.com/nozomiishii/configs/issues/1973)) ([165ef9b](https://github.com/nozomiishii/configs/commit/165ef9b1232b74a1e62222cf0683c2be413e8252))
+- release main ([#2031](https://github.com/nozomiishii/configs/issues/2031)) ([ba1c8b0](https://github.com/nozomiishii/configs/commit/ba1c8b0d0373eb1cc65bc89702ba1a41f5923e6b))
+- update pnpm to v10.23.0 ([#1646](https://github.com/nozomiishii/configs/issues/1646)) ([661efc8](https://github.com/nozomiishii/configs/commit/661efc8881270d9c93c91bacc7086a1d689a6f27))
+- update pnpm to v10.24.0 ([#1655](https://github.com/nozomiishii/configs/issues/1655)) ([14a28f4](https://github.com/nozomiishii/configs/commit/14a28f4155dcf4fa127c50aa86152dcf83cd90d5))
+- update pnpm to v10.25.0 ([#1686](https://github.com/nozomiishii/configs/issues/1686)) ([0a40705](https://github.com/nozomiishii/configs/commit/0a40705e65fbb77e94ca89aad01f0d8f03e969f8))
+- update pnpm to v10.26.0 ([#1706](https://github.com/nozomiishii/configs/issues/1706)) ([dc197a2](https://github.com/nozomiishii/configs/commit/dc197a212145c0b4a1b26f8ef2271d4f0f2ea122))
+- update pnpm to v10.26.1 ([#1712](https://github.com/nozomiishii/configs/issues/1712)) ([fa98e8a](https://github.com/nozomiishii/configs/commit/fa98e8a2d7f5aec20f8874e8f566cbf267e28aa0))
+- update pnpm to v10.26.2 ([#1719](https://github.com/nozomiishii/configs/issues/1719)) ([cb0ca83](https://github.com/nozomiishii/configs/commit/cb0ca832a280aae45343ec8a8a7d8cb02c5ccd0d))
+- update pnpm to v10.27.0 ([#1728](https://github.com/nozomiishii/configs/issues/1728)) ([5a736a0](https://github.com/nozomiishii/configs/commit/5a736a07edf9e48fa7209459186ac326e66183fd))
+- update pnpm to v10.28.0 ([#1750](https://github.com/nozomiishii/configs/issues/1750)) ([49b3342](https://github.com/nozomiishii/configs/commit/49b3342096a5091f3990c1742fea44d55d75cd17))
+- update pnpm to v10.28.1 ([#1783](https://github.com/nozomiishii/configs/issues/1783)) ([8ab851f](https://github.com/nozomiishii/configs/commit/8ab851f5b517d1a6aaf5f1a551712a9d08291fc8))
+- update pnpm to v10.28.2 [security] ([#1803](https://github.com/nozomiishii/configs/issues/1803)) ([3bf99c7](https://github.com/nozomiishii/configs/commit/3bf99c70bf15d71c797480c5fc213c83b42cd9a3))
+- update pnpm to v10.29.1 ([#1847](https://github.com/nozomiishii/configs/issues/1847)) ([331b504](https://github.com/nozomiishii/configs/commit/331b5045e0f62b613394d1a8bdd0da18c711399f))
+- update pnpm to v10.29.2 ([#1849](https://github.com/nozomiishii/configs/issues/1849)) ([180c37e](https://github.com/nozomiishii/configs/commit/180c37e71c139f6dabe0dc62a7e227095c263fb6))
+- update pnpm to v10.29.3 ([#1859](https://github.com/nozomiishii/configs/issues/1859)) ([a32b59f](https://github.com/nozomiishii/configs/commit/a32b59f56b170dd7f0dbf16718ed4806261e3910))
+- update pnpm to v10.30.0 ([#1872](https://github.com/nozomiishii/configs/issues/1872)) ([a03fd07](https://github.com/nozomiishii/configs/commit/a03fd07e69295164b6fa576b06e724848c3c0559))
+- update pnpm to v10.30.1 ([#1883](https://github.com/nozomiishii/configs/issues/1883)) ([233091d](https://github.com/nozomiishii/configs/commit/233091d278ab9b0271db6577aba1f13f29030fa6))
+- update pnpm to v10.30.2 ([#1901](https://github.com/nozomiishii/configs/issues/1901)) ([9b75ad0](https://github.com/nozomiishii/configs/commit/9b75ad06e6ea552d983313bf44fbac83c6ccca11))
+- update pnpm to v10.30.3 ([#1911](https://github.com/nozomiishii/configs/issues/1911)) ([bf0767e](https://github.com/nozomiishii/configs/commit/bf0767e66848eb142b058d11a5c8f2630e8809c8))
+- update pnpm to v10.31.0 ([#1936](https://github.com/nozomiishii/configs/issues/1936)) ([a70a929](https://github.com/nozomiishii/configs/commit/a70a929d39a07c6ad9df8a9ad70d1bf49f198310))
+- update pnpm to v10.32.0 ([#1943](https://github.com/nozomiishii/configs/issues/1943)) ([b2c305a](https://github.com/nozomiishii/configs/commit/b2c305a55fa6b3c48eb5bbb5011a22ed52cde7e0))
+- update pnpm to v10.32.1 ([#1945](https://github.com/nozomiishii/configs/issues/1945)) ([e263599](https://github.com/nozomiishii/configs/commit/e2635991025302bcc85dd1c61016365c392dfd79))
+- update pnpm to v10.33.0 ([#1995](https://github.com/nozomiishii/configs/issues/1995)) ([276cdda](https://github.com/nozomiishii/configs/commit/276cdda99f94f64e79eb87192e1e6d1b175c46b6))
+- update pnpm to v10.33.1 ([#2110](https://github.com/nozomiishii/configs/issues/2110)) ([5af1dc0](https://github.com/nozomiishii/configs/commit/5af1dc0b5d2ce5c49bc1f97a87d04f1e72aadd51))
+- update pnpm to v10.33.2 ([#2114](https://github.com/nozomiishii/configs/issues/2114)) ([de64989](https://github.com/nozomiishii/configs/commit/de64989ce298d538e759f980ab505030be9a3e24))
+
+## [0.0.7](https://github.com/nozomiishii/configs/compare/@nozomiishii/tsconfig-v0.0.6...@nozomiishii/tsconfig-v0.0.7) (2025-09-02)
+
+### Bug Fixes
+
+- remove node engine from package.json files ([b3ad146](https://github.com/nozomiishii/configs/commit/b3ad14646e733a4c7435544e76b8a7238f333388))
+
+## [0.0.6](https://github.com/nozomiishii/configs/compare/@nozomiishii/tsconfig-v0.0.5...@nozomiishii/tsconfig-v0.0.6) (2025-08-21)
+
+### Bug Fixes
+
+- devEngines in package.json ([02d57a3](https://github.com/nozomiishii/configs/commit/02d57a31f4d4d403b14ad223661c9531faeda296))
+- remove pnpm.executionEnv.nodeVersion ([9e2941a](https://github.com/nozomiishii/configs/commit/9e2941a0b00a83a5dc00391a533eccd3dd9b7824))
+
+## [0.0.5](https://github.com/nozomiishii/configs/compare/@nozomiishii/tsconfig-v0.0.4...@nozomiishii/tsconfig-v0.0.5) (2025-05-04)
+
+### Bug Fixes
+
+- resolve Next.js build failure ([9d9ced2](https://github.com/nozomiishii/configs/commit/9d9ced2405774cffaf5db8eb5015478cbdb29b6d))
+
+## [0.0.4](https://github.com/nozomiishii/configs/compare/@nozomiishii/tsconfig-v0.0.3...@nozomiishii/tsconfig-v0.0.4) (2025-05-03)
+
+### Features
+
+- enable TypeScript configuration inheritance via "extends": "@nozomiishii/tsconfig" ([72f5cbc](https://github.com/nozomiishii/configs/commit/72f5cbc5f8c470c607093db11f5b0e95eac520b4))
+
+## [0.0.3](https://github.com/nozomiishii/configs/compare/@nozomiishii/tsconfig-v0.0.2...@nozomiishii/tsconfig-v0.0.3) (2025-05-03)
+
+### Bug Fixes
+
+- update release workflow condition and add package manager configuration to multiple packages ([958992c](https://github.com/nozomiishii/configs/commit/958992ccd8bdaf906a50bb769ec45459fab81210))
+
+## [0.0.2](https://github.com/nozomiishii/configs/compare/@nozomiishii/tsconfig-v0.0.1...@nozomiishii/tsconfig-v0.0.2) (2024-06-16)
+
+### Features
+
+- add "noImplicitOverride" option to tsconfig.base.json ([c811cbc](https://github.com/nozomiishii/configs/commit/c811cbccb63996f20e0632a71c14b3b88e3fdf2a))
+- add "verbatimModuleSyntax": true ([4876e68](https://github.com/nozomiishii/configs/commit/4876e68a6d412519fbcb54f0d004344e10008b03))
+- create @nozomiishii/tsconfig ([a3619c1](https://github.com/nozomiishii/configs/commit/a3619c13690065b1b147184abd169168eb8d68cf))
+
+### Bug Fixes
+
+- set type module to @nozomiishii/tsconfig ([47e2ec1](https://github.com/nozomiishii/configs/commit/47e2ec1c35a3ffe04334138a9b4ca39e71fcb86d))
+- update prettier to v3.2.4 ([60809ce](https://github.com/nozomiishii/configs/commit/60809ce6684cb834633017eb27a95c010c8ca2f1))
+- update skipLibCheck to true in tsconfig ([4645861](https://github.com/nozomiishii/configs/commit/4645861919c56a8d66ccb440e8e274d2366be29c))


### PR DESCRIPTION
## 概要

Phase 5 ([#2202](https://github.com/nozomiishii/configs/pull/2202) + 緊急修正 [#2204](https://github.com/nozomiishii/configs/pull/2204)) を完全 revert し、 main を Phase 5 着手前の状態に戻す。 [#2118](https://github.com/nozomiishii/configs/issues/2118) Phase 5 を再設計するため。

## なぜ revert するか

[#2202](https://github.com/nozomiishii/configs/pull/2202) merge 後、 設計上の前提誤りが連続して発覚:

### 1. `changelog-path: "../../CHANGELOG.md"` は release-please で動作しない

事前調査で grafana/faro-web-sdk が同パターンで動作していると認識していたが、 実物の config を確認したところ faro-web-sdk は **single-component (`. のみ`) + `extra-files`** で 9 packages を扱う完全に別の構造だった。 multi-component manifest mode + `..` を含む `changelog-path` は release-please の path validator (`base.ts` の `/((^|\/)\.{1,2}|^~|^\/*)+\//`) で拒絶される。

### 2. per-package CHANGELOG 削除と root の bootstrap-sha 累積生成の不整合

[#2202](https://github.com/nozomiishii/configs/pull/2202) で 9 個の per-package CHANGELOG.md を削除した結果、 release-please が regenerate する時に各 package の **last tag (`<pkg>-v0.9.x`) からの差分のみ** を CHANGELOG に書き出すようになった (= 0.x 以前の履歴が per-package から失われる)。 一方 root component (`.`) は manifest が `0.0.0` で `v0.0.0` tag が存在しないため **bootstrap-sha 以降の累積** を CHANGELOG に書き出した。 結果:

- root CHANGELOG: 過去の全 BREAKING / Features を含む膨大な entry
- per-package CHANGELOG: 0.9.1 → 1.0.0 の 2 commit 分のみ

「root 集約」と「per-package 詳細」のどちらの読者期待にも応えない歪な状態になった。

### 3. release-please の per-package セクション化機能が存在しない

release-please の `changelog-type` は `default` と `github` の 2 択のみで、 multi-component manifest で「1 つの CHANGELOG ファイル内に各 component セクションを並べる」機能は **公式に存在しない** ([#2305](https://github.com/googleapis/release-please/issues/2305) / [#1456](https://github.com/googleapis/release-please/issues/1456) は未解決)。 root only CHANGELOG に per-package 集約を求めるなら custom script が必要。

## revert の内容

- [#2204](https://github.com/nozomiishii/configs/pull/2204) (changelog-path 削除の hotfix) → revert (差分: 9 packages config の `changelog-path` 行が復活)
- [#2202](https://github.com/nozomiishii/configs/pull/2202) (Phase 5 setup) → revert (差分: linked-versions plugin / umbrella component / release.yaml simplification / 9 packages CHANGELOG.md 削除がすべて undo)

main HEAD は実質 [#2194](https://github.com/nozomiishii/configs/pull/2194) merge 後の状態に戻る (#2203 eslint-plugin-n update のみ別途残存)。

`git diff f5c0c19e..HEAD` (この revert PR の base):
```
packages/eslint-config/package.json |  2 +-
pnpm-lock.yaml                      | 12 ++++++------
2 files changed, 7 insertions(+), 7 deletions(-)
```

つまり Phase 5 の痕跡はすべて消える。

## 副次対応

- 自動生成された [PR #2205](https://github.com/nozomiishii/configs/pull/2205) (`chore: release v1.0.0`) は revert merge 後に release-please が新 config で再評価し、 中身が空になる (もしくは自動 close)。 必要に応じて手動 close

## 教訓 (Phase 5 再検討時に活かす)

1. **release-please の `changelog-path` traversal 制約**: `..` は使えない。 multi-component で root only CHANGELOG を求めるなら別手段 (skip-changelog on root + custom script、 または scope mandatory + flat root)
2. **per-package CHANGELOG の削除は一方通行に近い**: release-please は last tag からの差分しか書かないため、 削除すると 0.x 履歴が consumer から見えなくなる。 削除する場合は最低限 `git history で参照` の note を残すか、 そもそも削除しない
3. **「root only CHANGELOG」の現実的な意味**: release-please は per-component 単位で CHANGELOG を生成する設計。 「1 つのファイルに per-component セクション」が欲しい場合は custom script による post-process が必要
4. **brainstorming 段階で実物の config を読む**: 参照した OSS の config を「動作確認済」と書くだけでなく、 実際のファイルを取得して構造を確認する必要があった

## 次のステップ

[#2118](https://github.com/nozomiishii/configs/issues/2118) Phase 5 を再 brainstorming。 以下の選択肢を検討予定:

- A. v1.0.0 統一を諦め independent versioning 維持 (現状継続)
- B. linked-versions + skip-changelog on root + per-package CHANGELOG canonical (root は書かれないが umbrella tag/version は維持)
- C. linked-versions + custom format job script で per-package extract から root を組み立てる
- D. faro-web-sdk pattern (single `.` + extra-files、 multi-component を諦める)
