### PR TITLE
fix: stub commitlint-config bins for fresh install

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,11 @@
 
 `configs` は `pnpm` を使った共有設定モノレポです。`packages/` に各種ツール（commitlint / ESLint / lefthook / prettier / tsconfig など）の設定をパッケージとして提供します。
 
+## ファイル拡張子方針
+
+- TypeScript / JavaScript の拡張子は `.ts` / `.js` のみを使用する。`.mjs` / `.cjs` は使わない。
+- 全パッケージが `"type": "module"` のため `.js` は ESM として解釈される。tsdown 出力・bin stub などすべて `.js` で統一する。
+
 ## 重要なパターン
 
 - 設定変更は基本的に `packages/` 配下の設定・ドキュメント側を優先して更新する。

--- a/packages/commitlint-config/bin/nozo-commitlint-init.js
+++ b/packages/commitlint-config/bin/nozo-commitlint-init.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "../dist/init/bin.js";

--- a/packages/commitlint-config/bin/nozo-commitlint.js
+++ b/packages/commitlint-config/bin/nozo-commitlint.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "../dist/cli.js";

--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -22,10 +22,11 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "nozo-commitlint": "./dist/cli.js",
-    "nozo-commitlint-init": "./dist/init/bin.js"
+    "nozo-commitlint": "./bin/nozo-commitlint.js",
+    "nozo-commitlint-init": "./bin/nozo-commitlint-init.js"
   },
   "files": [
+    "bin",
     "dist",
     "starter.ts",
     "README.md"

--- a/packages/commitlint-config/tsdown.config.ts
+++ b/packages/commitlint-config/tsdown.config.ts
@@ -1,29 +1,15 @@
 import { defineConfig } from "tsdown";
 
-const base = defineConfig({
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+    "init/index": "src/init/index.ts",
+    cli: "src/cli.ts",
+    "init/bin": "src/init/bin.ts",
+  },
   format: ["esm"],
   platform: "node",
   outExtensions: () => ({ js: ".js", dts: ".d.ts" }),
+  dts: true,
+  clean: true,
 });
-
-export default defineConfig([
-  {
-    ...base,
-    entry: {
-      "index": "src/index.ts",
-      "init/index": "src/init/index.ts",
-    },
-    dts: true,
-    clean: true,
-  },
-  {
-    ...base,
-    entry: {
-      "cli": "src/cli.ts",
-      "init/bin": "src/init/bin.ts",
-    },
-    dts: false,
-    clean: false,
-    banner: { js: "#!/usr/bin/env node" },
-  },
-]);


### PR DESCRIPTION
## 概要

- commitlint-config の bin を `bin/*.js` の薄い stub に変更し、新規 worktree や `node_modules` + `dist` を完全削除した状態からの初回 `pnpm install` でも `[WARN] Failed to create bin` が出ないようにした
- 根本原因は「bin が build artifact (`./dist/...`) を指していると、初回 install の bin link フェーズで dist がまだ存在せず ENOENT で WARN が出る」こと。`pnpm install` の bin link フェーズが root の `postinstall: pnpm -r run build` より前に走るため
- 同問題は eslint-config / lefthook-config / prettier-config / postinstall にも残るが、本 PR は **pattern lock 用**として commitlint-config だけに絞り、他は別 PR で順次対応

## 変更内容

- `packages/commitlint-config/bin/nozo-commitlint.js` を新設 (`#!/usr/bin/env node` + `import "../dist/cli.js"` の薄い stub)
- `packages/commitlint-config/bin/nozo-commitlint-init.js` を新設 (同パターン)
- `packages/commitlint-config/package.json`: `bin` を stub に向け、`files` に `bin` を追加
- `packages/commitlint-config/tsdown.config.ts`: shebang は stub 側に移管できるので bin 専用 wrap config を消し 1 wrap に統合 (`banner: { js: "#!/usr/bin/env node" }` を削除)
- `CLAUDE.md`: 拡張子方針 (`.js` のみ、`.mjs` / `.cjs` を使わない) を追記

## 検証

新規環境を再現するため `node_modules` と `packages/*/dist` を完全削除してから `CI=true pnpm install` を実行:

| 項目 | 修正前 | 修正後 |
|---|---|---|
| `nozo-commitlint` の WARN | 出る | **出ない** |
| `nozo-commitlint-init` の WARN | 出る | **出ない** |
| `node_modules/.bin/nozo-commitlint --version` | (shim 不在) | `@commitlint/cli@20.5.3` (exit 0) |

本 PR の `commit-msg` hook で動いた `nozo-commitlint` 自体が、stub 経由で正常動作している実証になっています。

## 残タスク (本 PR 範囲外)

- PR2: eslint-config (`nozo-eslint-init`)
- PR3: lefthook-config (`nozo-git-harvest`, `nozo-lefthook-init`)
- PR4: prettier-config (`nozo-prettier-init`)
- PR5: postinstall (`postinstall`, `nozo-postinstall-init`)
- 全 PR merge 後: memory `project_worktree_postinstall_shim.md` を削除予定
