### PR TITLE
chore: document prettier-config policy decisions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,10 +26,23 @@
 - setup / teardown は `beforeEach` / `afterEach` などの hook を避け、vitest の [`test.extend`](https://vitest.dev/guide/test-context.html) による fixture で書く。各 test が context 経由で依存を明示的に受け取ることで、test 間の hidden state（密結合）を排除する。
 - 既存テストが `tests/` 配下にあるパッケージは、新規テストから順次同階層配置に移行する。
 
-## packages/prettier-config: requirePragma による除外方針
+## packages/prettier-config: 運用方針
+
+### `requirePragma` による除外方針
 
 - `packages/prettier-config/src/index.ts` の `overrides` で `pnpm-lock.yaml` / `submodules/**` / `next-env.d.ts` / `*.md` / `*.mdx` を `requirePragma: true` で除外している。
 - これは `.prettierignore` を導入すると `.gitignore` と二重管理になり、片方だけ更新する事故を起こしやすいため、「明らかに format 不要」と分かりきっているものは shareable config 側で `requirePragma` を使って一括除外する方針を採っている（Prettier の一般的慣習からは離れるが意図的）。
+- 同じ理由から Prettier 3.6 で追加された `checkIgnorePragma` (`@noformat` / `@noprettier`) も採用しない。opt-out の入り口を増やすだけで `.prettierignore` 問題そのものは解決しないため。
+
+### experimental option は採用しない
+
+- Prettier の `experimental*` 系オプション (`experimentalOperatorPosition` / `experimentalTernaries` など) は今回も今後も採用しない。formatter は出力が揃ってさえいれば挙動の細部はどうでもよく、stable 化されて default になるのを待てば足りる。
+- ユーザー判断の文脈: formatter (Prettier / Biome / oxfmt) の覇権争いが落ち着くまでは experimental に乗らない方針。
+
+### oxfmt への移行方針
+
+- 将来的に [oxfmt](https://oxc.rs/) (Prettier 100% 互換、import sort 内蔵) に移行する意図はある。トリガーは **oxlint が ESLint のルールを完全に飲み込んだとき**。それまでは Prettier を使い続ける。
+- oxfmt は Prettier の config をそのまま受け取れる設計のため、本パッケージの設定は移行時にほぼそのまま流用できる見込み。逆に oxfmt 互換ではない Prettier plugin を増やすほど将来の移行コストが上がるため、必須でない plugin (`prettier-plugin-tailwindcss` / `prettier-plugin-sh` 等) は追加しない方針。
 
 ## リリース・Conventional Commits
 

--- a/packages/prettier-config/README.ja.md
+++ b/packages/prettier-config/README.ja.md
@@ -27,3 +27,39 @@ pnpx nozo init
 ## 同梱プラグイン
 
 - [prettier-plugin-packagejson](https://www.npmjs.com/package/prettier-plugin-packagejson)
+
+## ポリシー
+
+### ファイル除外: `.prettierignore` ではなく `requirePragma` を使う
+
+format 対象外にしたいファイル (`pnpm-lock.yaml` / `submodules/**` /
+`next-env.d.ts` / `*.md` / `*.mdx`) は、このパッケージの `overrides` で
+`requirePragma: true` を指定することで除外している。`.prettierignore`
+ファイルは作らない。
+
+`.prettierignore` を導入すると `.gitignore` と二重管理になり、片方だけ
+更新する事故を起こしやすい。Prettier 3.x は `.gitignore` を自動で尊重
+するため、ほとんどの ignore は `.gitignore` だけで足りる。
+
+同じ理由から、Prettier 3.6 で追加された `checkIgnorePragma`
+(`@noformat` / `@noprettier`) は採用しない。opt-out の入り口を増やす
+だけで、`.prettierignore` 問題そのものは解決しないため。
+
+### experimental option は採用しない
+
+Prettier の `experimental*` 系オプション
+(`experimentalOperatorPosition` / `experimentalTernaries` など) は今回
+も今後も採用しない。formatter は出力が揃ってさえいれば挙動の細部は
+どうでもよく、stable 化されて default になるのを待つだけで十分。
+experimental の挙動変化を追いかける価値はない。
+
+### oxfmt への移行方針
+
+将来的に [oxfmt](https://oxc.rs/) (OXC プロジェクトの Prettier 互換
+formatter) に移行する意図はある。トリガーは **oxlint が ESLint の
+ルールを完全に飲み込んだとき**。それまでは Prettier を使い続ける。
+
+oxfmt は Prettier の config をそのまま受け取れる設計のため、本
+パッケージの設定は移行時にほぼそのまま流用できる見込み。逆に、
+oxfmt 互換ではない Prettier plugin を増やすほど将来の移行コストが
+上がるため、必須でない plugin は追加しない方針。

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -30,3 +30,38 @@ re-exports the shared config.
 ## Included Plugins
 
 - [prettier-plugin-packagejson](https://www.npmjs.com/package/prettier-plugin-packagejson)
+
+## Policy
+
+### File exclusion: `requirePragma` over `.prettierignore`
+
+Files that should never be formatted (`pnpm-lock.yaml`, `submodules/**`,
+`next-env.d.ts`, `*.md`, `*.mdx`) are excluded via `requirePragma: true`
+overrides in this config rather than a `.prettierignore` file.
+
+A `.prettierignore` would duplicate patterns already in `.gitignore` and
+invite drift between the two. Prettier 3.x already honors `.gitignore`
+automatically, so most ignore needs are covered without a dedicated file.
+
+For the same reason, the Prettier 3.6 `checkIgnorePragma` option
+(`@noformat` / `@noprettier`) is **not** adopted: it adds another opt-out
+surface without removing the `.prettierignore` problem.
+
+### Experimental options
+
+Prettier's `experimental*` options (e.g. `experimentalOperatorPosition`,
+`experimentalTernaries`) are **not** adopted, now or in the future. We
+wait for them to stabilize and become defaults. Formatting is fine as
+long as it's consistent — there is no value in chasing experimental
+output changes.
+
+### Future migration to oxfmt
+
+We intend to migrate to [oxfmt](https://oxc.rs/) (Prettier-compatible
+formatter from the OXC project) eventually. The trigger is **when oxlint
+has fully absorbed ESLint's rule set**. Until then we stay on Prettier.
+
+Because oxfmt is designed to accept Prettier's config as-is, the
+settings in this package are expected to carry over without changes.
+Adding non-essential Prettier plugins increases future migration cost
+and is avoided.


### PR DESCRIPTION
## 概要

`@nozomiishii/prettier-config` の運用方針を README.md / README.ja.md と親 CLAUDE.md に明文化する。Issue #2196 の P3 / P4 / P5 についての意思決定を文章として残し、次回 audit (8 週後) の再提案を抑制することが目的。

## 内容

- **P3 (却下)**: `checkIgnorePragma` は採用しない。`.prettierignore` を作らず `requirePragma` で除外する現行方針を継続する理由を README に追記。
- **P4 (保留)**: oxfmt への移行意図と「oxlint が ESLint ルールを完全に飲み込んだら」というトリガー条件、および「必須でない Prettier plugin を増やすほど移行コストが上がるため避ける」方針を README に追記。
- **P5 (却下)**: experimental option は今回も今後も採用しない方針を README に追記。

CLAUDE.md 側は既存の「requirePragma による除外方針」セクションを「運用方針」に格上げし、P4 / P5 を併記する構造に再編成した。

## 影響範囲

ドキュメントのみ。config 値および code 挙動の変更なし。consumer 側の format 結果は変わらない。

refs #2196
