### PR TITLE
chore: drop bundled inspector spa from eslint config tarball

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -37,7 +37,6 @@
   ],
   "scripts": {
     "build": "tsdown",
-    "build:inspector": "pnpx @eslint/config-inspector build",
     "check:ts": "tsc",
     "dev": "pnpm typegen && eslint --inspect-config",
     "eslint": "eslint --max-warnings=0",
@@ -45,7 +44,7 @@
     "lint": "pnpm eslint .",
     "lint:fix": "pnpm eslint . --fix",
     "prepare": "pnpm run typegen",
-    "prepublishOnly": "pnpm run build && pnpm run build:inspector",
+    "prepublishOnly": "pnpm run build",
     "test": "vitest run",
     "typegen": "node --import @swc-node/register/esm-register scripts/typegen.ts"
   },


### PR DESCRIPTION
## Summary

- `packages/eslint-config/package.json` から `build:inspector` スクリプトを削除
- `prepublishOnly` を `pnpm run build && pnpm run build:inspector` → `pnpm run build` に簡略化
- npm publish 時に `dist/__eslint-config-inspector` 配下の inspector SPA を焼かなくなる → published tarball から SPA バンドルが消える

## Why

- inspector は GitHub Pages にホストされ ([#2273](https://github.com/nozomiishii/configs/pull/2273))、`https://nozomiishii.github.io/configs/eslint/` で常時参照できるようになった
- npm tarball に SPA を同梱しても利用シーンがなく、`files: ["dist", ...]` 経由で数 MB のフロントエンド資産を package サイズに乗せていただけだった
- インストール時間と npm 上の表示サイズの両方が小さくなる
- ローカルでの動作確認は `pnpm dev`（live inspector）でカバーできる

## Notes for release-please

- これは「ユーザー（npm 利用者）が観測する内容」を変える変更だが、機能 API は変わらず、付属物（dist 内 SPA）の削除のみ。互換性破壊ではないので **`chore:`** で出している（`BREAKING CHANGE` ノートも付けない）。bump としては patch 相当の挙動になる想定
- 参考: CLAUDE.md「`BREAKING CHANGE:` フッターと `feat!:` / `fix!:` の `!` は、リリースされるパッケージ・公開アセットの互換性を破る変更にのみ使用する」

## Depends on / 順序

- [#2273](https://github.com/nozomiishii/configs/pull/2273) を先にマージしてからこちらを rebase → マージするのが綺麗。ただし両 PR は独立した行に触っているので、どちらの順でも conflict はしない見込み

## Test plan

- [x] `git diff` で変更が `build:inspector` 行の削除と `prepublishOnly` の右辺変更のみであることを確認
- [ ] CI（lint / type check）が通ることを確認
- [ ] 次の release で生成される npm tarball から `dist/__eslint-config-inspector` が消えていることを確認
