### PR TITLE
fix: stub lefthook-config bins for fresh install

### DIFF
--- a/packages/lefthook-config/bin/nozo-git-harvest.js
+++ b/packages/lefthook-config/bin/nozo-git-harvest.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "../dist/cli.js";

--- a/packages/lefthook-config/bin/nozo-lefthook-init.js
+++ b/packages/lefthook-config/bin/nozo-lefthook-init.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "../dist/init/bin.js";

--- a/packages/lefthook-config/package.json
+++ b/packages/lefthook-config/package.json
@@ -22,10 +22,11 @@
   },
   "main": "recommended.yaml",
   "bin": {
-    "nozo-git-harvest": "./dist/cli.js",
-    "nozo-lefthook-init": "./dist/init/bin.js"
+    "nozo-git-harvest": "./bin/nozo-git-harvest.js",
+    "nozo-lefthook-init": "./bin/nozo-lefthook-init.js"
   },
   "files": [
+    "bin",
     "dist",
     "hooks",
     "recommended.yaml",

--- a/packages/lefthook-config/tsdown.config.ts
+++ b/packages/lefthook-config/tsdown.config.ts
@@ -1,26 +1,14 @@
 import { defineConfig } from "tsdown";
 
-const base = defineConfig({
+export default defineConfig({
+  clean: true,
+  dts: true,
+  entry: {
+    cli: "src/cli.ts",
+    "init/bin": "src/init/bin.ts",
+    "init/index": "src/init/index.ts",
+  },
   format: ["esm"],
-  platform: "node",
   outExtensions: () => ({ js: ".js" }),
+  platform: "node",
 });
-
-export default defineConfig([
-  {
-    ...base,
-    entry: { "init/index": "src/init/index.ts" },
-    dts: true,
-    clean: true,
-  },
-  {
-    ...base,
-    entry: {
-      "cli": "src/cli.ts",
-      "init/bin": "src/init/bin.ts",
-    },
-    dts: false,
-    clean: false,
-    banner: { js: "#!/usr/bin/env node" },
-  },
-]);


### PR DESCRIPTION
## 概要

- lefthook-config の bin (`nozo-git-harvest`, `nozo-lefthook-init`) を `bin/*.js` の薄い stub に変更
- [#2242](https://github.com/nozomiishii/configs/pull/2242) と同じ pattern。fresh install で `[WARN] Failed to create bin` が出ないようにする
- 根本原因と方針の詳細は #2242 を参照

## 変更内容

- `packages/lefthook-config/bin/nozo-git-harvest.js` を新設
- `packages/lefthook-config/bin/nozo-lefthook-init.js` を新設
- `packages/lefthook-config/package.json`: `bin` を stub に向け、`files` に `bin` を追加
- `packages/lefthook-config/tsdown.config.ts`: bin 専用 wrap config を消し 1 wrap に統合

## 検証

`node_modules` と `packages/*/dist` を完全削除してから `CI=true pnpm install`:

| 項目 | 修正前 | 修正後 |
|---|---|---|
| `nozo-git-harvest` の WARN | 出る | **出ない** |
| `nozo-lefthook-init` の WARN | 出る | **出ない** |
