### PR TITLE
fix: add always-update so release-as triggers v1.0.0 bump

### DIFF
--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -4,6 +4,7 @@
   "bootstrap-sha": "09c59ef0540b47e96916b8bb91c541ae53c5c72e",
 
   "release-as": "1.0.0",
+  "always-update": true,
 
   "changelog-sections": [
     { "type": "feat", "section": "Features" },


### PR DESCRIPTION
## 概要

[#2210](https://github.com/nozomiishii/configs/pull/2210) merge 後に release PR が作られなかった問題の hotfix。

## 何が起きたか

PR-A ([#2210](https://github.com/nozomiishii/configs/pull/2210)) merge の **21 秒前** に release PR ([#2208](https://github.com/nozomiishii/configs/pull/2208)) が merge されており、 全 packages が直前にリリース済み。 PR-A merge 後の release-please run の log:

```
✔ Building candidate release pull request for path: packages/postinstall
❯ commits: 0
✔ Considering: 0 commits
✔ No commits for path: packages/postinstall, skipping
...
❯ running plugin: LinkedVersions
✔ found 0 linked-versions candidates
"releases_created": "false", "prs_created": "false"
```

PR-A は config-only の変更で package path 配下に commit がないため、 各 package strategy が「0 commits → skip」 で release-as 1.0.0 が適用される前に candidate building が止まっていた。

## 修正

`"always-update": true` を追加。 これで 0 commits でも release-please が candidate を build → release-as 1.0.0 が適用 → linked-versions が 9 components を 1.0.0 に同期する。

[UI5/cli の release-please-config.json](https://github.com/UI5/cli/blob/main/release-please-config.json) で同じ設定が使われており、 動作実績あり。

## 後続作業 (PR-B)

release PR が merge された後、 別 PR で `release-as` と `always-update` の両方を削除する (永続的に always-update を残すと毎回 release PR が生成されてノイズ)。

Refs: [#2118](https://github.com/nozomiishii/configs/issues/2118), [#2210](https://github.com/nozomiishii/configs/pull/2210)
