### PR TITLE
fix: checkout released tag in publish job to avoid stale republish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,12 @@ jobs:
       prs: ${{ steps.release-please.outputs.prs }}
       releases_created: ${{ steps.release-please.outputs.releases_created }}
       paths_released: ${{ steps.release-please.outputs.paths_released }}
+      # The `nozo` component tag pins the publish job to the exact release commit.
+      # linked-versions force-syncs every component to the same version on each
+      # release, so all per-component tags point at the same commit; `nozo` (the core
+      # CLI) is a stable representative. There is no umbrella tag: the root `.` umbrella
+      # component sets skip-github-release so it produces no release/tag (by design).
+      tag_name: ${{ steps.release-please.outputs['packages/nozo--tag_name'] }}
 
     steps:
       - name: Load secrets from 1Password
@@ -152,6 +158,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          # Pin to the released tag, not the run's trigger commit. When PRs merge in
+          # rapid succession, the run that creates the release can be one whose checkout
+          # SHA predates the version bump, so `pnpm -r publish` would try to republish
+          # already-published versions ("cannot publish over the previously published").
+          ref: ${{ needs.release-please.outputs.tag_name }}
           persist-credentials: false
 
       - name: Setup Node

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,11 +33,9 @@ jobs:
       prs: ${{ steps.release-please.outputs.prs }}
       releases_created: ${{ steps.release-please.outputs.releases_created }}
       paths_released: ${{ steps.release-please.outputs.paths_released }}
-      # The `nozo` component tag pins the publish job to the exact release commit.
-      # linked-versions force-syncs every component to the same version on each
-      # release, so all per-component tags point at the same commit; `nozo` (the core
-      # CLI) is a stable representative. There is no umbrella tag: the root `.` umbrella
-      # component sets skip-github-release so it produces no release/tag (by design).
+      # No umbrella tag exists (root `.` sets skip-github-release by design), but
+      # linked-versions syncs all components onto one commit, so the `nozo` tag reliably
+      # pins the publish job to the release commit.
       tag_name: ${{ steps.release-please.outputs['packages/nozo--tag_name'] }}
 
     steps:
@@ -158,10 +156,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # Pin to the released tag, not the run's trigger commit. When PRs merge in
-          # rapid succession, the run that creates the release can be one whose checkout
-          # SHA predates the version bump, so `pnpm -r publish` would try to republish
-          # already-published versions ("cannot publish over the previously published").
+          # Pin to the released tag, not the run's trigger commit: with rapid merges the
+          # release-creating run may predate the version bump and republish a stale version.
           ref: ${{ needs.release-please.outputs.tag_name }}
           persist-credentials: false
 


### PR DESCRIPTION
## 概要

release の `publish` ジョブが run の trigger commit ではなく **release されたタグ（commit）**をチェックアウトするよう修正する。pm で顕在化した race（[pm run 26218100737](https://github.com/nozomiishii/pm/actions/runs/26218100737)）の横展開。

## 背景

短い間隔で PR を連続マージすると、release を作成する run が「version bump コミットより前の commit を起動 SHA に持つ run」になることがある。release-please は `releases_created=true` を返すが、`publish` ジョブは `ref:` 未指定で **起動 SHA（= bump 前のコミット）** をチェックアウトしてしまい、`pnpm -r publish` が既 publish 済みバージョンを再 publish しようとして `cannot publish over the previously published versions` で落ちうる。

## configs 固有の事情

configs は linked-versions の monorepo で、**単一の umbrella タグを持たない**。ルート `.` umbrella component は release PR タイトルにバージョンを出すためだけに置かれた phantom で、`skip-github-release: true` により release も tag も作らない設計（[#2223](https://github.com/nozomiishii/configs/pull/2223) / [#2225](https://github.com/nozomiishii/configs/pull/2225)）。

ただし linked-versions は毎 release で全 component を同一バージョンに強制 sync するため、**各 component タグはすべて同一の release コミットを指す**。そこで代表として `nozo`（中核 CLI）の tag を `tag_name` output に転送し、`publish` の `ref` に使う。umbrella タグの実在は不要で、artifact-free な現行設計を一切壊さない。

## 変更

- release-please ジョブの `outputs` に `tag_name: ${{ steps.release-please.outputs['packages/nozo--tag_name'] }}` を追加
- `publish` ジョブの `actions/checkout` に `ref: ${{ needs.release-please.outputs.tag_name }}` を追加