### PR TITLE
fix: increase postinstall init test timeout to avoid CI flakiness

### DIFF
--- a/packages/postinstall/src/init.test.ts
+++ b/packages/postinstall/src/init.test.ts
@@ -45,7 +45,9 @@ const test = baseTest
     },
   });
 
-test("init adds @nozomiishii/postinstall to devDependencies", ({ initResult }) => {
+// 最初に initResult を要求する test で file-scoped `built` fixture が `pnpm build` を走らせるため、
+// CI runner の負荷ブレで 5s デフォルトを超えうる（実測 7638ms）。build.test.ts と揃えて 30s。
+test("init adds @nozomiishii/postinstall to devDependencies", { timeout: 30_000 }, ({ initResult }) => {
   expect(initResult.pkg.devDependencies?.["@nozomiishii/postinstall"]).toMatch(/^\d+\.\d+\.\d+$/);
 });
 


### PR DESCRIPTION
## 概要

`packages/postinstall/src/init.test.ts` の最初の test が CI で 5s default timeout を超えて落ちる flake を解消する。

## 原因

`src/init.test.ts` の `built` fixture は file-scoped で `pnpm build` を実行する。最初に `initResult` を要求する test がその build コストを払う構造のため、CI runner の負荷ブレで 5s デフォルトを超えうる（[#2208](https://github.com/nozomiishii/configs/pull/2208) の Postinstall workflow で実測 7638ms で fail）。

`tests/build.test.ts` 側は [PR #2096](https://github.com/nozomiishii/configs/pull/2096) で 30s に拡張済みだが、その後 [PR #2165](https://github.com/nozomiishii/configs/pull/2165) で追加された `init.test.ts` は同じ build を走らせるのに timeout 拡張を入れ忘れていた。

## 変更内容

`init adds @nozomiishii/postinstall to devDependencies` test に `{ timeout: 30_000 }` を付与。`build.test.ts` と同じ理由・同じ値で揃える。2 つ目の `init adds postinstall script` test は file-scoped fixture が cache hit で軽い（80ms）ため変更しない。

## Test plan

- [x] `pnpm --filter @nozomiishii/postinstall test` がローカルで pass
- [ ] CI の Postinstall workflow `test` job が pass する
