### PR TITLE
feat: enforce extensionless relative imports in eslint-config

### DIFF
--- a/packages/eslint-config/rules/import-x.ts
+++ b/packages/eslint-config/rules/import-x.ts
@@ -31,11 +31,7 @@ export function importX() {
     name: name("import-x"),
     rules: {
       /**
-       * 相対 import の拡張子を省略させる（js/jsx/ts/tsx 等）
-       *
-       * bundler 解決前提なので `.js` を書かない。base を ignorePackages にすることで
-       * パッケージ import は無視しつつ、列挙していない拡張子（json / yaml / css など）は
-       * 拡張子必須のまま残す。checkTypeImports で `import type` も対象にする。
+       * 拡張子を省略できるもの（js/ts 系）は省略する。json などは維持。
        *
        * @see https://github.com/un-ts/eslint-plugin-import-x/blob/HEAD/docs/rules/extensions.md
        */
@@ -44,6 +40,7 @@ export function importX() {
         "ignorePackages",
         {
           checkTypeImports: true,
+          fix: true,
           pattern: {
             cjs: "never",
             cts: "never",
@@ -86,9 +83,7 @@ export function importX() {
       "import-x/no-named-as-default": "warn",
 
       /**
-       * 冗長なパスセグメントを禁止する（`./foo/index` → `.`、`../x/../y` など）
-       *
-       * noUselessIndex で `index` の明示も省かせる。
+       * 冗長なパスセグメントを禁止。noUselessIndex で `index` も省く。
        *
        * @see https://github.com/un-ts/eslint-plugin-import-x/blob/HEAD/docs/rules/no-useless-path-segments.md
        */

--- a/packages/eslint-config/rules/import-x.ts
+++ b/packages/eslint-config/rules/import-x.ts
@@ -31,6 +31,33 @@ export function importX() {
     name: name("import-x"),
     rules: {
       /**
+       * 相対 import の拡張子を省略させる（js/jsx/ts/tsx 等）
+       *
+       * bundler 解決前提なので `.js` を書かない。base を ignorePackages にすることで
+       * パッケージ import は無視しつつ、列挙していない拡張子（json / yaml / css など）は
+       * 拡張子必須のまま残す。checkTypeImports で `import type` も対象にする。
+       *
+       * @see https://github.com/un-ts/eslint-plugin-import-x/blob/HEAD/docs/rules/extensions.md
+       */
+      "import-x/extensions": [
+        "warn",
+        "ignorePackages",
+        {
+          checkTypeImports: true,
+          pattern: {
+            cjs: "never",
+            cts: "never",
+            js: "never",
+            jsx: "never",
+            mjs: "never",
+            mts: "never",
+            ts: "never",
+            tsx: "never",
+          },
+        },
+      ],
+
+      /**
        * import文は先頭に書く
        *
        * @see https://github.com/un-ts/eslint-plugin-import-x/blob/HEAD/docs/rules/first.md
@@ -57,6 +84,15 @@ export function importX() {
        * @see https://github.com/un-ts/eslint-plugin-import-x/blob/HEAD/docs/rules/no-named-as-default.md
        */
       "import-x/no-named-as-default": "warn",
+
+      /**
+       * 冗長なパスセグメントを禁止する（`./foo/index` → `.`、`../x/../y` など）
+       *
+       * noUselessIndex で `index` の明示も省かせる。
+       *
+       * @see https://github.com/un-ts/eslint-plugin-import-x/blob/HEAD/docs/rules/no-useless-path-segments.md
+       */
+      "import-x/no-useless-path-segments": ["warn", { noUselessIndex: true }],
     },
   });
 }


### PR DESCRIPTION
## 概要

`@nozomiishii/eslint-config` の import-x ルールに2つ追加し、相対 import を拡張子なし・`/index` 省略に統一する。tsdown / bundler module resolution 前提なので `.js` を書かずに済む。

## 追加ルール

- `import-x/extensions`: base を `ignorePackages` にし、`pattern` で `js/jsx/ts/tsx` と `mjs/cjs/mts/cts` を `never`。これで JS/TS 系拡張子は省略強制、列挙していない拡張子（`json` / `yaml` / `css` など）は `ignorePackages` の挙動で拡張子維持のまま残る。`checkTypeImports: true` で `import type` も対象。
- `import-x/no-useless-path-segments`: `{ noUselessIndex: true }`。`./foo/index` → `.` のように冗長な `index` も省かせる。

## 破壊的変更ではない理由

ルール追加は機能追加（`feat`）。consumer が更新すると新たな lint 指摘が出るが、autofix 可能で挙動互換性は壊さないため `!` は付けない。

## 事前準備

リポジトリ内の既存違反は #2333 で先に解消済み（reformat を別 PR に分離）。本 PR は eslint-config のみ変更。

## 検証

eslint-config を build し直し、`eslint-config` 自身と `nozo` の lint（`--max-warnings=0`、新ルール有効）が両方 0 件。tsc / prettier も green。