### PR TITLE
chore: remove commit/PR format rules from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,10 +2,6 @@
 
 このリポジトリで Claude Code (claude.ai/code) が作業する際のガイドラインです。
 
-## Git・GitHub 運用ルール
-
-- PR タイトルは Conventional Commits 形式（英語）で `<type>: <subject>` と書く。許可 type は `feat` / `fix` / `chore` のみ。subject は小文字始まり / ASCII のみ / 末尾スペース禁止。違反すると CI（`amannn/action-semantic-pull-request`、`nozomiishii/workflows` 経由）が落ちる。詳細は [.github/workflows/_pull-request.yaml](.github/workflows/_pull-request.yaml) を参照。
-
 ## アーキテクチャ概要
 
 `configs` は `pnpm` を使った共有設定モノレポです。`packages/` に各種ツール（commitlint / ESLint / lefthook / prettier / tsconfig など）の設定をパッケージとして提供します。


### PR DESCRIPTION
## 概要

`CLAUDE.md` から PR タイトル / コミットメッセージの形式ルールを削除した。これらは git hooks / CI（commitlint・semantic-pull-request）が機械的に検査するため、CLAUDE.md に重複して持つ必要がなくなった。

## 補足

リリース・Conventional Commits の BREAKING CHANGE 方針は形式ルールでなく意味的判断（release-please の誤 bump 防止）なので残している。