### PR TITLE
feat: add prettier --cache to init scripts

### DIFF
--- a/packages/prettier-config/src/init/index.test.ts
+++ b/packages/prettier-config/src/init/index.test.ts
@@ -50,15 +50,15 @@ test("init adds prettier to devDependencies", ({ initResult }) => {
 });
 
 test("init adds format script", ({ initResult }) => {
-  expect(initResult.pkg.scripts?.format).toBe("pnpm prettier . --check --cache");
+  expect(initResult.pkg.scripts?.format).toBe("pnpm prettier . --check");
 });
 
 test("init adds format:fix script", ({ initResult }) => {
-  expect(initResult.pkg.scripts?.["format:fix"]).toBe("pnpm prettier . --write --cache");
+  expect(initResult.pkg.scripts?.["format:fix"]).toBe("pnpm prettier . --write");
 });
 
 test("init adds prettier script", ({ initResult }) => {
-  expect(initResult.pkg.scripts?.prettier).toBe("prettier --ignore-unknown");
+  expect(initResult.pkg.scripts?.prettier).toBe("prettier --ignore-unknown --cache");
 });
 
 test("init generates prettier.config.ts", ({ initResult }) => {

--- a/packages/prettier-config/src/init/index.test.ts
+++ b/packages/prettier-config/src/init/index.test.ts
@@ -50,11 +50,11 @@ test("init adds prettier to devDependencies", ({ initResult }) => {
 });
 
 test("init adds format script", ({ initResult }) => {
-  expect(initResult.pkg.scripts?.format).toBe("pnpm prettier . --check");
+  expect(initResult.pkg.scripts?.format).toBe("pnpm prettier . --check --cache");
 });
 
 test("init adds format:fix script", ({ initResult }) => {
-  expect(initResult.pkg.scripts?.["format:fix"]).toBe("pnpm prettier . --write");
+  expect(initResult.pkg.scripts?.["format:fix"]).toBe("pnpm prettier . --write --cache");
 });
 
 test("init adds prettier script", ({ initResult }) => {

--- a/packages/prettier-config/src/init/index.ts
+++ b/packages/prettier-config/src/init/index.ts
@@ -36,8 +36,8 @@ export async function init({ cwd }: InitOptions): Promise<void> {
 
   target.scripts = {
     ...target.scripts,
-    "format": "pnpm prettier . --check",
-    "format:fix": "pnpm prettier . --write",
+    "format": "pnpm prettier . --check --cache",
+    "format:fix": "pnpm prettier . --write --cache",
     "prettier": "prettier --ignore-unknown",
   };
 

--- a/packages/prettier-config/src/init/index.ts
+++ b/packages/prettier-config/src/init/index.ts
@@ -36,9 +36,9 @@ export async function init({ cwd }: InitOptions): Promise<void> {
 
   target.scripts = {
     ...target.scripts,
-    "format": "pnpm prettier . --check --cache",
-    "format:fix": "pnpm prettier . --write --cache",
-    "prettier": "prettier --ignore-unknown",
+    "format": "pnpm prettier . --check",
+    "format:fix": "pnpm prettier . --write",
+    "prettier": "prettier --ignore-unknown --cache",
   };
 
   await writeFile(targetPath, `${JSON.stringify(target, null, 2)}\n`);


### PR DESCRIPTION
## 概要

`@nozomiishii/prettier-config` の `nozo-prettier-init` が生成する scripts に Prettier の `--cache` flag を追加する。`--cache` は `prettier` script (`prettier --ignore-unknown --cache`) に集約し、`format` / `format:fix` script は action (`--check` / `--write`) のみを持つ責務分離構成を採る。

```jsonc
{
  "scripts": {
    "format": "pnpm prettier . --check",
    "format:fix": "pnpm prettier . --write",
    "prettier": "prettier --ignore-unknown --cache"
  }
}
```

`pnpm prettier . --check` は内部的に `prettier --ignore-unknown --cache . --check` に展開されるため、`--cache` は実質 `format` / `format:fix` どちらの経路でも有効になる。

## 背景

Prettier の `--cache` (2.7+) は config option ではなく CLI flag でしか有効化できないため、shared config 側で provide するには init template の scripts に書き込む以外に方法がない (config option 化は [prettier#18089](https://github.com/prettier/prettier/issues/18089) で議論中)。

事例: 14k ファイル規模で `90s → 17s` の高速化。

`--cache-location` は指定せず default (`node_modules/.cache/prettier/.prettier-cache`) を使う。`node_modules` は通常 `.gitignore` 済みのため追加対応不要。

## 動機

Issue #2196 P1 (high) の対応。

## 影響範囲

- 既存 consumer (既に `nozo init` 済み repo): 影響なし。再度 `nozo init` した時のみ反映される。
- 新規 consumer: format / format:fix が cache hit ぶん速くなる。

refs #2196
