### PR TITLE
fix: surface version in release pr title via root umbrella component

### DIFF
--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -4,7 +4,7 @@
   "bootstrap-sha": "09c59ef0540b47e96916b8bb91c541ae53c5c72e",
 
   "release-as": "1.0.0",
-  "pull-request-title-pattern": "chore: release ${version}",
+  "group-pull-request-title-pattern": "chore: release ${version}",
 
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
@@ -13,6 +13,12 @@
   ],
 
   "packages": {
+    ".": {
+      "release-type": "node",
+      "component": "configs",
+      "skip-changelog": true,
+      "skip-github-release": true
+    },
     "packages/commitlint-config": {
       "release-type": "node",
       "component": "@nozomiishii/commitlint-config"
@@ -56,6 +62,7 @@
       "type": "linked-versions",
       "groupName": "configs",
       "components": [
+        "configs",
         "@nozomiishii/commitlint-config",
         "@nozomiishii/cspell-config",
         "@nozomiishii/eslint-config",

--- a/.github/.release-please-manifest.json
+++ b/.github/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
+  ".": "0.0.0",
   "packages/commitlint-config": "0.3.0",
   "packages/cspell-config": "0.5.3",
   "packages/eslint-config": "0.9.2",


### PR DESCRIPTION
## 概要

[#2218](https://github.com/nozomiishii/configs/pull/2218) (1.0.0 release PR) のタイトルが `chore: release main` のままで version が表示されない問題の真の修正。 [#2219](https://github.com/nozomiishii/configs/pull/2219) で `pull-request-title-pattern` を入れたが、 source code を読んだ結果これは個別 PR (`separate-pull-requests` mode) 用で、 我々の構成 (manifest + linked-versions) では使われないことが判明。

## 何が必要だったか

Merge plugin の title 生成 ([`merge.ts` L102-115](https://github.com/googleapis/release-please/blob/main/src/plugins/merge.ts)):

```ts
title: PullRequestTitle.ofComponentTargetBranchVersion(
  rootRelease?.pullRequest.title.component,  // `.` path の candidate がないと undefined
  this.targetBranch,                          // "main"
  rootRelease?.pullRequest.title.version,    // 同上
  this.pullRequestTitlePattern,               // = group-pull-request-title-pattern
  this.componentNoSpace
),
```

`rootRelease` は `if (candidate.path === '.')` で見つける。 つまり **`.` umbrella component が manifest にないと version が title に出ない**。

## 変更内容

### `.release-please-config.json`

- `pull-request-title-pattern` → **`group-pull-request-title-pattern: "chore: release ${version}"`** に変更 (Merge plugin が読むキー)
- `packages` に **`"."` umbrella** を追加:
  ```json
  ".": {
    "release-type": "node",
    "component": "configs",
    "skip-changelog": true,         ← root CHANGELOG.md を書かない
    "skip-github-release": true     ← extra GitHub Release を作らない
  }
  ```
- `linked-versions.components` に **`"configs"`** を追加して 9 component の sync group に umbrella も含める

### `.release-please-manifest.json`

- `".": "0.0.0"` を追加して umbrella の baseline を明示

### 副次的に発生する artifact

- `configs-v1.0.0` git tag は作成される (skip-changelog / skip-github-release は file write と Release page 生成を抑止するが tag は別系統で必要)。 ユーザー許容済み

## 期待される挙動 (本 PR merge 後)

1. release-please が再走、 `.` umbrella が新規 candidate として登場
2. linked-versions plugin が `configs` を含む 10 components 全部を 1.0.0 に sync
3. Merge plugin が `rootRelease` (= `.` candidate) を pickup → title pattern `${version}` を `1.0.0` に解決
4. 既存の [#2218](https://github.com/nozomiishii/configs/pull/2218) のタイトルが `chore: release main` → **`chore: release 1.0.0`** に in-place 更新 (release-please は同 head branch の PR を更新する)
5. PR body には `<details><summary>configs: 1.0.0</summary>` セクションが追加される (`Synchronize configs versions` の 1 行 chore entry)
6. release PR を merge すると 9 packages + `configs` umbrella の 10 個の tag が打たれる (うち npm publish は 9 packages のみ、 `configs-v1.0.0` tag は付くが GitHub Release は無し)

## リスク

- **`.` umbrella の path attribution**: bootstrap-sha (`09c59ef0...`) 以降の root file changes (`.github/`, root README, root config 等) が `.` に attribute される可能性。 PR body に出ても skip-changelog で root CHANGELOG.md には書かれないので実害は限定的だが、 [#2218](https://github.com/nozomiishii/configs/pull/2218) PR body が膨らむ可能性あり
- per-package `bootstrap-sha` override は release-please の `ReleaserConfigJson` interface 上 [サポートされていない](https://github.com/googleapis/release-please/blob/main/src/manifest.ts#L160-L195) ので、 直近 main HEAD への限定が config だけでは不可能

Refs: [#2118](https://github.com/nozomiishii/configs/issues/2118), [#2218](https://github.com/nozomiishii/configs/pull/2218), [#2219](https://github.com/nozomiishii/configs/pull/2219)
