### PR TITLE
chore: use default github token for release-please to isolate 403

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,7 +61,9 @@ jobs:
         with:
           config-file: .github/.release-please-config.json
           manifest-file: .github/.release-please-manifest.json
-          token: ${{ steps.app-token.outputs.token }}
+          # DIAGNOSTIC: temporarily use the default GITHUB_TOKEN instead of the app token
+          # to isolate whether the create-release 403 is specific to the GitHub App token.
+          token: ${{ github.token }}
 
       - name: Echo release-please outputs
         if: steps.release-please.outputs


### PR DESCRIPTION
## 概要

release が `Resource not accessible by integration`（403, `POST /releases`）で止まっている件の切り分け（その3）。

token 版（v3.1.1/v3.2.0）・scoping・`issues: write` はいずれも無関係と確定済み。残る分岐は「**GitHub App token そのものが原因か**」。release-please-action の token を一時的に既定の `GITHUB_TOKEN` に差し替えて検証する（**診断目的の一時変更**。検証後に App token へ戻す）。

ジョブ権限は `contents: write` / `issues: write` / `pull-requests: write` を付与済みで、tag/release/PR 作成に必要な権限は満たす。release-please は main へ push せず tag・release・release PR を作るだけなので main ブランチ ruleset には抵触しない。

## 期待

- 9 release が作成されれば → 原因は **App token 固有**で確定。App インストール権限の精査へ。
- それでも 403 なら → token 種別は無関係。action / multi-release / tag 名側の問題（次は CLI 化を検証）。

#2263 はマージ済みなので release は作り直される。
