### PR TITLE
fix: stub prettier-config bin for fresh install

### DIFF
--- a/packages/prettier-config/bin/nozo-prettier-init.js
+++ b/packages/prettier-config/bin/nozo-prettier-init.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "../dist/init/bin.js";

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -22,9 +22,10 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "nozo-prettier-init": "./dist/init/bin.js"
+    "nozo-prettier-init": "./bin/nozo-prettier-init.js"
   },
   "files": [
+    "bin",
     "dist",
     "starter.ts",
     "README.md"

--- a/packages/prettier-config/tsdown.config.ts
+++ b/packages/prettier-config/tsdown.config.ts
@@ -1,26 +1,14 @@
 import { defineConfig } from "tsdown";
 
-const base = defineConfig({
+export default defineConfig({
+  clean: true,
+  dts: true,
+  entry: {
+    index: "src/index.ts",
+    "init/bin": "src/init/bin.ts",
+    "init/index": "src/init/index.ts",
+  },
   format: ["esm"],
-  platform: "node",
   outExtensions: () => ({ js: ".js", dts: ".d.ts" }),
+  platform: "node",
 });
-
-export default defineConfig([
-  {
-    ...base,
-    entry: {
-      "index": "src/index.ts",
-      "init/index": "src/init/index.ts",
-    },
-    dts: true,
-    clean: true,
-  },
-  {
-    ...base,
-    entry: { "init/bin": "src/init/bin.ts" },
-    dts: false,
-    clean: false,
-    banner: { js: "#!/usr/bin/env node" },
-  },
-]);


### PR DESCRIPTION
## 概要

- prettier-config の bin (`nozo-prettier-init`) を `bin/nozo-prettier-init.js` の薄い stub に変更
- [#2242](https://github.com/nozomiishii/configs/pull/2242) と同じ pattern。fresh install で `[WARN] Failed to create bin` が出ないようにする
- 根本原因と方針の詳細は #2242 を参照

## 変更内容

- `packages/prettier-config/bin/nozo-prettier-init.js` を新設
- `packages/prettier-config/package.json`: `bin` を stub に向け、`files` に `bin` を追加
- `packages/prettier-config/tsdown.config.ts`: bin 専用 wrap config を消し 1 wrap に統合

## 検証

`node_modules` と `packages/*/dist` を完全削除してから `CI=true pnpm install`:

| 項目 | 修正前 | 修正後 |
|---|---|---|
| `nozo-prettier-init` の WARN | 出る | **出ない** |
