### PR TITLE
chore: grant permission-issues to release app token and restore app token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,6 +53,7 @@ jobs:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
           permission-contents: write
+          permission-issues: write
           permission-pull-requests: write
 
       - name: Run release-please
@@ -61,9 +62,7 @@ jobs:
         with:
           config-file: .github/.release-please-config.json
           manifest-file: .github/.release-please-manifest.json
-          # DIAGNOSTIC: temporarily use the default GITHUB_TOKEN instead of the app token
-          # to isolate whether the create-release 403 is specific to the GitHub App token.
-          token: ${{ github.token }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Echo release-please outputs
         if: steps.release-please.outputs


### PR DESCRIPTION
## 概要

release 403 切り分け（その4）。App に `issues: write` 権限を付与したので、これまで 422 で試せなかった **`permission-issues: write`（app token 側）+ `issues: write`（job 側）** のパターンを検証する。あわせて #2306 の診断（`token: ${{ github.token }}`）を app token に戻す。

## 変更

- release-please ジョブの app token に `permission-issues: write` を追加（App が issues 権限を付与済みのため 422 にならない）
- release-please の `token` を `github.token` → App token に戻す

## 期待

- 9 release が作成されれば → release-please が release 作成時に issues 権限を要していた、が原因と確定。
- それでも 403 なら → 権限ではなく新 stateless installation token × slash タグの GitHub 側 regression が濃厚（次は `X-GitHub-Stateless-S2S-Token: disabled` での A/B 確認へ）。

#2263 はマージ済みなので release は作り直される。
