### PR TITLE
chore: configure release-please pull-request-title-pattern

### DIFF
--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -4,6 +4,7 @@
   "bootstrap-sha": "09c59ef0540b47e96916b8bb91c541ae53c5c72e",
 
   "release-as": "1.0.0",
+  "pull-request-title-pattern": "chore: release ${version}",
 
   "changelog-sections": [
     { "type": "feat", "section": "Features" },


### PR DESCRIPTION
## 概要

release-please が生成する release PR のタイトルが現状 `chore: release main` (branch 名のみ) で version 数値が出ないので、 `pull-request-title-pattern` に `${version}` placeholder を入れて `chore: release 1.0.0` 形式に変える。

## 変更内容

`.github/.release-please-config.json` に以下を追加:

```json
"pull-request-title-pattern": "chore: release ${version}"
```

`${version}` は release-please が release PR 生成時に埋める template variable。 linked-versions group では同期 version (今回 [#2218](https://github.com/nozomiishii/configs/pull/2218) なら `1.0.0`) が入る。

## 期待される挙動 (本 PR merge 後)

1. main への push が release-please workflow を trigger
2. 既存の open release PR ([#2218](https://github.com/nozomiishii/configs/pull/2218)) が release-please により再評価され、 タイトルが `chore: release main` → `chore: release 1.0.0` に in-place 更新される
3. 以降の release PR も同パターンで version 表示される

## 参考

- [release-please docs - Customize the release pull request](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#customize-the-release-pull-request) で `pull-request-title-pattern` の template variables (`${branch}` / `${version}` / `${component}` / `${scope}`) が定義

Refs: [#2118](https://github.com/nozomiishii/configs/issues/2118), [#2218](https://github.com/nozomiishii/configs/pull/2218)
