### PR TITLE
chore: drop redundant extensions from relative imports

### DIFF
--- a/packages/eslint-config/src/init/bin.ts
+++ b/packages/eslint-config/src/init/bin.ts
@@ -1,4 +1,4 @@
-import { init } from "./index.js";
+import { init } from ".";
 
 await init({ cwd: process.cwd() });
 process.stdout.write("✓ @nozomiishii/eslint-config installed\n");

--- a/packages/eslint-config/src/init/index.test.ts
+++ b/packages/eslint-config/src/init/index.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { test as baseTest, expect } from "vitest";
-import { init } from "./index.js";
+import { init } from ".";
 
 type InitResult = {
   configContent: string;

--- a/packages/nozo/src/commands/init.test.ts
+++ b/packages/nozo/src/commands/init.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { test as baseTest, expect } from "vitest";
-import { toolIds, tools } from "./init.js";
+import { toolIds, tools } from "./init";
 
 const test = baseTest.extend<{ cwd: string }>({
   cwd: async ({ task: _ }, provide) => {


### PR DESCRIPTION
## 概要

eslint 対象パッケージ（nozo / eslint-config）の intra-package 相対 import から、冗長な `.js` 拡張子と `/index` を除去する。

## 背景

これらは bundler module resolution 下で拡張子なしで解決でき、eslint-config の rule modules（`./rules/<name>`）と同じ書き方になる。後続の `feat(eslint-config)` で `import-x/extensions`(never) と `import-x/no-useless-path-segments`(noUselessIndex) を有効化する前提として、先に違反を解消しておく reformat PR（CLAUDE.md の「設定変更とは別 PR・scope なし chore」方針）。

## 変更

- `packages/nozo/src/commands/init.test.ts`: `./init.js` → `./init`
- `packages/eslint-config/src/init/bin.ts`: `./index.js` → `.`
- `packages/eslint-config/src/init/index.test.ts`: `./index.js` → `.`

`../package.json`（`with { type: "json" }`）は拡張子維持が必要なため対象外。

## 検証

両パッケージで tsc / eslint（現行ルール）green。型・解決に影響なし。