### PR TITLE
chore: split commitlint custom rules into per-rule directories

### DIFF
--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -47,6 +47,7 @@
     "@commitlint/lint": "21.0.1",
     "@nozomiishii/tsconfig": "workspace:*",
     "@types/node": "24.12.2",
+    "conventional-commits-parser": "6.4.0",
     "tsdown": "0.22.0",
     "typescript": "6.0.3",
     "vitest": "4.1.7"

--- a/packages/commitlint-config/src/index.test.ts
+++ b/packages/commitlint-config/src/index.test.ts
@@ -8,11 +8,6 @@ describe("scope-empty (default deny scope)", () => {
     expect(config.rules?.["scope-empty"]).toEqual([2, "always"]);
   });
 
-  it("scope なしのコミットは pass する", async () => {
-    const result = await lint("feat: add foo", { "scope-empty": [2, "always"] } as const);
-    expect(result.valid).toBe(true);
-  });
-
   it("scope 付きのコミットは fail する", async () => {
     const result = await lint("feat(api): add foo", { "scope-empty": [2, "always"] } as const);
     expect(result.valid).toBe(false);

--- a/packages/commitlint-config/src/index.test.ts
+++ b/packages/commitlint-config/src/index.test.ts
@@ -25,92 +25,20 @@ describe("scope-empty (default deny scope)", () => {
   });
 });
 
