### PR TITLE
fix: quote --edit arg in lefthook-config commitlint hook

### DIFF
--- a/packages/lefthook-config/hooks/commit-msg/commitlint.yaml
+++ b/packages/lefthook-config/hooks/commit-msg/commitlint.yaml
@@ -1,4 +1,4 @@
 commit-msg:
   jobs:
     - name: commitlint
-      run: node_modules/.bin/nozo-commitlint --edit {1} --verbose
+      run: node_modules/.bin/nozo-commitlint --edit "{1}" --verbose


### PR DESCRIPTION
## 概要

`@nozomiishii/lefthook-config` の `hooks/commit-msg/commitlint.yaml` で `{1}` プレースホルダがクオートされておらず、リポジトリパスにスペースが含まれているとシェルが引数を分割してしまい、commitlint が `Unknown argument: ...` で失敗する問題を修正。

## 背景

iCloud 同期のディレクトリ（`Library/Mobile Documents/...`）に置かれた vault リポジトリで commit しようとすると、以下のエラーで失敗していた:

```
Unknown argument: Documents/iCloud~md~obsidian/Documents/.git/COMMIT_EDITMSG
```

原因は `commit-msg.jobs[].run` に書かれている `nozo-commitlint --edit {1} --verbose` の `{1}` がクオートされておらず、`{1}` が `/Users/.../Library/Mobile Documents/.../COMMIT_EDITMSG` に展開された後、`Mobile` と `Documents/...` でシェルが word-split し、`commitlint` が複数の引数として受け取ってしまうため。

## 変更点

- `packages/lefthook-config/hooks/commit-msg/commitlint.yaml`: `{1}` をダブルクオートで囲む（`"{1}"`）

## 動作確認

- 修正後、iCloud パス配下の repo（vault）で `git commit` が通ることを確認
- スペースを含まない通常のパスでも引き続き正常動作（クオート追加は無害）
