### PR TITLE
fix: collapse umbrella section to synchronize stub

### DIFF
--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -17,7 +17,8 @@
       "release-type": "node",
       "component": "configs",
       "skip-changelog": true,
-      "skip-github-release": true
+      "skip-github-release": true,
+      "exclude-paths": ["."]
     },
     "packages/commitlint-config": {
       "release-type": "node",

--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
 
-  "bootstrap-sha": "09c59ef0540b47e96916b8bb91c541ae53c5c72e",
+  "bootstrap-sha": "362a8e8f6891e6ce9111e2f167151426ac22df6a",
 
   "release-as": "1.0.0",
   "group-pull-request-title-pattern": "chore: release ${version}",


### PR DESCRIPTION
## Summary

[#2218](https://github.com/nozomiishii/configs/pull/2218) (`chore: release 1.0.0`) の release PR body で `<details><summary>configs: 1.0.0</summary>` (= `.` umbrella) セクションが約 530 行の歴史を吸い込んでいるのを修正する。 想定どおりの「`Synchronize configs versions` 1 行 stub」 に縮める。

## 原因

release-please の `manifest.ts:451-460` で、 `path === ROOT_PROJECT_PATH` (`.`) の commit 振り分けは split せず **全 commit** をそのまま渡す特殊ロジックになっていた。 さらに `.` umbrella には対応 git tag が無いので `bootstrap-sha` から HEAD まで全部 walk され、 BREAKING CHANGES から renovate update まで全部 umbrella に乗っていた。

## 対応

### exclude-paths による output 制御 (本命)

`.` umbrella に `exclude-paths: ["."]` を設定する。 `commit-exclude.ts:33-41` の `shouldInclude` で `path === ROOT_PROJECT_PATH` の時 `isRelevant` が常に true を返す → 全 file が match → 全 commit が exclude → umbrella の commit count が 0 になる。

その後 `linked-versions.ts:62-130` の `preconfigure` が:

1. `missingReleasePaths` に `.` を追加
2. fake commit を `commitsByPath["."]` に push:
    ```
    chore(configs): Synchronize configs versions
    
    Release-As: <primaryVersion>
    ```
3. `releaseAs: primaryVersion` 付きの新 strategy で `.` を再構築

結果として `.` の release PR body は `Synchronize configs versions` 1 行に固定される。 `${version}` も Merge plugin が rootRelease (= `.` candidate) から取れるので動作不変。

### bootstrap-sha の bump (performance)

`bootstrap-sha` を 2023-08-07 の旧 SHA から直近 release main merge ([#2208](https://github.com/nozomiishii/configs/pull/2208) = `362a8e8f`) に進める。 exclude-paths で output は確定するが、 walk 自体は走るので、 SHA が古いと毎 release 回ごとに 3 年分の commit を歩いてしまう。 これを直近の release commit まで狭めることで walk が軽くなる。

## 出力

| 出力先 | 内容 |
|---|---|
| PR body の `.` セクション | `* **configs:** Synchronize configs versions` 1 行 |
| per-package CHANGELOG.md | per-package commit のみ (変化なし) |
| root CHANGELOG.md | 作られない (`skip-changelog`) |
| GitHub Release page | 作られない (`skip-github-release`) |
| tag `configs-v1.0.0` | 作られない (`skip-github-release` が buildRelease 早期 return) |
| title | `chore: release 1.0.0` ✓ |

## 将来サイクル

`exclude-paths: ["."]` は self-stabilizing。 何 cycle 経っても `.` umbrella の commit は 0 → linked-versions が Synchronize stub を inject、 を毎回繰り返すだけ。 bootstrap-sha や tag の手動メンテは不要。

## マージ順

このまま [#2218](https://github.com/nozomiishii/configs/pull/2218) より先に merge → release-please 再走で [#2218](https://github.com/nozomiishii/configs/pull/2218) の release-notes.md の `.` セクションが 530 行 → 1 行に縮小される想定。

## Test plan

- [ ] release-please workflow が正常終了し、 [#2218](https://github.com/nozomiishii/configs/pull/2218) が更新される
- [ ] [#2218](https://github.com/nozomiishii/configs/pull/2218) の `<details><summary>configs: 1.0.0</summary>` セクションが `Synchronize configs versions` 1 行になる
- [ ] per-package セクションが従来どおり (variation: feat / chore commit + Synchronize stub) のまま
- [ ] [#2218](https://github.com/nozomiishii/configs/pull/2218) の title が `chore: release 1.0.0` のまま維持される
