### PR TITLE
fix: stub postinstall bins for fresh install

### DIFF
--- a/packages/postinstall/bin/nozo-postinstall-init.js
+++ b/packages/postinstall/bin/nozo-postinstall-init.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "../dist/init/bin.js";

--- a/packages/postinstall/bin/postinstall.js
+++ b/packages/postinstall/bin/postinstall.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "../dist/index.js";

--- a/packages/postinstall/package.json
+++ b/packages/postinstall/package.json
@@ -21,10 +21,11 @@
   },
   "types": "./dist/index.d.ts",
   "bin": {
-    "postinstall": "./dist/index.js",
-    "nozo-postinstall-init": "./dist/init/bin.js"
+    "nozo-postinstall-init": "./bin/nozo-postinstall-init.js",
+    "postinstall": "./bin/postinstall.js"
   },
   "files": [
+    "bin",
     "dist",
     "README.md"
   ],

--- a/packages/postinstall/tsdown.config.ts
+++ b/packages/postinstall/tsdown.config.ts
@@ -1,26 +1,14 @@
 import { defineConfig } from "tsdown";
 
-const base = defineConfig({
+export default defineConfig({
+  clean: true,
+  dts: true,
+  entry: {
+    index: "src/index.ts",
+    "init/bin": "src/init/bin.ts",
+    "init/index": "src/init/index.ts",
+  },
   format: ["esm"],
-  platform: "node",
   outExtensions: () => ({ js: ".js", dts: ".d.ts" }),
+  platform: "node",
 });
-
-export default defineConfig([
-  {
-    ...base,
-    entry: { "init/index": "src/init/index.ts" },
-    dts: true,
-    clean: true,
-  },
-  {
-    ...base,
-    entry: {
-      "index": "src/index.ts",
-      "init/bin": "src/init/bin.ts",
-    },
-    dts: false,
-    clean: false,
-    banner: { js: "#!/usr/bin/env node" },
-  },
-]);


### PR DESCRIPTION
## 概要

- postinstall パッケージの bin (`postinstall`, `nozo-postinstall-init`) を `bin/*.js` の薄い stub に変更
- [#2242](https://github.com/nozomiishii/configs/pull/2242) と同じ pattern。これで bin-stub rollout が **全 config パッケージで完了** ([#2242](https://github.com/nozomiishii/configs/pull/2242), [#2243](https://github.com/nozomiishii/configs/pull/2243), [#2244](https://github.com/nozomiishii/configs/pull/2244), [#2245](https://github.com/nozomiishii/configs/pull/2245), 本 PR)
- 根本原因と方針の詳細は #2242 を参照

## 変更内容

- `packages/postinstall/bin/postinstall.js` を新設
- `packages/postinstall/bin/nozo-postinstall-init.js` を新設
- `packages/postinstall/package.json`: `bin` を stub に向け、`files` に `bin` を追加
- `packages/postinstall/tsdown.config.ts`: bin 専用 wrap config を消し 1 wrap に統合

## 検証

`node_modules` と `packages/*/dist` を完全削除してから `CI=true pnpm install`:

| 項目 | 修正前 | 修正後 |
|---|---|---|
| `postinstall` の WARN | 出る | **出ない** |
| `nozo-postinstall-init` の WARN | 出る | **出ない** |

## フォローアップ

5 PR がすべて merge されたら、memory `project_worktree_postinstall_shim.md` を削除する予定 (workaround 手順が不要になるため)。
