### PR TITLE
fix: pin create-github-app-token to v3.1.1 to unblock release

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,6 +17,12 @@
       "matchDepNames": ["node"],
       "matchUpdateTypes": ["minor", "patch"],
       "enabled": false
+    },
+    {
+      "description": "TEMPORARY: freeze actions/create-github-app-token at v3.1.1. v3.2.0 breaks release-please-action's multi-release (monorepo) flow with a 403 on POST /releases. Remove this rule once the v3.2.0 regression is resolved upstream and re-verified.",
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["actions/create-github-app-token"],
+      "enabled": false
     }
   ]
 }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
@@ -93,7 +93,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}


### PR DESCRIPTION
## 概要

release ワークフローの `create-github-app-token` を **v3.2.0 → v3.1.1** に戻す。

monorepo の configs では、release-please-action が複数 release を一括作成する経路で、v3.2.0 の App token だと `Resource not accessible by integration`（403, `POST /releases`）になり release が作成できなくなっていた（[run 26205025231](https://github.com/nozomiishii/configs/actions/runs/26205025231) ほか）。

## 切り分け根拠

- configs 内で 2026-05-13（v3.1.1）は同じ Action・同じ monorepo 構成で 9 release の作成に成功していた。release.yaml 上の変更点は v3.1.1 → v3.2.0（#2284）と権限 scope 化（#2297）のみ。blanket でも scoped でも v3.2.0 では 403。
- 単一 release の workflows / pm（Action・v3.2.0）や git-harvest（CLI・v3.2.0）は成功。**複数 release 一括 × v3.2.0 × release-please-action** の組み合わせでだけ落ちる。
- ruleset / tag 保護 / タグ衝突 / Discussions はいずれも無関係であることを実機確認済み。

## 検証

このブランチをマージし、main への push で release が走った際に 9 release（`@nozomiishii/*-v1.1.0` ほか）が作成されれば v3.2.0 が真因と確定。#2263 はマージ済みなので token を直せば再 run で release は作り直される。

## フォローアップ

- 恒久対応なら Renovate に v3.2.0 への再 bump 抑止ルール（理由コメント付き）を追加する。
- `actions/create-github-app-token` 側へ v3.2.0 の回帰として upstream issue を起票する。
