### PR TITLE
fix: collapse release matrix jobs to support root umbrella component

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,17 +67,13 @@ jobs:
   format:
     needs: release-please
 
-    if: needs.release-please.outputs.prs
+    if: needs.release-please.outputs.prs && needs.release-please.outputs.prs != '[]'
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
     permissions:
       contents: write # required to push the formatted CHANGELOG commit back to the release-please PR branch
-
-    strategy:
-      matrix:
-        pr: ${{ fromJson(needs.release-please.outputs.prs) }}
 
     steps:
       - name: Load secrets from 1Password
@@ -98,7 +94,7 @@ jobs:
       - name: Checkout release-please Pull Request
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ matrix.pr.headBranchName }}
+          ref: ${{ fromJson(needs.release-please.outputs.prs)[0].headBranchName }}
           persist-credentials: false # auth は後段の `gh auth setup-git` で配線する
 
       - name: Setup Node
@@ -132,14 +128,10 @@ jobs:
       id-token: write # Required for OIDC
       contents: read
 
-    if: needs.release-please.outputs.releases_created == 'true' && needs.release-please.outputs.paths_released != '[]'
+    if: needs.release-please.outputs.releases_created == 'true'
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
-
-    strategy:
-      matrix:
-        path: ${{ fromJson(needs.release-please.outputs.paths_released) }}
 
     steps:
       - name: Checkout
@@ -150,7 +142,5 @@ jobs:
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
-      - name: Publish package
-        env:
-          MATRIX_PATH: ${{ matrix.path }}
-        run: pnpm --filter "./${MATRIX_PATH}" publish
+      - name: Publish all public packages
+        run: pnpm -r publish --no-git-checks


### PR DESCRIPTION
## 概要

[#2223](https://github.com/nozomiishii/configs/pull/2223) で `.` umbrella component (`configs`) を追加した結果、 `paths_released` に `.` が含まれて publish job の matrix が `pnpm --filter "./." publish` を走らせ、 root package が `private: true` で publish 不能なため失敗するリスクの修正。

## 何が問題か

現在の release.yaml の `publish` job は matrix で `paths_released` を iterate:

```yaml
strategy:
  matrix:
    path: ${{ fromJson(needs.release-please.outputs.paths_released) }}
steps:
  - run: pnpm --filter "./${MATRIX_PATH}" publish
```

`.` umbrella を追加したので `paths_released` には `["."、 "packages/commitlint-config", ...]` のような 10 path が入る。 `.` path で `pnpm --filter "./." publish` が走ると root の `private: true` package を publish しようとして fail する。

## 修正内容

[Phase 5 v1 の release.yaml diff (#2202)](https://github.com/nozomiishii/configs/pull/2202/files) を完全踏襲:

### `format` job

- `if: needs.release-please.outputs.prs && needs.release-please.outputs.prs != '[]'` に強化 (空 array で job が空 matrix で trigger するのを防ぐ)
- **matrix を削除**。 manifest + linked-versions 構成は grouped PR が **常に 1 つ**なので、 `fromJson(needs.release-please.outputs.prs)[0].headBranchName` で直接 checkout

### `publish` job

- `if` から `&& needs.release-please.outputs.paths_released != '[]'` を削除 (`releases_created == 'true'` のみで十分)
- **matrix を削除**
- `pnpm --filter "./${MATRIX_PATH}" publish` (1 path ずつ) → **`pnpm -r publish --no-git-checks`** (1 step で workspace 全体)
  - pnpm の `-r` は workspace の `private: true` package を自動 skip するので root は publish されない
  - 各 package の `publishConfig` を respect
  - `--no-git-checks` は detached HEAD checkout 上で running するために必要 (Phase 5 v1 で導入された理由と同じ)

## merge 順序

[#2218](https://github.com/nozomiishii/configs/pull/2218) (1.0.0 release PR) を merge する **前に** 本 PR を merge しておく必要がある。 そうしないと publish job が壊れる。

順序:

1. **本 PR を merge** → release.yaml が新しい shape に
2. release-please workflow が再走 (config 変更ではないので [#2218](https://github.com/nozomiishii/configs/pull/2218) には影響しない、 タイトル `chore: release 1.0.0` も保持)
3. [#2218](https://github.com/nozomiishii/configs/pull/2218) を merge → 新しい publish job で 9 packages が 1 step で publish

Refs: [#2118](https://github.com/nozomiishii/configs/issues/2118), [#2218](https://github.com/nozomiishii/configs/pull/2218), [#2223](https://github.com/nozomiishii/configs/pull/2223)
