### PR TITLE
chore: rename nozo package description

### DIFF
--- a/packages/nozo/package.json
+++ b/packages/nozo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nozo",
   "version": "0.4.5",
-  "description": "Nozomi config manager",
+  "description": "nozo shared configs CLI",
   "keywords": [
     "cli",
     "config"


### PR DESCRIPTION
## 概要

`packages/nozo/package.json` の `description` を `Nozomi config manager` から `nozo shared configs CLI` に変更。

- `Nozomi`（人名）→ `nozo`（パッケージ名・ブランド名）に統一
- 「config manager」だと役割が曖昧だったため、shared configs を扱う CLI であることを明示

npm 上の表示や検索結果での識別性を上げるための description 文言調整。
