### PR TITLE
chore: drop release-as override after v1.0.0 graduation

### DIFF
--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -3,7 +3,6 @@
 
   "bootstrap-sha": "362a8e8f6891e6ce9111e2f167151426ac22df6a",
 
-  "release-as": "1.0.0",
   "group-pull-request-title-pattern": "chore: release ${version}",
 
   "changelog-sections": [


### PR DESCRIPTION
## Summary

v1.0.0 graduation のために [#2210](https://github.com/nozomiishii/configs/pull/2210) で導入した `release-as: "1.0.0"` を削除する。 v1.0.0 が無事 publish されたので、 これを残しておくと **以降の release も全部 1.0.0 を強制**してしまい、 Conventional Commits ベースの semver 自動 bump が動かなくなる。

これを外すことで、 次の `feat:` commit が来た時点で 1.1.0、 `fix:` commit が来たら 1.0.1 のように release-please が自然に bump できるようになる。

## マージ後の動作

- 次の release main PR から `${version}` は manifest の per-package version を起点に Conventional Commits で計算
- linked-versions plugin で全 components が同じ version に同期されるのは継続
- `.` umbrella の Synchronize stub 化 ([#2225](https://github.com/nozomiishii/configs/pull/2225) で導入) も継続

## Test plan

- [ ] release-please workflow が正常終了する
- [ ] 新規 release main PR (or 既存) のタイトルが `chore: release 1.0.0` のままではなく、 後続 commit の semver 計算結果に追従する
- [ ] 例: `feat:` commit を main に積んだ後、 release PR が `chore: release 1.1.0` を提案する