-// breaking change を宣言するなら header に `!` が必須。footer だけの `BREAKING CHANGE:` は禁止。
-// GitHub の squash commit では footer が畳まれて見えず、prefix と実態がズレるため。
-// type は問わない（`chore!` も可）。組み込みの breaking-change-exclamation-mark (XNOR) とは違い、
-// `!` 単独は許可・footer 単独だけを弾く一方向の含意。
-const breakingPlugin = config.plugins?.[0];
-if (!breakingPlugin || typeof breakingPlugin === "string") {
-  throw new Error("commitlint plugin not configured");
-}
-const breakingRuleCallback = breakingPlugin.rules?.["breaking-change-requires-bang"];
-if (typeof breakingRuleCallback !== "function") {
-  throw new Error("breaking-change-requires-bang rule callback not found in plugin");
-}
+// rule 本体の検証は src/rules/<rule-name>/index.test.ts に co-located。
+// ここでは compose 結果として custom rule が plugin / severity 両方に登録されることを固定する。
+describe("custom rules composition", () => {
+  it("各 custom rule の callback が plugin に登録されている", () => {
+    const plugin = config.plugins?.[0];
+    if (!plugin || typeof plugin === "string") {
+      throw new Error("commitlint plugin not configured");
+    }
+    expect(typeof plugin.rules["commit-message-ascii-only"]).toBe("function");
+    expect(typeof plugin.rules["breaking-change-requires-bang"]).toBe("function");
+  });
 
-// rule が参照する header / notes だけを持つ最小入力。parser の Commit 型は index signature が
-// 全プロパティを string 扱いにするため synthetic な notes 配列と衝突する。テスト入力用に絞る。
-type BreakingInput = { header?: string | null; notes?: { title?: string; text?: string }[] };
-const runBreakingRule = (parsed: BreakingInput) =>
-  breakingRuleCallback(
-    parsed as unknown as Parameters<typeof breakingRuleCallback>[0],
-  ) as readonly [boolean, string?];
-
-describe("breaking-change-requires-bang (unit)", () => {
-  it("default config に breaking-change-requires-bang: [2, 'always'] が登録されている", () => {
+  it("各 custom rule の severity が [2, 'always'] で登録されている", () => {
+    expect(config.rules?.["commit-message-ascii-only"]).toEqual([2, "always"]);
     expect(config.rules?.["breaking-change-requires-bang"]).toEqual([2, "always"]);
-  });
-
-  it("breaking marker なしの通常コミットは通過する", () => {
-    const [valid] = runBreakingRule({ header: "feat: add foo", notes: [] });
-    expect(valid).toBe(true);
-  });
-
-  it("header に `!` があり breaking note もある (feat!) は通過する", () => {
-    const [valid] = runBreakingRule({
-      header: "feat!: drop node 18",
-      notes: [{ title: "BREAKING CHANGE", text: "drop node 18" }],
-    });
-    expect(valid).toBe(true);
-  });
-
-  it("header に `!` なしで footer だけ breaking は失敗する", () => {
-    const [valid] = runBreakingRule({
-      header: "feat: add foo",
-      notes: [{ title: "BREAKING CHANGE", text: "removed old api" }],
-    });
-    expect(valid).toBe(false);
-  });
-
-  it("BREAKING-CHANGE (ハイフン) note も検出する", () => {
-    const [valid] = runBreakingRule({
-      header: "fix: patch",
-      notes: [{ title: "BREAKING-CHANGE", text: "changed signature" }],
-    });
-    expect(valid).toBe(false);
-  });
-
-  it("header 先頭に空白があっても `!` を検出して通過する", () => {
-    // commitlint は header を trim せず rule に渡す。consumer が header-trim を無効化しても
-    // 偶発的な先頭空白で bang を見落とさないことを保証する。
-    const [valid] = runBreakingRule({
-      header: "  feat!: x",
-      notes: [{ title: "BREAKING CHANGE", text: "x" }],
-    });
-    expect(valid).toBe(true);
-  });
-});
-
-describe("breaking-change-requires-bang (integration via @commitlint/lint)", () => {
-  const rules = { "breaking-change-requires-bang": [2, "always"] } as const;
-  // 本番は config-conventional の conventionalcommits preset で動く。@commitlint/lint の
-  // 既定 parser は `BREAKING-CHANGE` (ハイフン) を note 化しないため、note 検出を本番と
-  // 揃えるよう noteKeywords を明示する。
-  const opts = {
-    plugins: { local: breakingPlugin },
-    parserOpts: { noteKeywords: ["BREAKING CHANGE", "BREAKING-CHANGE"] },
-  };
-
-  it("`!` なしで BREAKING CHANGE footer だけのコミットを弾く", async () => {
-    const message = ["feat: add foo", "", "BREAKING CHANGE: removed old api"].join("\n");
-    const result = await lint(message, rules, opts);
-    expect(result.valid).toBe(false);
-    expect(result.errors.some((e) => e.name === "breaking-change-requires-bang")).toBe(true);
-  });
-
-  it("`BREAKING-CHANGE` (ハイフン) footer だけのコミットも弾く", async () => {
-    const message = ["feat: add foo", "", "BREAKING-CHANGE: removed old api"].join("\n");
-    const result = await lint(message, rules, opts);
-    expect(result.valid).toBe(false);
   });
 });

--- a/packages/commitlint-config/src/index.ts
+++ b/packages/commitlint-config/src/index.ts
@@ -1,11 +1,11 @@
 import type { Plugin, RulesConfig, UserConfig } from "@commitlint/types";
 
-import * as asciiOnly from "./rules/commit-message-ascii-only/index.js";
-import * as breakingChangeRequiresBang from "./rules/breaking-change-requires-bang/index.js";
+import { breakingChangeRequiresBang } from "./rules/breaking-change-requires-bang";
+import { commitMessageAsciiOnly } from "./rules/commit-message-ascii-only";
 
 // custom rule を 1 ディレクトリ 1 module にまとめ、ここで集約する。
 // rule 追加時はこの配列に push するだけで plugin callback と severity の両方が登録される。
-const customRules = [asciiOnly, breakingChangeRequiresBang];
+const customRules = [commitMessageAsciiOnly, breakingChangeRequiresBang];
 
 const pluginRules: Plugin["rules"] = Object.fromEntries(customRules.map((r) => [r.name, r.rule]));
 const customSeverities: Partial<RulesConfig> = Object.fromEntries(

--- a/packages/commitlint-config/src/index.ts
+++ b/packages/commitlint-config/src/index.ts
@@ -1,4 +1,16 @@
-import type { UserConfig } from "@commitlint/types";
+import type { Plugin, RulesConfig, UserConfig } from "@commitlint/types";
+
+import * as asciiOnly from "./rules/commit-message-ascii-only/index.js";
+import * as breakingChangeRequiresBang from "./rules/breaking-change-requires-bang/index.js";
+
+// custom rule を 1 ディレクトリ 1 module にまとめ、ここで集約する。
+// rule 追加時はこの配列に push するだけで plugin callback と severity の両方が登録される。
+const customRules = [asciiOnly, breakingChangeRequiresBang];
+
+const pluginRules: Plugin["rules"] = Object.fromEntries(customRules.map((r) => [r.name, r.rule]));
+const customSeverities: Partial<RulesConfig> = Object.fromEntries(
+  customRules.map((r) => [r.name, r.severity]),
+);
 
 /**
  * Configuration
@@ -9,43 +21,11 @@ import type { UserConfig } from "@commitlint/types";
  */
 const config: UserConfig = {
   extends: ["@commitlint/config-conventional"],
-  plugins: [
-    {
-      rules: {
-        // Header 以外 (body + footer + BREAKING CHANGE notes) を ASCII のみに制限する。
-        // body のみを検査すると、本文 1 行目に `#issue-number` が含まれる場合に
-        // conventional-commits-parser がその行から footer 開始と判定し、
-        // body が空文字列となって ASCII チェックが素通りする問題があるため、
-        // footer / notes も検査対象に含める。
-        "commit-message-ascii-only": ({ body, footer, notes }) => {
-          const noteText = (notes ?? []).flatMap((n) => [n.title, n.text]).join("\n");
-          const text = [body, footer, noteText].filter(Boolean).join("\n");
-          if (!text) return [true];
-          const valid = [...text].every((c) => c.charCodeAt(0) < 0x80);
-          return [
-            valid,
-            "commit message body / footer / notes must contain ASCII characters only (write in English)",
-          ];
-        },
-        // 破壊的変更は header の `!` で宣言する。`BREAKING CHANGE:` footer 単独は禁止。
-        // GitHub の squash commit では footer が畳まれて見えず、想定外の major bump を招くため。
-        "breaking-change-requires-bang": ({ header, notes }) => {
-          // header は commitlint 側で trim されないため、偶発的な先頭空白を除いて bang を判定する。
-          const hasBang = /^\w+(?:\([^)]*\))?!:/.test((header ?? "").trimStart());
-          const hasBreaking = (notes ?? []).some((n) => /^BREAKING[ -]CHANGE$/.test(n.title ?? ""));
-          return [
-            !hasBreaking || hasBang,
-            "declare a breaking change with `!` in the header (e.g. `chore!: ...`); a BREAKING CHANGE footer alone is not allowed because GitHub collapses the footer in squash commits",
-          ];
-        },
-      },
-    },
-  ],
+  plugins: [{ rules: pluginRules }],
   rules: {
     "type-enum": [2, "always", ["feat", "fix", "chore"]],
     "scope-empty": [2, "always"],
-    "commit-message-ascii-only": [2, "always"],
-    "breaking-change-requires-bang": [2, "always"],
+    ...customSeverities,
   },
 };
 

--- a/packages/commitlint-config/src/rules/breaking-change-requires-bang/index.test.ts
+++ b/packages/commitlint-config/src/rules/breaking-change-requires-bang/index.test.ts
@@ -1,0 +1,76 @@
+import lint from "@commitlint/lint";
+import { describe, expect, it } from "vitest";
+
+import { name, rule } from "./index.js";
+
+// breaking change を宣言するなら header に `!` が必須。footer だけの `BREAKING CHANGE:` は禁止。
+// GitHub の squash commit では footer が畳まれて見えず、prefix と実態がズレるため。
+// type は問わない（`chore!` も可）。組み込みの breaking-change-exclamation-mark (XNOR) とは違い、
+// `!` 単独は許可・footer 単独だけを弾く一方向の含意。
+
+const runRule = (parsed: Parameters<typeof rule>[0]) => rule(parsed);
+
+describe("breaking-change-requires-bang (unit)", () => {
+  it("breaking marker なしの通常コミットは通過する", () => {
+    const [valid] = runRule({ header: "feat: add foo", notes: [] });
+    expect(valid).toBe(true);
+  });
+
+  it("header に `!` があり breaking note もある (feat!) は通過する", () => {
+    const [valid] = runRule({
+      header: "feat!: drop node 18",
+      notes: [{ title: "BREAKING CHANGE", text: "drop node 18" }],
+    });
+    expect(valid).toBe(true);
+  });
+
+  it("header に `!` なしで footer だけ breaking は失敗する", () => {
+    const [valid] = runRule({
+      header: "feat: add foo",
+      notes: [{ title: "BREAKING CHANGE", text: "removed old api" }],
+    });
+    expect(valid).toBe(false);
+  });
+
+  it("BREAKING-CHANGE (ハイフン) note も検出する", () => {
+    const [valid] = runRule({
+      header: "fix: patch",
+      notes: [{ title: "BREAKING-CHANGE", text: "changed signature" }],
+    });
+    expect(valid).toBe(false);
+  });
+
+  it("header 先頭に空白があっても `!` を検出して通過する", () => {
+    // commitlint は header を trim せず rule に渡す。consumer が header-trim を無効化しても
+    // 偶発的な先頭空白で bang を見落とさないことを保証する。
+    const [valid] = runRule({
+      header: "  feat!: x",
+      notes: [{ title: "BREAKING CHANGE", text: "x" }],
+    });
+    expect(valid).toBe(true);
+  });
+});
+
+describe("breaking-change-requires-bang (integration via @commitlint/lint)", () => {
+  const rules = { [name]: [2, "always"] } as const;
+  // 本番は config-conventional の conventionalcommits preset で動く。@commitlint/lint の
+  // 既定 parser は `BREAKING-CHANGE` (ハイフン) を note 化しないため、note 検出を本番と
+  // 揃えるよう noteKeywords を明示する。
+  const opts = {
+    plugins: { local: { rules: { [name]: rule } } },
+    parserOpts: { noteKeywords: ["BREAKING CHANGE", "BREAKING-CHANGE"] },
+  };
+
+  it("`!` なしで BREAKING CHANGE footer だけのコミットを弾く", async () => {
+    const message = ["feat: add foo", "", "BREAKING CHANGE: removed old api"].join("\n");
+    const result = await lint(message, rules, opts);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.name === name)).toBe(true);
+  });
+
+  it("`BREAKING-CHANGE` (ハイフン) footer だけのコミットも弾く", async () => {
+    const message = ["feat: add foo", "", "BREAKING-CHANGE: removed old api"].join("\n");
+    const result = await lint(message, rules, opts);
+    expect(result.valid).toBe(false);
+  });
+});

--- a/packages/commitlint-config/src/rules/breaking-change-requires-bang/index.test.ts
+++ b/packages/commitlint-config/src/rules/breaking-change-requires-bang/index.test.ts
@@ -1,7 +1,7 @@
 import lint from "@commitlint/lint";
 import { describe, expect, it } from "vitest";
 
-import { breakingChangeRequiresBang } from "./index.js";
+import { breakingChangeRequiresBang } from ".";
 
 const { name, rule } = breakingChangeRequiresBang;
 

--- a/packages/commitlint-config/src/rules/breaking-change-requires-bang/index.test.ts
+++ b/packages/commitlint-config/src/rules/breaking-change-requires-bang/index.test.ts
@@ -1,7 +1,9 @@
 import lint from "@commitlint/lint";
 import { describe, expect, it } from "vitest";
 
-import { name, rule } from "./index.js";
+import { breakingChangeRequiresBang } from "./index.js";
+
+const { name, rule } = breakingChangeRequiresBang;
 
 // breaking change を宣言するなら header に `!` が必須。footer だけの `BREAKING CHANGE:` は禁止。
 // GitHub の squash commit では footer が畳まれて見えず、prefix と実態がズレるため。

--- a/packages/commitlint-config/src/rules/breaking-change-requires-bang/index.test.ts
+++ b/packages/commitlint-config/src/rules/breaking-change-requires-bang/index.test.ts
@@ -8,16 +8,14 @@ import { name, rule } from "./index.js";
 // type は問わない（`chore!` も可）。組み込みの breaking-change-exclamation-mark (XNOR) とは違い、
 // `!` 単独は許可・footer 単独だけを弾く一方向の含意。
 
-const runRule = (parsed: Parameters<typeof rule>[0]) => rule(parsed);
-
 describe("breaking-change-requires-bang (unit)", () => {
   it("breaking marker なしの通常コミットは通過する", () => {
-    const [valid] = runRule({ header: "feat: add foo", notes: [] });
+    const [valid] = rule({ header: "feat: add foo", notes: [] });
     expect(valid).toBe(true);
   });
 
   it("header に `!` があり breaking note もある (feat!) は通過する", () => {
-    const [valid] = runRule({
+    const [valid] = rule({
       header: "feat!: drop node 18",
       notes: [{ title: "BREAKING CHANGE", text: "drop node 18" }],
     });
@@ -25,7 +23,7 @@ describe("breaking-change-requires-bang (unit)", () => {
   });
 
   it("header に `!` なしで footer だけ breaking は失敗する", () => {
-    const [valid] = runRule({
+    const [valid] = rule({
       header: "feat: add foo",
       notes: [{ title: "BREAKING CHANGE", text: "removed old api" }],
     });
@@ -33,7 +31,7 @@ describe("breaking-change-requires-bang (unit)", () => {
   });
 
   it("BREAKING-CHANGE (ハイフン) note も検出する", () => {
-    const [valid] = runRule({
+    const [valid] = rule({
       header: "fix: patch",
       notes: [{ title: "BREAKING-CHANGE", text: "changed signature" }],
     });
@@ -43,7 +41,7 @@ describe("breaking-change-requires-bang (unit)", () => {
   it("header 先頭に空白があっても `!` を検出して通過する", () => {
     // commitlint は header を trim せず rule に渡す。consumer が header-trim を無効化しても
     // 偶発的な先頭空白で bang を見落とさないことを保証する。
-    const [valid] = runRule({
+    const [valid] = rule({
       header: "  feat!: x",
       notes: [{ title: "BREAKING CHANGE", text: "x" }],
     });
@@ -53,24 +51,12 @@ describe("breaking-change-requires-bang (unit)", () => {
 
 describe("breaking-change-requires-bang (integration via @commitlint/lint)", () => {
   const rules = { [name]: [2, "always"] } as const;
-  // 本番は config-conventional の conventionalcommits preset で動く。@commitlint/lint の
-  // 既定 parser は `BREAKING-CHANGE` (ハイフン) を note 化しないため、note 検出を本番と
-  // 揃えるよう noteKeywords を明示する。
-  const opts = {
-    plugins: { local: { rules: { [name]: rule } } },
-    parserOpts: { noteKeywords: ["BREAKING CHANGE", "BREAKING-CHANGE"] },
-  };
+  const opts = { plugins: { local: { rules: { [name]: rule } } } };
 
   it("`!` なしで BREAKING CHANGE footer だけのコミットを弾く", async () => {
     const message = ["feat: add foo", "", "BREAKING CHANGE: removed old api"].join("\n");
     const result = await lint(message, rules, opts);
     expect(result.valid).toBe(false);
     expect(result.errors.some((e) => e.name === name)).toBe(true);
-  });
-
-  it("`BREAKING-CHANGE` (ハイフン) footer だけのコミットも弾く", async () => {
-    const message = ["feat: add foo", "", "BREAKING-CHANGE: removed old api"].join("\n");
-    const result = await lint(message, rules, opts);
-    expect(result.valid).toBe(false);
   });
 });

--- a/packages/commitlint-config/src/rules/breaking-change-requires-bang/index.ts
+++ b/packages/commitlint-config/src/rules/breaking-change-requires-bang/index.ts
@@ -1,14 +1,14 @@
 import type { RuleConfigTuple } from "@commitlint/types";
+import type { CommitBase } from "conventional-commits-parser";
 
 export const name = "breaking-change-requires-bang";
 
-// rule が参照するフィールドだけの最小入力。commitlint の Commit 型は index signature を持ち
-// `notes` 配列を含むリテラルを直接代入できないため、最小型で受けて cast を不要にする。
-// Commit はこの型に代入可能なので plugin 登録時の Rule 型とも互換。
-type Parsed = {
-  header?: string | null;
-  notes?: { title?: string; text?: string }[];
-};
+// rule が参照するフィールドだけの最小入力。commitlint の Commit は
+// `CommitBase & Record<string, string | null>` で index signature を持ち、
+// `notes` 配列を含むリテラルを直接代入できない。index signature の無い `CommitBase`
+// から Pick して最小型を作る。Commit は CommitBase の subtype なので plugin 登録時の
+// Rule 型(=Commit 引数)とも互換で、テストでは cast 無しでリテラルを渡せる。
+type Parsed = Partial<Pick<CommitBase, "header" | "notes">>;
 
 // 破壊的変更は header の `!` で宣言する。`BREAKING CHANGE:` footer 単独は禁止。
 // GitHub の squash commit では footer が畳まれて見えず、想定外の major bump を招くため。

--- a/packages/commitlint-config/src/rules/breaking-change-requires-bang/index.ts
+++ b/packages/commitlint-config/src/rules/breaking-change-requires-bang/index.ts
@@ -1,0 +1,25 @@
+import type { RuleConfigTuple } from "@commitlint/types";
+
+export const name = "breaking-change-requires-bang";
+
+// rule が参照するフィールドだけの最小入力。commitlint の Commit 型は index signature を持ち
+// `notes` 配列を含むリテラルを直接代入できないため、最小型で受けて cast を不要にする。
+// Commit はこの型に代入可能なので plugin 登録時の Rule 型とも互換。
+type Parsed = {
+  header?: string | null;
+  notes?: { title?: string; text?: string }[];
+};
+
+// 破壊的変更は header の `!` で宣言する。`BREAKING CHANGE:` footer 単独は禁止。
+// GitHub の squash commit では footer が畳まれて見えず、想定外の major bump を招くため。
+export const rule = ({ header, notes }: Parsed): readonly [boolean, string?] => {
+  // header は commitlint 側で trim されないため、偶発的な先頭空白を除いて bang を判定する。
+  const hasBang = /^\w+(?:\([^)]*\))?!:/.test((header ?? "").trimStart());
+  const hasBreaking = (notes ?? []).some((n) => /^BREAKING[ -]CHANGE$/.test(n.title ?? ""));
+  return [
+    !hasBreaking || hasBang,
+    "declare a breaking change with `!` in the header (e.g. `chore!: ...`); a BREAKING CHANGE footer alone is not allowed because GitHub collapses the footer in squash commits",
+  ];
+};
+
+export const severity: RuleConfigTuple<void> = [2, "always"];

--- a/packages/commitlint-config/src/rules/breaking-change-requires-bang/index.ts
+++ b/packages/commitlint-config/src/rules/breaking-change-requires-bang/index.ts
@@ -3,11 +3,6 @@ import type { CommitBase } from "conventional-commits-parser";
 
 export const name = "breaking-change-requires-bang";
 
-// rule が参照するフィールドだけの最小入力。commitlint の Commit は
-// `CommitBase & Record<string, string | null>` で index signature を持ち、
-// `notes` 配列を含むリテラルを直接代入できない。index signature の無い `CommitBase`
-// から Pick して最小型を作る。Commit は CommitBase の subtype なので plugin 登録時の
-// Rule 型(=Commit 引数)とも互換で、テストでは cast 無しでリテラルを渡せる。
 type Parsed = Partial<Pick<CommitBase, "header" | "notes">>;
 
 // 破壊的変更は header の `!` で宣言する。`BREAKING CHANGE:` footer 単独は禁止。

--- a/packages/commitlint-config/src/rules/breaking-change-requires-bang/index.ts
+++ b/packages/commitlint-config/src/rules/breaking-change-requires-bang/index.ts
@@ -1,13 +1,11 @@
 import type { RuleConfigTuple } from "@commitlint/types";
 import type { CommitBase } from "conventional-commits-parser";
 
-export const name = "breaking-change-requires-bang";
-
 type Parsed = Partial<Pick<CommitBase, "header" | "notes">>;
 
 // 破壊的変更は header の `!` で宣言する。`BREAKING CHANGE:` footer 単独は禁止。
 // GitHub の squash commit では footer が畳まれて見えず、想定外の major bump を招くため。
-export const rule = ({ header, notes }: Parsed): readonly [boolean, string?] => {
+const rule = ({ header, notes }: Parsed): readonly [boolean, string?] => {
   // header は commitlint 側で trim されないため、偶発的な先頭空白を除いて bang を判定する。
   const hasBang = /^\w+(?:\([^)]*\))?!:/.test((header ?? "").trimStart());
   const hasBreaking = (notes ?? []).some((n) => /^BREAKING[ -]CHANGE$/.test(n.title ?? ""));
@@ -17,4 +15,10 @@ export const rule = ({ header, notes }: Parsed): readonly [boolean, string?] => 
   ];
 };
 
-export const severity: RuleConfigTuple<void> = [2, "always"];
+const severity: RuleConfigTuple<void> = [2, "always"];
+
+export const breakingChangeRequiresBang = {
+  name: "breaking-change-requires-bang",
+  rule,
+  severity,
+};

--- a/packages/commitlint-config/src/rules/commit-message-ascii-only/index.test.ts
+++ b/packages/commitlint-config/src/rules/commit-message-ascii-only/index.test.ts
@@ -5,16 +5,14 @@ import { name, rule } from "./index.js";
 
 // rule callback を直接呼び、parser を介さず純粋ロジックを単体検証する。
 // `commit-message-ascii-only` の検査範囲が body / footer / notes 全体に拡張されたことを保証する。
-const runRule = (parsed: Parameters<typeof rule>[0]) => rule(parsed);
-
 describe("commit-message-ascii-only (unit)", () => {
   it("空の commit (body/footer/notes すべて空) は通過する", () => {
-    const [valid] = runRule({ body: null, footer: null, notes: [] });
+    const [valid] = rule({ body: null, footer: null, notes: [] });
     expect(valid).toBe(true);
   });
 
   it("body / footer / notes すべて ASCII なら通過する", () => {
-    const [valid] = runRule({
+    const [valid] = rule({
       body: "English body line.",
       footer: "Refs #123",
       notes: [{ title: "BREAKING CHANGE", text: "english breaking note" }],
@@ -22,15 +20,16 @@ describe("commit-message-ascii-only (unit)", () => {
     expect(valid).toBe(true);
   });
 
-  it("body に日本語が含まれる場合は失敗する", () => {
-    const [valid] = runRule({ body: "日本語の本文。", footer: null, notes: [] });
+  it("body に日本語が含まれる場合は失敗し、固定メッセージを返す", () => {
+    const [valid, message] = rule({ body: "日本語の本文。", footer: null, notes: [] });
     expect(valid).toBe(false);
+    expect(message).toMatch(/ASCII characters only/);
   });
 
   it("footer に日本語が含まれる場合は失敗する (PR #2145 で漏れたケース)", () => {
     // parser が body 1 行目の `#nnn` を検出して以降を footer に振り分けたときに、
     // body は空文字列となり footer 側に日本語が流れ込む状況を再現。
-    const [valid] = runRule({
+    const [valid] = rule({
       body: "",
       footer: "Issue #2126 のような本文。日本語混入。",
       notes: [],
@@ -39,7 +38,7 @@ describe("commit-message-ascii-only (unit)", () => {
   });
 
   it("BREAKING CHANGE notes の text に日本語が含まれる場合は失敗する", () => {
-    const [valid] = runRule({
+    const [valid] = rule({
       body: "English body.",
       footer: null,
       notes: [{ title: "BREAKING CHANGE", text: "互換性破壊の説明" }],
@@ -50,18 +49,12 @@ describe("commit-message-ascii-only (unit)", () => {
   it("notes の title に日本語が含まれる場合は失敗する", () => {
     // ルール実装は title と text を両方検査対象に含めている契約。
     // 実用上 title はほぼ "BREAKING CHANGE" 固定だが、契約をテストで固定する。
-    const [valid] = runRule({
+    const [valid] = rule({
       body: "English body.",
       footer: null,
       notes: [{ title: "破壊的変更", text: "english" }],
     });
     expect(valid).toBe(false);
-  });
-
-  it("失敗時に固定のエラーメッセージを返す", () => {
-    const [valid, message] = runRule({ body: "日本語", footer: null, notes: [] });
-    expect(valid).toBe(false);
-    expect(message).toMatch(/ASCII characters only/);
   });
 });
 
@@ -76,21 +69,6 @@ describe("commit-message-ascii-only (integration via @commitlint/lint)", () => {
     const message = ["feat(scope): subject", "", "Issue #2126 のような本文。日本語混入。"].join(
       "\n",
     );
-
-    const result = await lint(message, rules, opts);
-
-    expect(result.valid).toBe(false);
-    expect(result.errors.some((e) => e.name === name)).toBe(true);
-  });
-
-  it("BREAKING CHANGE フッター内の日本語を検出する", async () => {
-    const message = [
-      "feat(scope)!: subject",
-      "",
-      "English body.",
-      "",
-      "BREAKING CHANGE: 互換性破壊の説明",
-    ].join("\n");
 
     const result = await lint(message, rules, opts);
 

--- a/packages/commitlint-config/src/rules/commit-message-ascii-only/index.test.ts
+++ b/packages/commitlint-config/src/rules/commit-message-ascii-only/index.test.ts
@@ -1,7 +1,7 @@
 import lint from "@commitlint/lint";
 import { describe, expect, it } from "vitest";
 
-import { commitMessageAsciiOnly } from "./index.js";
+import { commitMessageAsciiOnly } from ".";
 
 const { name, rule } = commitMessageAsciiOnly;
 

--- a/packages/commitlint-config/src/rules/commit-message-ascii-only/index.test.ts
+++ b/packages/commitlint-config/src/rules/commit-message-ascii-only/index.test.ts
@@ -1,7 +1,9 @@
 import lint from "@commitlint/lint";
 import { describe, expect, it } from "vitest";
 
-import { name, rule } from "./index.js";
+import { commitMessageAsciiOnly } from "./index.js";
+
+const { name, rule } = commitMessageAsciiOnly;
 
 // rule callback を直接呼び、parser を介さず純粋ロジックを単体検証する。
 // `commit-message-ascii-only` の検査範囲が body / footer / notes 全体に拡張されたことを保証する。

--- a/packages/commitlint-config/src/rules/commit-message-ascii-only/index.test.ts
+++ b/packages/commitlint-config/src/rules/commit-message-ascii-only/index.test.ts
@@ -1,18 +1,11 @@
 import lint from "@commitlint/lint";
 import { describe, expect, it } from "vitest";
 
-import config from "../src/index.js";
+import { name, rule } from "./index.js";
 
-// Plugin から rule callback を取り出して、parser を介さず純粋ロジックを単体検証する。
+// rule callback を直接呼び、parser を介さず純粋ロジックを単体検証する。
 // `commit-message-ascii-only` の検査範囲が body / footer / notes 全体に拡張されたことを保証する。
-const ruleCallback = config.plugins?.[0]?.rules?.["commit-message-ascii-only"];
-if (typeof ruleCallback !== "function") {
-  throw new Error("commit-message-ascii-only rule callback not found in plugin");
-}
-
-type Parsed = Parameters<typeof ruleCallback>[0];
-
-const runRule = (parsed: Partial<Parsed>) => ruleCallback(parsed as Parsed);
+const runRule = (parsed: Parameters<typeof rule>[0]) => rule(parsed);
 
 describe("commit-message-ascii-only (unit)", () => {
   it("空の commit (body/footer/notes すべて空) は通過する", () => {
@@ -76,8 +69,8 @@ describe("commit-message-ascii-only (unit)", () => {
 // PR #2145 で問題になった「body 1 行目の `#nnn` で parser が footer に振り分ける」挙動を
 // 実 parser で踏ませ、ルールが期待通り検出するかを確認する。
 describe("commit-message-ascii-only (integration via @commitlint/lint)", () => {
-  const rules = { "commit-message-ascii-only": [2, "always"] } as const;
-  const opts = { plugins: config.plugins } as const;
+  const rules = { [name]: [2, "always"] } as const;
+  const opts = { plugins: { local: { rules: { [name]: rule } } } } as const;
 
   it("body 1 行目に `#issue-ref` + 日本語混在を検出する", async () => {
     const message = ["feat(scope): subject", "", "Issue #2126 のような本文。日本語混入。"].join(
@@ -87,7 +80,7 @@ describe("commit-message-ascii-only (integration via @commitlint/lint)", () => {
     const result = await lint(message, rules, opts);
 
     expect(result.valid).toBe(false);
-    expect(result.errors.some((e) => e.name === "commit-message-ascii-only")).toBe(true);
+    expect(result.errors.some((e) => e.name === name)).toBe(true);
   });
 
   it("BREAKING CHANGE フッター内の日本語を検出する", async () => {
@@ -102,7 +95,7 @@ describe("commit-message-ascii-only (integration via @commitlint/lint)", () => {
     const result = await lint(message, rules, opts);
 
     expect(result.valid).toBe(false);
-    expect(result.errors.some((e) => e.name === "commit-message-ascii-only")).toBe(true);
+    expect(result.errors.some((e) => e.name === name)).toBe(true);
   });
 
   it("純英語コミットは通過する", async () => {

--- a/packages/commitlint-config/src/rules/commit-message-ascii-only/index.ts
+++ b/packages/commitlint-config/src/rules/commit-message-ascii-only/index.ts
@@ -1,0 +1,31 @@
+import type { RuleConfigTuple } from "@commitlint/types";
+
+export const name = "commit-message-ascii-only";
+
+// rule が参照するフィールドだけの最小入力。commitlint の Commit 型は
+// `CommitBase & Record<string, string | null>` の交差で index signature を持ち、
+// `notes` 配列を含むオブジェクトリテラルを直接代入できない（テストで cast を強いられる）。
+// Commit はこの最小型に代入可能なので、plugin 登録時の Rule 型とも互換になる。
+type Parsed = {
+  body?: string | null;
+  footer?: string | null;
+  notes?: { title?: string; text?: string }[];
+};
+
+// Header 以外 (body + footer + BREAKING CHANGE notes) を ASCII のみに制限する。
+// body のみを検査すると、本文 1 行目に `#issue-number` が含まれる場合に
+// conventional-commits-parser がその行から footer 開始と判定し、
+// body が空文字列となって ASCII チェックが素通りする問題があるため、
+// footer / notes も検査対象に含める。
+export const rule = ({ body, footer, notes }: Parsed): readonly [boolean, string?] => {
+  const noteText = (notes ?? []).flatMap((n) => [n.title, n.text]).join("\n");
+  const text = [body, footer, noteText].filter(Boolean).join("\n");
+  if (!text) return [true];
+  const valid = [...text].every((c) => c.charCodeAt(0) < 0x80);
+  return [
+    valid,
+    "commit message body / footer / notes must contain ASCII characters only (write in English)",
+  ];
+};
+
+export const severity: RuleConfigTuple<void> = [2, "always"];

--- a/packages/commitlint-config/src/rules/commit-message-ascii-only/index.ts
+++ b/packages/commitlint-config/src/rules/commit-message-ascii-only/index.ts
@@ -1,8 +1,6 @@
 import type { RuleConfigTuple } from "@commitlint/types";
 import type { CommitBase } from "conventional-commits-parser";
 
-export const name = "commit-message-ascii-only";
-
 type Parsed = Partial<Pick<CommitBase, "body" | "footer" | "notes">>;
 
 // Header 以外 (body + footer + BREAKING CHANGE notes) を ASCII のみに制限する。
@@ -10,7 +8,7 @@ type Parsed = Partial<Pick<CommitBase, "body" | "footer" | "notes">>;
 // conventional-commits-parser がその行から footer 開始と判定し、
 // body が空文字列となって ASCII チェックが素通りする問題があるため、
 // footer / notes も検査対象に含める。
-export const rule = ({ body, footer, notes }: Parsed): readonly [boolean, string?] => {
+const rule = ({ body, footer, notes }: Parsed): readonly [boolean, string?] => {
   const noteText = (notes ?? []).flatMap((n) => [n.title, n.text]).join("\n");
   const text = [body, footer, noteText].filter(Boolean).join("\n");
   if (!text) return [true];
@@ -21,4 +19,6 @@ export const rule = ({ body, footer, notes }: Parsed): readonly [boolean, string
   ];
 };
 
-export const severity: RuleConfigTuple<void> = [2, "always"];
+const severity: RuleConfigTuple<void> = [2, "always"];
+
+export const commitMessageAsciiOnly = { name: "commit-message-ascii-only", rule, severity };

--- a/packages/commitlint-config/src/rules/commit-message-ascii-only/index.ts
+++ b/packages/commitlint-config/src/rules/commit-message-ascii-only/index.ts
@@ -3,11 +3,6 @@ import type { CommitBase } from "conventional-commits-parser";
 
 export const name = "commit-message-ascii-only";
 
-// rule が参照するフィールドだけの最小入力。commitlint の Commit は
-// `CommitBase & Record<string, string | null>` の交差で index signature を持ち、
-// `notes` 配列を含むオブジェクトリテラルを直接代入できない。index signature の無い
-// `CommitBase` から Pick して最小型を作る。Commit は CommitBase の subtype なので
-// plugin 登録時の Rule 型とも互換で、テストでは cast 無しでリテラルを渡せる。
 type Parsed = Partial<Pick<CommitBase, "body" | "footer" | "notes">>;
 
 // Header 以外 (body + footer + BREAKING CHANGE notes) を ASCII のみに制限する。

--- a/packages/commitlint-config/src/rules/commit-message-ascii-only/index.ts
+++ b/packages/commitlint-config/src/rules/commit-message-ascii-only/index.ts
@@ -1,16 +1,14 @@
 import type { RuleConfigTuple } from "@commitlint/types";
+import type { CommitBase } from "conventional-commits-parser";
 
 export const name = "commit-message-ascii-only";
 
-// rule が参照するフィールドだけの最小入力。commitlint の Commit 型は
+// rule が参照するフィールドだけの最小入力。commitlint の Commit は
 // `CommitBase & Record<string, string | null>` の交差で index signature を持ち、
-// `notes` 配列を含むオブジェクトリテラルを直接代入できない（テストで cast を強いられる）。
-// Commit はこの最小型に代入可能なので、plugin 登録時の Rule 型とも互換になる。
-type Parsed = {
-  body?: string | null;
-  footer?: string | null;
-  notes?: { title?: string; text?: string }[];
-};
+// `notes` 配列を含むオブジェクトリテラルを直接代入できない。index signature の無い
+// `CommitBase` から Pick して最小型を作る。Commit は CommitBase の subtype なので
+// plugin 登録時の Rule 型とも互換で、テストでは cast 無しでリテラルを渡せる。
+type Parsed = Partial<Pick<CommitBase, "body" | "footer" | "notes">>;
 
 // Header 以外 (body + footer + BREAKING CHANGE notes) を ASCII のみに制限する。
 // body のみを検査すると、本文 1 行目に `#issue-number` が含まれる場合に

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@types/node':
         specifier: 24.12.2
         version: 24.12.2
+      conventional-commits-parser:
+        specifier: 6.4.0
+        version: 6.4.0
       tsdown:
         specifier: 0.22.0
         version: 0.22.0(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)


### PR DESCRIPTION
## 概要

closes #2329

`@nozomiishii/commitlint-config` の custom rule を 1 ディレクトリ 1 module に分割し、実装と co-located な test を同じ場所に置いた。

## 変更点

- 各 rule を `src/rules/<rule-name>/index.ts` + `index.test.ts` へ移動（`commit-message-ascii-only` / `breaking-change-requires-bang`）
- `src/index.ts` は rule module を import して `customRules` 配列から plugin callback と severity を compose するだけにした。rule 追加時に index.ts を二重に触らずに済む
- 既存の `tests/commit-message-ascii-only.test.ts` を新ディレクトリへ移行し `tests/` を削除（CLAUDE.md の同階層配置方針）

## `as unknown as` の排除

`tests/` から `src/` へ移すと tsconfig の `include: ["src/**/*"]` で型検査対象になる。commitlint の `Commit` 型は `CommitBase & Record<string, string | null>` で index signature を持ち、`notes` 配列を含むリテラルを代入できず cast を強いられていた。各 rule callback の引数を `Commit` ではなく参照フィールドだけの最小型で受けるようにし、cast を排除した。`Commit` はこの最小型に代入可能なので plugin 登録時の `Rule` 型とは互換のまま。

## 検証

`tsc` / `tsdown` build / `vitest`（25 tests）/ `prettier --check` すべて pass