### PR TITLE
chore: enable linked-versions and bootstrap v1.0.0

### DIFF
--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -3,8 +3,7 @@
 
   "bootstrap-sha": "09c59ef0540b47e96916b8bb91c541ae53c5c72e",
 
-  "bump-minor-pre-major": true,
-  "bump-patch-for-minor-pre-major": true,
+  "release-as": "1.0.0",
 
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
@@ -49,5 +48,23 @@
       "release-type": "node",
       "component": "nozo"
     }
-  }
+  },
+
+  "plugins": [
+    {
+      "type": "linked-versions",
+      "groupName": "configs",
+      "components": [
+        "@nozomiishii/commitlint-config",
+        "@nozomiishii/cspell-config",
+        "@nozomiishii/eslint-config",
+        "@nozomiishii/lefthook-config",
+        "@nozomiishii/markdownlint-cli2-config",
+        "@nozomiishii/postinstall",
+        "@nozomiishii/prettier-config",
+        "@nozomiishii/tsconfig",
+        "nozo"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## 概要

[Issue #2118](https://github.com/nozomiishii/configs/issues/2118) Phase 5 v2。 全 9 packages を v1.0.0 に揃えるための release-please 設定変更。

Phase 5 v1 ([#2202](https://github.com/nozomiishii/configs/pull/2202) / [#2204](https://github.com/nozomiishii/configs/pull/2204) → revert [#2206](https://github.com/nozomiishii/configs/pull/2206)) で 4 つの設計前提誤りで失敗した経緯を踏まえ、 grain-lang full pattern (`.` umbrella + root CHANGELOG) を捨てて [UI5/cli](https://github.com/UI5/cli/blob/main/release-please-config.json) pattern に最小化した。

## 変更内容

- `linked-versions` plugin を追加 (`groupName: "configs"`、 9 components 列挙)
- `release-as: "1.0.0"` を bootstrap として一時追加 (release PR merge 後に削除する PR-B を follow-up で開く、 [Esri/calcite-design-system PR #13843](https://github.com/Esri/calcite-design-system/pull/13843) → [#13928](https://github.com/Esri/calcite-design-system/pull/13928) と同形)
- `bump-minor-pre-major` / `bump-patch-for-minor-pre-major` を削除 (1.0.0 へバンプ可能化)
- per-package CHANGELOG.md は維持 (`.` umbrella component は **追加しない** → 前回の bootstrap-sha 累積問題が構造的に発火しない)
- root CHANGELOG.md / umbrella tag は今回 scope out (G2/G3、 後付け option として `project_phase5_v2_plan.md` に記録)

## 期待される挙動 (本 PR merge 後)

1. release-please が **1 つの release PR を 1.0.0 で生成**、 9 packages 全部が 1.0.0 に bump される
2. release PR 内で各 package CHANGELOG.md に 1.0.0 entry が追加される (変更ない package は `### Miscellaneous Chores * **<pkg>:** Synchronize configs versions` の 1 行 chore entry が `linked-versions` plugin の fake commit injection により自動生成される)
3. release PR を merge すると 9 個の `<component>-v1.0.0` tag + 9 packages の npm publish が同時発生

## 後続作業

- **PR-B**: release PR merge 後、 `release-as` field を削除する fix-up PR を別途 open
- (option) Phase 6: [#2182](https://github.com/nozomiishii/configs/issues/2182) は merge 済み ([#2195](https://github.com/nozomiishii/configs/pull/2195))、 残るのは `.claude/settings.local.json` のグローバル化のみ

## Reference

- [UI5/cli release-please-config.json](https://github.com/UI5/cli/blob/main/release-please-config.json) — release-please + linked-versions + per-package CHANGELOG only + no `.` umbrella の完全 match
- [FormidableLabs/victory](https://github.com/FormidableLabs/victory) (11.2k stars) — 思想 (synced + per-package only) の TS world での validation (changesets `fixed` mode)
- [Esri/calcite-design-system PR #13843](https://github.com/Esri/calcite-design-system/pull/13843) → [#13928](https://github.com/Esri/calcite-design-system/pull/13928) — `release-as` config bootstrap → 削除の 2 PR flow 実例

## 検討した代替候補と却下理由

詳細はこのリポジトリの auto-memory `project_phase5_v2_plan.md` に記録済み。 要点:

- **`.` umbrella component 追加 (grain-lang pattern)**: root CHANGELOG が scope-prefix 依存で「commit ↔ package mapping」 が完全には信頼できない。 bootstrap-sha 累積の per-package override 対策も OSS 実例なしの未検証手段
- **自前 aggregator script で root CHANGELOG 生成**: prior art 調査で maintained ツール事実上ゼロ ([@monorepo-utils/collect-changelog](https://github.com/azu/monorepo-utils/tree/master/packages/@monorepo-utils/collect-changelog) は近いが lerna 前提 + cclog-parser 古い)。 release-please 多数派が per-package CHANGELOG only で運用できているシグナルと照らして、 G3 を phantom requirement と認定
- **changesets 移行**: CC 駆動の simplicity を捨てる trade-off (audience separation / squash merge 耐性 / per-package bump matrix の 3 価値命題が我々の case では全部 weak)。 詳細は `feedback_release_please_choice.md`

Refs: [#2118](https://github.com/nozomiishii/configs/issues/2118)
