### PR TITLE
fix: repair release workflow lockfile and deprecation warning

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ steps.secrets.outputs.APP_ID }}
+          client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
 
       - name: Run release-please
@@ -88,7 +88,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ steps.secrets.outputs.APP_ID }}
+          client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
 
       - name: Checkout release-please Pull Request

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,7 +295,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.4))
+        version: 4.1.5(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.4))
 
   packages/postinstall:
     dependencies:


### PR DESCRIPTION
## 背景

[Release ワークフロー run #25622818729](https://github.com/nozomiishii/configs/actions/runs/25622818729) が `format` ジョブで失敗し、合わせて deprecation warning も出ていた。両方を 2 commit で修正する。

## 修正内容

### 1. `pnpm-lock.yaml` の修復 (`fix:`)

`packages/nozo` の vitest エントリが lockfile 上で `vitest@4.1.5(...esbuild@0.27.7...)` を参照しているが、resolution snapshot は `esbuild@0.28.0` 版しか存在しない不整合状態だった。Renovate の sequential merge が原因の典型的な lockfile 破損。

`pnpm install --no-frozen-lockfile` で再生成し、`packages/nozo` のエントリを `esbuild@0.28.0` に揃えた。再生成後 `pnpm install --frozen-lockfile` が通ることを確認済み。

エラー:

```
[ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY] Broken lockfile: no entry for 'vitest@4.1.5(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.4))' in pnpm-lock.yaml
```

### 2. `actions/create-github-app-token` の入力名移行 (`chore:`)

v3 で `app-id:` が deprecated になり `client-id:` 推奨に。action 内部では両方とも `createAppAuth({ appId: ... })` に同じ値で渡されるだけなので、1Password に置いてある値も `APP_ID` の env マッピングもそのまま流用できる。

警告:

```
Input 'app-id' has been deprecated with message: Use 'client-id' instead.
```

## Test plan

- [ ] release ワークフローで `pnpm install --frozen-lockfile` がパスする
- [ ] release ワークフローで deprecation warning が出ない
- [ ] `Generate GitHub App token` ステップが正常にトークンを発行する
