### PR TITLE
feat: add breaking-change-requires-bang rule to commitlint-config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,5 +42,6 @@
 
 ## リリース・Conventional Commits
 
-- `BREAKING CHANGE:` フッターと `feat!:` / `fix!:` の `!` 修飾は、**リリースされるパッケージ・公開アセットの互換性を破る変更にのみ**使用する。CI / workflows / branch protection / リポジトリ運用上の変更には使わない。これらの注意事項は PR 本文に記述する（release-please など自動リリースツールが major / minor バンプを誤って行い、CHANGELOG に `⚠ BREAKING CHANGES` セクションを誤生成するのを防ぐため。実例: 2026-04-25 にこのリポジトリ群で `chore: migrate reusable workflows to v3.0.0` PR が誤って BREAKING CHANGE として記録された）。
+- 破壊的変更は header の `!` で宣言する（`feat!:` / `fix!:` / `chore!:`）。`BREAKING CHANGE:` footer 単独（header に `!` なし）は `@nozomiishii/commitlint-config` の `breaking-change-requires-bang` rule が弾く。GitHub の squash commit では footer が畳まれて見えず、release-please は `!`・footer を問わず breaking を major bump 扱いにするため。
+- `!` を付けるのはリリースされるパッケージ・公開アセットの互換性を破る変更のみ（依存の動作環境 EOL など）。CI / workflows / branch protection / リポジトリ運用だけの変更には付けない。この判断は機械化できないので人が見る。運用変更の意図・背景は PR 本文に書く（実例: 2026-04-25 に `chore: migrate reusable workflows to v3.0.0` が誤って BREAKING CHANGE 記録）。
 - shared-config (例: `prettier-config`) の挙動変更で発生する cascade reformat は、**設定変更 PR (`feat(<config>)!: ...`) と必ず別 PR に分離**し、scope なしの `chore: reformat ...` で出すこと。同一 PR の squash commit に混ざると release-please の path-based 振り分けにより、変更 scope と無関係なパッケージにも `⚠ BREAKING CHANGES` セクションと minor バンプが波及する（実例: 2026-05-01 の PR #2140 / #2141 が release PR #2128 で全パッケージに BREAKING を誤付与）。

--- a/packages/commitlint-config/README.ja.md
+++ b/packages/commitlint-config/README.ja.md
@@ -29,6 +29,7 @@ pnpx nozo init
 - `type-enum`: `feat` / `fix` / `chore` のみ許可。
 - `scope-empty`: デフォルトで scope 禁止。`feat: subject` は通り、`feat(api): subject` は弾かれる。
 - `commit-message-ascii-only`: body / footer / notes は ASCII のみ（コミットメッセージは英語で書く）。
+- `breaking-change-requires-bang`: 破壊的変更は header の `!` で宣言する。`BREAKING CHANGE:` footer 単独（header に `!` なし）は弾かれる。GitHub の squash commit では footer が畳まれて見えないため。
 
 ### consumer 側で scope を許可する
 

--- a/packages/commitlint-config/README.md
+++ b/packages/commitlint-config/README.md
@@ -30,6 +30,7 @@ and writes a `commitlint.config.ts` that re-exports the shared config.
 - `type-enum`: only `feat` / `fix` / `chore` are allowed.
 - `scope-empty`: scope must be empty by default. `feat: subject` passes; `feat(api): subject` is rejected.
 - `commit-message-ascii-only`: body / footer / notes must be ASCII (write commit messages in English).
+- `breaking-change-requires-bang`: declare breaking changes with `!` in the header. A `BREAKING CHANGE:` footer alone (no `!` in the header) is rejected, since GitHub collapses the footer in squash commits.
 
 ### Allowing scope in a consumer
 

--- a/packages/commitlint-config/src/index.test.ts
+++ b/packages/commitlint-config/src/index.test.ts
@@ -24,3 +24,93 @@ describe("scope-empty (default deny scope)", () => {
     expect(result.valid).toBe(true);
   });
 });
