### PR TITLE
feat!: deny scope by default in commitlint-config

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -1,9 +1,1 @@
-// このリポジトリは release-please の path-based 振り分けに乗せるため
-// scope を意図的に使う運用 (`feat(<package>):` `chore(deps):` 等)。
-// shared config の default (scope 禁止) を 0 に落として scope 付きを許可する。
-export default {
-  extends: ["@nozomiishii/commitlint-config"],
-  rules: {
-    "scope-empty": [0, "always"],
-  },
-};
+export default { extends: ["@nozomiishii/commitlint-config"] };

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -1,1 +1,9 @@
-export default { extends: ["@nozomiishii/commitlint-config"] };
+// このリポジトリは release-please の path-based 振り分けに乗せるため
+// scope を意図的に使う運用 (`feat(<package>):` `chore(deps):` 等)。
+// shared config の default (scope 禁止) を 0 に落として scope 付きを許可する。
+export default {
+  extends: ["@nozomiishii/commitlint-config"],
+  rules: {
+    "scope-empty": [0, "always"],
+  },
+};

--- a/packages/commitlint-config/README.ja.md
+++ b/packages/commitlint-config/README.ja.md
@@ -24,6 +24,27 @@ pnpx nozo init
 
 これで `@nozomiishii/commitlint-config` が pin で `devDependencies` に追加され、shared config を re-export する `commitlint.config.ts` が生成される。
 
+## デフォルト挙動
+
+- `type-enum`: `feat` / `fix` / `chore` のみ許可。
+- `scope-empty`: デフォルトで scope 禁止。`feat: subject` は通り、`feat(api): subject` は弾かれる。
+- `commit-message-ascii-only`: body / footer / notes は ASCII のみ（コミットメッセージは英語で書く）。
+
+### consumer 側で scope を許可する
+
+自分の `commitlint.config.ts` で `scope-empty` を上書きする:
+
+```ts
+export default {
+  extends: ["@nozomiishii/commitlint-config"],
+  rules: {
+    "scope-empty": [0, "always"],
+    // 任意: 許可する scope を絞り込みたいとき
+    "scope-enum": [2, "always", ["api", "ui", "infra"]],
+  },
+};
+```
+
 ## 同梱 bin
 
 このパッケージは pin された `@commitlint/cli` をラップする `nozo-commitlint` という namespace 付きの bin も同梱しています。Lefthook の設定（例: `@nozomiishii/lefthook-config`）からはこの shim を直接呼び出します:

--- a/packages/commitlint-config/README.md
+++ b/packages/commitlint-config/README.md
@@ -25,6 +25,27 @@ pnpx nozo init
 This adds `@nozomiishii/commitlint-config` to your `devDependencies` (pinned)
 and writes a `commitlint.config.ts` that re-exports the shared config.
 
+## Defaults
+
+- `type-enum`: only `feat` / `fix` / `chore` are allowed.
+- `scope-empty`: scope must be empty by default. `feat: subject` passes; `feat(api): subject` is rejected.
+- `commit-message-ascii-only`: body / footer / notes must be ASCII (write commit messages in English).
+
+### Allowing scope in a consumer
+
+Override `scope-empty` in your own `commitlint.config.ts`:
+
+```ts
+export default {
+  extends: ["@nozomiishii/commitlint-config"],
+  rules: {
+    "scope-empty": [0, "always"],
+    // Optional: pin an allow-list
+    "scope-enum": [2, "always", ["api", "ui", "infra"]],
+  },
+};
+```
+
 ## Bin
 
 The package also ships a namespaced bin, `nozo-commitlint`, which wraps the

--- a/packages/commitlint-config/src/index.test.ts
+++ b/packages/commitlint-config/src/index.test.ts
@@ -1,0 +1,26 @@
+import lint from "@commitlint/lint";
+import { describe, expect, it } from "vitest";
+
+import config from "./index.js";
+
+describe("scope-empty (default deny scope)", () => {
+  it("default config に scope-empty: [2, 'always'] が登録されている", () => {
+    expect(config.rules?.["scope-empty"]).toEqual([2, "always"]);
+  });
+
+  it("scope なしのコミットは pass する", async () => {
+    const result = await lint("feat: add foo", { "scope-empty": [2, "always"] } as const);
+    expect(result.valid).toBe(true);
+  });
+
+  it("scope 付きのコミットは fail する", async () => {
+    const result = await lint("feat(api): add foo", { "scope-empty": [2, "always"] } as const);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.name === "scope-empty")).toBe(true);
+  });
+
+  it("consumer が scope-empty を 0 に上書きすれば scope 付きでも pass する", async () => {
+    const result = await lint("feat(api): add foo", { "scope-empty": [0, "always"] } as const);
+    expect(result.valid).toBe(true);
+  });
+});

--- a/packages/commitlint-config/src/index.ts
+++ b/packages/commitlint-config/src/index.ts
@@ -32,6 +32,7 @@ const config: UserConfig = {
   ],
   rules: {
     "type-enum": [2, "always", ["feat", "fix", "chore"]],
+    "scope-empty": [2, "always"],
     "commit-message-ascii-only": [2, "always"],
   },
 };


### PR DESCRIPTION
## Summary

`@nozomiishii/commitlint-config` のデフォルトに `scope-empty: [2, "always"]` を追加し、scope なしを必須にする (`feat: subject` は通り、`feat(api): subject` は弾かれる)。scope を使いたい consumer は自分の `commitlint.config.ts` で `scope-empty` を 0 に上書きすればよい (commitlint の `extends` 標準の override 機構)。

このリポジトリ自身は scope を使わない方針 (release-please は path-based 振り分けで package を判定するので scope は不要、かつ scope は人為的なミスのもとになる)。よって override は入れず、shared config の default をそのまま受ける。

## Changes

- `packages/commitlint-config/src/index.ts`: `scope-empty: [2, "always"]` を追加
- `packages/commitlint-config/src/index.test.ts` (新規): scope-empty の 4 ケース (rule 登録 / scope なし pass / scope あり fail / override 0 で scope あり pass)
- `packages/commitlint-config/README.md` / `README.ja.md`: `Defaults` セクションと scope を許可する override 例を追記

## ⚠ BREAKING CHANGE 注意

`@nozomiishii/commitlint-config` を extends している既存 consumer で、これまで scope 付きで通っていたコミット (`feat(api): ...` 等) は弾かれるようになる。scope を使い続けたい場合は consumer 側で以下のように override する:

```ts
export default {
  extends: ["@nozomiishii/commitlint-config"],
  rules: {
    "scope-empty": [0, "always"],
  },
};
```

renovate が `chore(deps): ...` 形式でコミット/PR を作るリポジトリでは、override を入れるか、renovate 側で scope を抑止するか、いずれか必要 (renovate のコミットは GitHub API 経由で local commit-msg hook をバイパスするので、影響は PR title check 側に出る)。

## Test plan

- [x] `pnpm --filter @nozomiishii/commitlint-config test` (vitest 16/16 pass)
- [x] `pnpm --filter @nozomiishii/commitlint-config tsc` (型チェック clean)
- [x] `pnpm --filter @nozomiishii/commitlint-config build` (tsdown build OK)
- [x] このリポジトリ自身が override なしで動くことを commit-msg hook で確認 (`chore: drop dogfood scope override` が scope なしで通過)
