### PR TITLE
chore: host eslint config inspector on github pages

### DIFF
--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -1,4 +1,4 @@
-name: Pages
+name: GitHub Pages
 
 # Prerequisite (one-time, manual): repository Settings → Pages → Source must be set to "GitHub Actions".
 # The default GITHUB_TOKEN cannot toggle this; the workflow assumes it is already enabled.
@@ -10,12 +10,12 @@ on:
       - main
     paths:
       - "packages/eslint-config/**"
-      - ".github/workflows/pages.yaml"
+      - ".github/workflows/github-pages.yaml"
 
 permissions: {}
 
 concurrency:
-  group: pages
+  group: github-pages
   cancel-in-progress: false
 
 defaults:

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,73 @@
+name: Pages
+
+# Prerequisite (one-time, manual): repository Settings → Pages → Source must be set to "GitHub Actions".
+# The default GITHUB_TOKEN cannot toggle this; the workflow assumes it is already enabled.
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/eslint-config/**"
+      - ".github/workflows/pages.yaml"
+
+permissions: {}
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-slim
+    timeout-minutes: 10
+
+    permissions:
+      contents: read # required by actions/checkout to fetch repository code
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
+        with:
+          working-directory: packages/eslint-config
+
+      - name: Build eslint config inspector
+        working-directory: packages/eslint-config
+        run: pnpx @eslint/config-inspector build --base /configs/eslint/ --outDir ../../_site/eslint
+
+      - name: Configure Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+
+    permissions:
+      pages: write # required by actions/deploy-pages to publish the uploaded artifact
+      id-token: write # required by actions/deploy-pages for OIDC verification of the artifact
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ dist
 .eslint-config-inspector
 eslint-typegen.d.ts
 
-# GitHub Pages artifact (built by .github/workflows/github-pages.yaml)
+# GitHub Pages artifact
 _site
 
 # Claude Code

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ dist
 .eslint-config-inspector
 eslint-typegen.d.ts
 
-# GitHub Pages artifact (built by .github/workflows/pages.yaml)
+# GitHub Pages artifact (built by .github/workflows/github-pages.yaml)
 _site
 
 # Claude Code

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ dist
 .eslint-config-inspector
 eslint-typegen.d.ts
 
+# GitHub Pages artifact (built by .github/workflows/pages.yaml)
+_site
+
 # Claude Code
 **/.claude/settings.local.json
 **/CLAUDE.local.md

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -46,7 +46,6 @@
     "lint:fix": "pnpm eslint . --fix",
     "prepare": "pnpm run typegen",
     "prepublishOnly": "pnpm run build && pnpm run build:inspector",
-    "start": "pnpx serve dist/__eslint-config-inspector",
     "test": "vitest run",
     "typegen": "node --import @swc-node/register/esm-register scripts/typegen.ts"
   },


### PR DESCRIPTION
## Summary

- `.github/workflows/pages.yaml` を追加し、`@eslint/config-inspector build` の成果物を GitHub Pages に静的ホストする
- 公開 URL: https://nozomiishii.github.io/configs/eslint/
- trigger: `main` への push のうち `packages/eslint-config/**` または `.github/workflows/pages.yaml` が変わった時、および `workflow_dispatch`
- 並行で `_site/` を gitignore に追加（CI / ローカル両方の build artifact 置き場）
- ついでに `packages/eslint-config/package.json` から `start` script を削除。`pnpx serve dist/__eslint-config-inspector` を呼ぶだけのスクリプトで、Pages 公開後は日常的に `pnpm dev`（live inspector）で代替できるため

## 構造

- `_site/eslint/` 配下に inspector の SPA を配置（`actions/upload-pages-artifact` の `path` は `_site`）
- 将来 `prettier-config` などを足したい場合は `_site/<package>/` に build を増設すれば同じ `https://nozomiishii.github.io/configs/<package>/` パターンで増やせる
- inspector は `--base /configs/eslint/` で焼くため、asset 参照が `/configs/eslint/*` 固定になる

## 一度きりの手動セットアップ（実施済み）

- repo Settings → Pages → Source = "GitHub Actions"
- `GITHUB_TOKEN` ではトグルできないので必須の手作業（リポジトリオーナーのみ可）

## Follow-up（別 PR で出す）

- `build:inspector` script と `prepublishOnly` の inspector bundle を整理する。現状 `prepublishOnly` が `pnpm run build:inspector` を呼んでいて、`files: ["dist", ...]` 経由で npm tarball に SPA が同梱されている。Pages で公開された以上、npm 側に重複バンドルする意味が薄いため、別 PR で `prepublishOnly` を `pnpm run build` のみに整理する

## Test plan

- [x] ローカルで `pnpm exec eslint-config-inspector build --base /configs/eslint/ --outDir ../../_site/eslint` が成功し、`_site/eslint/index.html` 内の asset href が `/configs/eslint/*` 始まりになることを確認
- [ ] PR がマージされ main push が走った後、Pages workflow が green になることを確認
- [ ] https://nozomiishii.github.io/configs/eslint/ が開けることを確認