+
+// breaking change を宣言するなら header に `!` が必須。footer だけの `BREAKING CHANGE:` は禁止。
+// GitHub の squash commit では footer が畳まれて見えず、prefix と実態がズレるため。
+// type は問わない（`chore!` も可）。組み込みの breaking-change-exclamation-mark (XNOR) とは違い、
+// `!` 単独は許可・footer 単独だけを弾く一方向の含意。
+const breakingPlugin = config.plugins?.[0];
+if (!breakingPlugin || typeof breakingPlugin === "string") {
+  throw new Error("commitlint plugin not configured");
+}
+const breakingRuleCallback = breakingPlugin.rules?.["breaking-change-requires-bang"];
+if (typeof breakingRuleCallback !== "function") {
+  throw new Error("breaking-change-requires-bang rule callback not found in plugin");
+}
+
+// rule が参照する header / notes だけを持つ最小入力。parser の Commit 型は index signature が
+// 全プロパティを string 扱いにするため synthetic な notes 配列と衝突する。テスト入力用に絞る。
+type BreakingInput = { header?: string | null; notes?: { title?: string; text?: string }[] };
+const runBreakingRule = (parsed: BreakingInput) =>
+  breakingRuleCallback(
+    parsed as unknown as Parameters<typeof breakingRuleCallback>[0],
+  ) as readonly [boolean, string?];
+
+describe("breaking-change-requires-bang (unit)", () => {
+  it("default config に breaking-change-requires-bang: [2, 'always'] が登録されている", () => {
+    expect(config.rules?.["breaking-change-requires-bang"]).toEqual([2, "always"]);
+  });
+
+  it("breaking marker なしの通常コミットは通過する", () => {
+    const [valid] = runBreakingRule({ header: "feat: add foo", notes: [] });
+    expect(valid).toBe(true);
+  });
+
+  it("header に `!` があり breaking note もある (feat!) は通過する", () => {
+    const [valid] = runBreakingRule({
+      header: "feat!: drop node 18",
+      notes: [{ title: "BREAKING CHANGE", text: "drop node 18" }],
+    });
+    expect(valid).toBe(true);
+  });
+
+  it("header に `!` なしで footer だけ breaking は失敗する", () => {
+    const [valid] = runBreakingRule({
+      header: "feat: add foo",
+      notes: [{ title: "BREAKING CHANGE", text: "removed old api" }],
+    });
+    expect(valid).toBe(false);
+  });
+
+  it("BREAKING-CHANGE (ハイフン) note も検出する", () => {
+    const [valid] = runBreakingRule({
+      header: "fix: patch",
+      notes: [{ title: "BREAKING-CHANGE", text: "changed signature" }],
+    });
+    expect(valid).toBe(false);
+  });
+
+  it("header 先頭に空白があっても `!` を検出して通過する", () => {
+    // commitlint は header を trim せず rule に渡す。consumer が header-trim を無効化しても
+    // 偶発的な先頭空白で bang を見落とさないことを保証する。
+    const [valid] = runBreakingRule({
+      header: "  feat!: x",
+      notes: [{ title: "BREAKING CHANGE", text: "x" }],
+    });
+    expect(valid).toBe(true);
+  });
+});
+
+describe("breaking-change-requires-bang (integration via @commitlint/lint)", () => {
+  const rules = { "breaking-change-requires-bang": [2, "always"] } as const;
+  // 本番は config-conventional の conventionalcommits preset で動く。@commitlint/lint の
+  // 既定 parser は `BREAKING-CHANGE` (ハイフン) を note 化しないため、note 検出を本番と
+  // 揃えるよう noteKeywords を明示する。
+  const opts = {
+    plugins: { local: breakingPlugin },
+    parserOpts: { noteKeywords: ["BREAKING CHANGE", "BREAKING-CHANGE"] },
+  };
+
+  it("`!` なしで BREAKING CHANGE footer だけのコミットを弾く", async () => {
+    const message = ["feat: add foo", "", "BREAKING CHANGE: removed old api"].join("\n");
+    const result = await lint(message, rules, opts);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.name === "breaking-change-requires-bang")).toBe(true);
+  });
+
+  it("`BREAKING-CHANGE` (ハイフン) footer だけのコミットも弾く", async () => {
+    const message = ["feat: add foo", "", "BREAKING-CHANGE: removed old api"].join("\n");
+    const result = await lint(message, rules, opts);
+    expect(result.valid).toBe(false);
+  });
+});

