### PR TITLE
chore: pin ci node version to root package.json

### DIFF
--- a/.github/actions/setup-node/action.yaml
+++ b/.github/actions/setup-node/action.yaml
@@ -1,12 +1,6 @@
 name: "Node.js with pnpm"
 description: "Setup Node.js and install dependencies using pnpm"
 
-inputs:
-  working-directory:
-    description: "keyword specifies the working directory where the command is run."
-    required: false
-    default: "."
-
 runs:
   using: "composite"
 
@@ -17,16 +11,14 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version-file: ${{ inputs.working-directory }}/package.json
+        node-version-file: package.json
         # Required for publishing packages to npm
         registry-url: "https://registry.npmjs.org"
 
     - name: Install dependencies
       shell: bash
       run: pnpm install --frozen-lockfile --ignore-scripts
-      working-directory: ${{ inputs.working-directory }}
 
     - name: Build workspace packages
       shell: bash
       run: pnpm -r run build
-      working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/eslint-config.yaml
+++ b/.github/workflows/eslint-config.yaml
@@ -45,8 +45,6 @@ jobs:
       - name: Setup Node
         if: steps.changes.outputs.src == 'true'
         uses: ./.github/actions/setup-node
-        with:
-          working-directory: packages/eslint-config
 
       - name: Lint
         if: steps.changes.outputs.src == 'true'

--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -38,8 +38,6 @@ jobs:
 
       - name: Setup Node
         uses: ./.github/actions/setup-node
-        with:
-          working-directory: packages/eslint-config
 
       - name: Build eslint config inspector
         working-directory: packages/eslint-config

--- a/.github/workflows/postinstall.yaml
+++ b/.github/workflows/postinstall.yaml
@@ -45,8 +45,6 @@ jobs:
       - name: Setup Node
         if: steps.changes.outputs.src == 'true'
         uses: ./.github/actions/setup-node
-        with:
-          working-directory: packages/postinstall
 
       - name: Test
         if: steps.changes.outputs.src == 'true'


### PR DESCRIPTION
## Summary

- `.github/actions/setup-node` の `node-version-file` を**常にリポジトリルートの `package.json`** を読むように固定。ルートの `engines.node: 24.15.0` (ピン) が CI 上の node バージョンとして必ず効くようになる。
- composite action の `working-directory` input を撤廃。`pnpm install --frozen-lockfile --ignore-scripts` と `pnpm -r run build` をルート実行に変更（pnpm workspace の前提に合わせる）。
- `eslint-config.yaml` / `postinstall.yaml` / `github-pages.yaml` の setup-node 呼び出しから `working-directory` 引数を削除。後段の `pnpm lint` / `pnpm test` / `pnpx @eslint/config-inspector build` は workflow 側の `defaults.run.working-directory` または step 単位の `working-directory` で従来どおり個別パッケージで動く。

## Why

`actions/setup-node` の `node-version-file` に個別パッケージの `package.json` を渡していたため、`packages/eslint-config` (`>=24.0.0`) や `packages/nozo` (`>=24.0.0`) などの **range 指定** が CI の node バージョン解決に使われ、ジョブごとに node が揺れる構造になっていた（ルートの `24.15.0` ピンが効くのは引数なしで呼ばれるジョブだけ）。

`engines.node` には 2 つの意味が混在している:

1. **開発・CI で使う node** — ルート package.json の `24.15.0` ピン
2. **publish 後に consumer が動かせる最低 node** — 個別パッケージの `>=24.0.0` 等の range

(2) の range は公開パッケージの consumer 向け契約として有用なので残し、(1) として使うものをルートに一本化する形に整える。

## Test plan

- [ ] `eslint-config` / `postinstall` / `github-pages` workflow が green
- [ ] `setting-files` / `markdown` / `release` workflow（元々ルート参照だった）の挙動に変化がないこと
- [ ] CI のセットアップログで使われる node が `24.15.0` 固定であること
