### PR TITLE
fix: scope release app token permissions and pin op cli version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,6 @@ jobs:
 
     permissions:
       contents: write # required by release-please-action to create release tags and commits
-      issues: write # required by release-please-action to label release issues
       pull-requests: write # required by release-please-action to open the release PR
 
     outputs:
@@ -38,6 +37,9 @@ jobs:
       - name: Load secrets from 1Password
         id: secrets
         uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          # renovate: datasource=docker depName=1password/op versioning=semver
+          version: "2.34.0"
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           APP_ID: op://github-app/nozomiishii-release/username
@@ -49,6 +51,8 @@ jobs:
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Run release-please
         id: release-please
@@ -79,6 +83,9 @@ jobs:
       - name: Load secrets from 1Password
         id: secrets
         uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          # renovate: datasource=docker depName=1password/op versioning=semver
+          version: "2.34.0"
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           APP_ID: op://github-app/nozomiishii-release/username
@@ -90,6 +97,7 @@ jobs:
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
+          permission-contents: write
 
       - name: Checkout release-please Pull Request
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## 概要

zizmor v1.25 系の 2 つの audit が release workflow を落とすため先回りで正攻法に修正する。

- `github-app` (high): create-github-app-token が blanket なトークンを発行している指摘 → 各 job で必要な permission のみ明示付与
- `unpinned-tools` (medium): 1password/load-secrets-action が op CLI version 未指定 → version を pin

## 変更内容

- `create-github-app-token` に最小権限を付与
  - `release-please` job: `permission-contents: write` + `permission-pull-requests: write`
  - `format` job: `permission-contents: write`（PR ブランチへ push するだけのため contents のみ）
- `1password/load-secrets-action` 2 箇所に op CLI version を pin（renovate annotation 付き、`version: "2.34.0"`）
- `release-please` job の `permissions` から `issues: write` を削除

## 補足

GitHub App (`nozomiishii-release`) には `issues` 権限が付与されていない。`permission-issues` を付けると release が 422 で落ちるため**意図的に付けない**。

## 検証

共有 zizmor config (`nozomiishii/workflows/.github/zizmor.yaml`) を `--persona=auditor` で適用し、`No findings to report` を確認済み。
