### PR TITLE
fix: stub eslint-config bin for fresh install

### DIFF
--- a/packages/eslint-config/bin/nozo-eslint-init.js
+++ b/packages/eslint-config/bin/nozo-eslint-init.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "../dist/init/bin.js";

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -22,9 +22,10 @@
   },
   "main": "eslint.config.ts",
   "bin": {
-    "nozo-eslint-init": "./dist/init/bin.js"
+    "nozo-eslint-init": "./bin/nozo-eslint-init.js"
   },
   "files": [
+    "bin",
     "dist",
     "rules",
     "utils",

--- a/packages/eslint-config/tsdown.config.ts
+++ b/packages/eslint-config/tsdown.config.ts
@@ -1,23 +1,13 @@
 import { defineConfig } from "tsdown";
 
-const base = defineConfig({
+export default defineConfig({
+  entry: {
+    "init/index": "src/init/index.ts",
+    "init/bin": "src/init/bin.ts",
+  },
   format: ["esm"],
-  outExtensions: () => ({ dts: ".d.ts", js: ".js" }),
   platform: "node",
+  outExtensions: () => ({ dts: ".d.ts", js: ".js" }),
+  dts: true,
+  clean: true,
 });
-
-export default defineConfig([
-  {
-    ...base,
-    clean: true,
-    dts: true,
-    entry: { "init/index": "src/init/index.ts" },
-  },
-  {
-    ...base,
-    banner: { js: "#!/usr/bin/env node" },
-    clean: false,
-    dts: false,
-    entry: { "init/bin": "src/init/bin.ts" },
-  },
-]);

--- a/packages/eslint-config/tsdown.config.ts
+++ b/packages/eslint-config/tsdown.config.ts
@@ -1,13 +1,13 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
+  clean: true,
+  dts: true,
   entry: {
-    "init/index": "src/init/index.ts",
     "init/bin": "src/init/bin.ts",
+    "init/index": "src/init/index.ts",
   },
   format: ["esm"],
-  platform: "node",
   outExtensions: () => ({ dts: ".d.ts", js: ".js" }),
-  dts: true,
-  clean: true,
+  platform: "node",
 });


### PR DESCRIPTION
## 概要

- eslint-config の bin (`nozo-eslint-init`) を `bin/nozo-eslint-init.js` の薄い stub に変更
- [#2242](https://github.com/nozomiishii/configs/pull/2242) と同じ pattern。fresh install (新規 worktree や `node_modules` + `dist` を完全削除した状態) で `[WARN] Failed to create bin` が出ないようにする
- 根本原因と方針の詳細は #2242 を参照

## 変更内容

- `packages/eslint-config/bin/nozo-eslint-init.js` を新設 (`#!/usr/bin/env node` + `import "../dist/init/bin.js"`)
- `packages/eslint-config/package.json`: `bin` を stub に向け、`files` に `bin` を追加
- `packages/eslint-config/tsdown.config.ts`: shebang は stub 側に移管できるので bin 専用 wrap config を消し 1 wrap に統合

## 検証

`node_modules` と `packages/*/dist` を完全削除してから `CI=true pnpm install`:

| 項目 | 修正前 | 修正後 |
|---|---|---|
| `nozo-eslint-init` の WARN | 出る | **出ない** |

shim も期待通り `bin/nozo-eslint-init.js` 経由で配置:

```
node_modules/.bin/nozo-eslint-init
  → ../@nozomiishii/eslint-config/bin/nozo-eslint-init.js
```
