### PR TITLE
fix: skip git setup when not inside a git repo

### DIFF
--- a/packages/postinstall/src/git.ts
+++ b/packages/postinstall/src/git.ts
@@ -6,6 +6,12 @@ import { echo, $ } from "zx";
 export async function setupGit() {
   echo("Setup git");
 
+  const insideRepo = await $`git rev-parse --is-inside-work-tree`.nothrow().quiet();
+  if (insideRepo.exitCode !== 0) {
+    echo("Skipped: not inside a git repository.");
+    return;
+  }
+
   // Gitでファイルの大文字小文字を区別
   await $`git config core.ignorecase false`;
 


### PR DESCRIPTION
## Summary

- `nozo init` を非 git ディレクトリで実行すると postinstall が `fatal: not in a git directory` で落ち、以降の setup（vscode / act / lefthook / welcome）まで巻き込まれて止まる問題を修正
- `setupGit` で `git rev-parse --is-inside-work-tree` を `.nothrow().quiet()` で実行し、git リポジトリでなければ `Skipped: not inside a git repository.` を出して early return する
- `setupAct` の「前提が揃わなければ skip」と同じパターンに合わせた

## 背景

ユーザーが `/Users/nozomiishii/Desktop/test/`（git 管理外）で `nozo init` を実行したところ、以下のように `setupGit` が exit code 128 で zx の `$` から例外化し、process 全体が落ちていた:

```
_ProcessOutput [Error]: fatal: not in a git directory
    at setupGit (.../@nozomiishii/postinstall/dist/index.js:104:9)
    exit code: 128
```

`nozo init` は新規プロジェクトでも使われる想定なので、git リポジトリ初期化前のディレクトリでも安全に動作する必要がある。

## Test plan

- [x] `pnpm build` 成功（TS エラーなし）
- [x] `pnpm test` 既存テスト 3 件パス
- [x] 手動検証: `$TMPDIR` 配下の非 git ディレクトリで `node dist/index.js` を実行 → `Setup git` の直後に `Skipped: not inside a git repository.` を出力し、以降の `Setup vscode` / `Setup act` / `Setup lefthook` / welcome がすべて実行されて exit 0
- [ ] 手動検証: 既存の git リポジトリ内で `node dist/index.js` を実行し、従来どおり `core.ignorecase: false` が設定されること
