### PR TITLE
chore: rename cleanup-merged hook to cleanup-worktrees-and-branches

### DIFF
--- a/packages/lefthook-config/README.ja.md
+++ b/packages/lefthook-config/README.ja.md
@@ -26,7 +26,7 @@ pnpx nozo init
 
 これで `lefthook` と `@nozomiishii/lefthook-config` が pin で `devDependencies` に追加され、推奨プリセットを extend する `lefthook.yaml` が生成される。
 
-補助的なランタイム（現在は `cleanup-merged` post-merge フラグメントで使う `git-harvest`）は、このパッケージの `bin` フィールドが提供する shim でラップされており、利用側が直接 dependency に追加しなくても `node_modules/.bin/nozo-*` として公開されます。
+補助的なランタイム（現在は `cleanup-worktrees-and-branches` post-merge フラグメントで使う `git-harvest`）は、このパッケージの `bin` フィールドが提供する shim でラップされており、利用側が直接 dependency に追加しなくても `node_modules/.bin/nozo-*` として公開されます。
 
 ## プリセット全体を使う
 
@@ -57,7 +57,7 @@ extends:
 
 - `hooks/commit-msg/commitlint.yaml` — `nozo-commitlint`（`@nozomiishii/commitlint-config` が提供）を実行
 - `hooks/post-merge/update-node-modules.yaml` — pnpm > bun > npm > yarn
-- `hooks/post-merge/cleanup-merged.yaml` — このパッケージが提供する `nozo-git-harvest` shim 経由で [`git-harvest`](https://github.com/nozomiishii/git-harvest) を実行
+- `hooks/post-merge/cleanup-worktrees-and-branches.yaml` — このパッケージが提供する `nozo-git-harvest` shim 経由で [`git-harvest`](https://github.com/nozomiishii/git-harvest) を実行
 - `hooks/pre-commit/yaml.yaml` — ステージしたファイルが `.yml` 拡張子だった場合にコミットを失敗させる（`.yaml` を強制）
 
 ## 設定を書く際のルール（重要）

--- a/packages/lefthook-config/README.md
+++ b/packages/lefthook-config/README.md
@@ -31,8 +31,9 @@ This adds `lefthook` and `@nozomiishii/lefthook-config` to your
 `devDependencies` (pinned) and writes a `lefthook.yaml` that extends the
 recommended preset.
 
-Auxiliary runtimes (currently `git-harvest`, used by the `cleanup-merged`
-post-merge fragment) are wrapped by shims that this package ships under
+Auxiliary runtimes (currently `git-harvest`, used by the
+`cleanup-worktrees-and-branches` post-merge fragment) are wrapped by
+shims that this package ships under
 its own `bin` field, so they are exposed as `node_modules/.bin/nozo-*`
 without requiring consumers to add them as direct dependencies.
 
@@ -65,7 +66,7 @@ extends:
 
 - `hooks/commit-msg/commitlint.yaml` — runs `nozo-commitlint` (provided by `@nozomiishii/commitlint-config`)
 - `hooks/post-merge/update-node-modules.yaml` — pnpm > bun > npm > yarn
-- `hooks/post-merge/cleanup-merged.yaml` — runs [`git-harvest`](https://github.com/nozomiishii/git-harvest) via the `nozo-git-harvest` shim shipped by this package
+- `hooks/post-merge/cleanup-worktrees-and-branches.yaml` — runs [`git-harvest`](https://github.com/nozomiishii/git-harvest) via the `nozo-git-harvest` shim shipped by this package
 - `hooks/pre-commit/yaml.yaml` — fails the commit when staged files use the `.yml` extension (enforces `.yaml`)
 
 ## Authoring rules (important)

--- a/packages/lefthook-config/hooks/post-merge/cleanup-worktrees-and-branches.yaml
+++ b/packages/lefthook-config/hooks/post-merge/cleanup-worktrees-and-branches.yaml
@@ -1,4 +1,4 @@
 post-merge:
   jobs:
-    - name: cleanup-merged
+    - name: cleanup-worktrees-and-branches
       run: node_modules/.bin/nozo-git-harvest

--- a/packages/lefthook-config/recommended.yaml
+++ b/packages/lefthook-config/recommended.yaml
@@ -12,7 +12,7 @@
 extends:
   - node_modules/@nozomiishii/lefthook-config/hooks/commit-msg/commitlint.yaml
   - node_modules/@nozomiishii/lefthook-config/hooks/post-merge/update-node-modules.yaml
-  - node_modules/@nozomiishii/lefthook-config/hooks/post-merge/cleanup-merged.yaml
+  - node_modules/@nozomiishii/lefthook-config/hooks/post-merge/cleanup-worktrees-and-branches.yaml
   - node_modules/@nozomiishii/lefthook-config/hooks/pre-commit/yaml.yaml
 
 commit-msg:


### PR DESCRIPTION
## Summary

- `@nozomiishii/lefthook-config` の post-merge フックフラグメントを `cleanup-merged` から `cleanup-worktrees-and-branches` に rename
- ファイル名・job 名・`recommended.yaml` の extends パス・README (en/ja) の参照をすべて同期
- 既存の挙動 (`nozo-git-harvest` 実行) は変更なし

## Why

旧名 `cleanup-merged` は「何が merged されてて、何を cleanup するのか」が曖昧だった。実体は `git-harvest` が「merge 済みのローカルブランチ削除 + それに紐づく worktree の prune」を行うので、対象を明示する名前に変更した。

## Impact

- `recommended.yaml` 経由で使っている consumer は次回パッケージ更新時に自動で新パスへ追随するため影響なし
- フラグメントを直接 cherry-pick している consumer (`hooks/post-merge/cleanup-merged.yaml` をパス指定) はパスを書き換える必要あり
- CHANGELOG.md の過去エントリ内の `cleanup-merged` 表記は履歴なのでそのまま残置

## Test plan

- [ ] CI green (commitlint / semantic PR / lint / build)
- [ ] release-please による次回バンプで `lefthook-config` 側のみ更新されることを確認
