### PR TITLE
chore: exclude self-managed packages from pnpm minimumReleaseAge

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,6 +23,11 @@ publicHoistPattern:
   - "*prettier*"
   - "*storybook*"
 
+# minimumReleaseAge は新しく公開された版を一定期間 install させない pnpm の安全機構。自前パッケージは待たず即取り込みたいので除外する。
+minimumReleaseAgeExclude:
+  - "@nozomiishii/*"
+  - git-harvest
+
 # pinバージョンでインストールする
 savePrefix: ""
 


### PR DESCRIPTION
## 概要

pnpm の `minimumReleaseAge` から自前 (nozomiishii self-managed) パッケージを除外する。

## 背景

pnpm v11 は `minimumReleaseAge` のデフォルトが 1440 分 (24h)。さらに pnpm 11.1.3 から、既存の `pnpm-lock.yaml` エントリをこのポリシーで再検証する挙動が入り、publish 直後の自前パッケージ (`@nozomiishii/*`, `git-harvest`) が `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` で弾かれるようになった。

Renovate の共有 preset (`github>nozomiishii/renovate`) は同じ自前パッケージを Renovate 側の age-gate から除外済みだが、それは「Renovate が PR を作るタイミング」を制御するだけ。pnpm 本体の supply-chain ポリシーは別レイヤーなので、`pnpm-workspace.yaml` 側にも同じ除外が必要。

## 変更

`pnpm-workspace.yaml` に `minimumReleaseAgeExclude` (`@nozomiishii/*`, `git-harvest`) を追加。

third-party 依存は Renovate が 3 days 待ってから PR を作るため pnpm の 24h を必ず超えており、supply-chain 保護はそのまま維持される。