--- a/packages/commitlint-config/src/index.ts
+++ b/packages/commitlint-config/src/index.ts
@@ -27,6 +27,17 @@ const config: UserConfig = {
             "commit message body / footer / notes must contain ASCII characters only (write in English)",
           ];
         },
+        // 破壊的変更は header の `!` で宣言する。`BREAKING CHANGE:` footer 単独は禁止。
+        // GitHub の squash commit では footer が畳まれて見えず、想定外の major bump を招くため。
+        "breaking-change-requires-bang": ({ header, notes }) => {
+          // header は commitlint 側で trim されないため、偶発的な先頭空白を除いて bang を判定する。
+          const hasBang = /^\w+(?:\([^)]*\))?!:/.test((header ?? "").trimStart());
+          const hasBreaking = (notes ?? []).some((n) => /^BREAKING[ -]CHANGE$/.test(n.title ?? ""));
+          return [
+            !hasBreaking || hasBang,
+            "declare a breaking change with `!` in the header (e.g. `chore!: ...`); a BREAKING CHANGE footer alone is not allowed because GitHub collapses the footer in squash commits",
+          ];
+        },
       },
     },
   ],
@@ -34,6 +45,7 @@ const config: UserConfig = {
     "type-enum": [2, "always", ["feat", "fix", "chore"]],
     "scope-empty": [2, "always"],
     "commit-message-ascii-only": [2, "always"],
+    "breaking-change-requires-bang": [2, "always"],
   },
 };
 


### PR DESCRIPTION
## 背景

CLAUDE.md に文章で書いていた「破壊的変更マーカーの使い分け」を commitlint でシステム的に強制したい、という要望から。

調査の結果、release-please 側では解決できないと確定した:

- 破壊的変更の判定は parse 後の `notes` に `BREAKING CHANGE` があるか1点のみ（[`src/commit.ts`](https://github.com/googleapis/release-please/blob/main/src/commit.ts)）
- `!` bang / `BREAKING CHANGE:` footer / `BREAKING-CHANGE:` footer は全て同じ note に集約され、bump 判定で区別されない
- type フィルタや footer 無視のオプションは存在しない

GitHub の squash commit では footer が畳まれて開かないと見えず、`chore:` + footer だけの破壊的変更が想定外の major bump を招いていた（例: 2026-04-25 の `chore: migrate reusable workflows to v3.0.0`）。誤 major を止められる唯一の場所が commit 時の commitlint。

## 変更

`@nozomiishii/commitlint-config` に custom rule `breaking-change-requires-bang` を追加。

- 破壊的変更は header の `!` で宣言する（`feat!:` / `fix!:` / `chore!:`）
- `BREAKING CHANGE:` footer 単独（header に `!` なし）は弾く
- type は問わない（`chore!` も可。依存の EOL 等は正当な破壊的変更）
- 組み込みの `breaking-change-exclamation-mark`（`!` と footer の両立を要求する XNOR）とは別物で、`!` 単独は許可・footer 単独だけを弾く一方向の含意

| commit | 判定 |
| --- | --- |
| `feat!:` / `chore!:` | 通過 |
| `chore!:` + `BREAKING CHANGE:` footer | 通過 |
| `feat:` + `BREAKING CHANGE:` footer | 弾く |
| `chore:` + `BREAKING CHANGE:` footer | 弾く |

あわせて README（ja/en）に追記し、CLAUDE.md は機械化された部分を rule への言及に置換、機械化できない「何を破壊的変更と見なすか」の人判断ガイダンスは残置。

## テスト

`src/index.test.ts` に同階層配置で追加。機能本位の最小セット（unit 6 / integration 2）:

- breaking なし → 通過、`!` あり → 通過、`!` なし footer → 弾く
- `BREAKING-CHANGE`（ハイフン）も検出
- header 先頭空白でも `!` を検出（consumer が `header-trim` を無効化した場合の保険）
- 実 parser 経由で footer→note→拒否を end-to-end 検証（noteKeywords を本番同様に固定）

## リリース

新ルール追加は consumer の既存 commit を新たに reject し得る挙動変更だが、minor（`feat`）として出す方針。
