### PR TITLE
fix: restore issues write permission for release-please job

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,12 +17,6 @@
       "matchDepNames": ["node"],
       "matchUpdateTypes": ["minor", "patch"],
       "enabled": false
-    },
-    {
-      "description": "TEMPORARY: freeze actions/create-github-app-token at v3.1.1. v3.2.0 breaks release-please-action's multi-release (monorepo) flow with a 403 on POST /releases. Remove this rule once the v3.2.0 regression is resolved upstream and re-verified.",
-      "matchManagers": ["github-actions"],
-      "matchDepNames": ["actions/create-github-app-token"],
-      "enabled": false
     }
   ]
 }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,7 @@ jobs:
 
     permissions:
       contents: write # required by release-please-action to create release tags and commits
+      issues: write # required by release-please-action to label release issues
       pull-requests: write # required by release-please-action to open the release PR
 
     outputs:
@@ -47,7 +48,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
@@ -93,7 +94,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}


### PR DESCRIPTION
## 概要

release が `Resource not accessible by integration`（403, `POST /releases`）で止まっている件の切り分け。

直前の検証で **token 版（v3.1.1 / v3.2.0）も scoping（blanket / scoped）も無関係**と判明した。最後に release を作成できていた 2026-05-13 の構成と現在の唯一の素直な差分が **release-please ジョブの `issues: write` 削除**（#2297 で除去）だったため、これを復活させて検証する。

## 変更

- release-please ジョブに `issues: write` を復活（05-13 の動作時と同じ権限構成に戻す）
- `create-github-app-token` を v3.1.1 → v3.2.0 に戻す（v3.1.1 でも 403 となり token 版は無実と確定したため、検証用 pin を解除）
- `.github/renovate.json` の暫定固定ルールを削除

## 期待

マージ後の Release run で 9 release が作成されれば、原因は job 直下 `issues: write` 不足と確定。それでも 403 なら token/権限は無関係で、release-please CLI 化など別経路の検証へ進む。#2263 はマージ済みなので token を直せば release は作り直される。
