### PR TITLE
fix: prevent release format step from being cancelled

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,8 +7,8 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: release
+  cancel-in-progress: false
 
 # デフォルト権限を無効化し、各ジョブで必要最小限の権限のみ付与する
 permissions: {}


### PR DESCRIPTION
## 背景

release-please が生成する `CHANGELOG.md` は raw 出力 (`*` リスト + 連続空行) で、リポジトリの markdownlint ルール (MD004 dash 強制 / MD012 連続空行禁止) に違反する。これは想定済みで、`format` ジョブが release PR ブランチを checkout して `pnpm fix:md && pnpm format:fix` を走らせ、`chore: format CHANGELOG.md` を push し直す設計になっている。

## 起きた問題

[#2228](https://github.com/nozomiishii/configs/pull/2228) (release 1.0.1) で markdown lint CI が失敗。原因は以下の race condition:

1. 04:08:55 [#2230](https://github.com/nozomiishii/configs/pull/2230) マージで release.yaml 起動 → release-please が release PR に raw CHANGELOG を push → format ジョブ走行中
2. 04:09:36 [#2231](https://github.com/nozomiishii/configs/pull/2231) マージで release.yaml が再 trigger
3. `concurrency.cancel-in-progress: true` により走行中の format ジョブが **cancelled**
4. [#2231](https://github.com/nozomiishii/configs/pull/2231) の release-please run は `outputs.prs == '[]'` (README 変更で release-please tracked package に影響なし) で format ジョブも skip
5. release PR は未整形のまま放置 → markdown lint が落ちる

直近 5 回の release run を時系列で見ると:

| 時刻 (UTC) | trigger PR | release-please | format |
|---|---|---|---|
| 04:03:18 | [#2229](https://github.com/nozomiishii/configs/pull/2229) pnpm 11.0.7 | success | success |
| 04:08:55 | [#2230](https://github.com/nozomiishii/configs/pull/2230) @eslint-react | success | **cancelled** |
| 04:09:36 | [#2231](https://github.com/nozomiishii/configs/pull/2231) drop bogus namespace | success | **skipped** |

## 修正

`concurrency` を queue 動作に切り替え:

- `group: ${{ github.workflow }}-${{ github.ref }}` → `group: release` (固定値、`workflow_dispatch` も同一 group に乗る)
- `cancel-in-progress: true` → `false`

これで in-flight の format ジョブが新しい push で cancel されることが構造的に無くなる。同期パターンは [`nozomiishii/git-harvest` の release.yaml](https://github.com/nozomiishii/git-harvest/blob/main/.github/workflows/release.yaml) と揃えた形。

## 残るエッジケース (未対応)

format ジョブ自身が pnpm install / fix:md でコケた + 次 push が tracked package に影響しない場合は、依然として release PR が未整形で残る。発生確率が低いので一旦保留。再発したら format の `if` を `release-please.result == 'success'` ベースに変更 + ブランチ存在チェック step 追加で対応する案がある。

## test plan

- [ ] 本 PR をマージ後、次回 release run で format ジョブが queue (= 直前 run の format 完了を待つ) ことを Actions ログで確認
- [ ] [#2228](https://github.com/nozomiishii/configs/pull/2228) の lint エラー自体は別途手動 format で解消する (本 PR の対象外)
