### PR TITLE
fix: disable vitest prefer-describe-function-title rule

### DIFF
--- a/packages/eslint-config/rules/viest.ts
+++ b/packages/eslint-config/rules/viest.ts
@@ -50,6 +50,13 @@ export function viest() {
         "vitest/no-done-callback": "off",
 
         /**
+         * 名前だけのdescribeをdescribe(関数)化して温存する方向に働くためoffにする。describe(関数)は使いたい場面で手書きする。
+         *
+         * @see https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-describe-function-title.md
+         */
+        "vitest/prefer-describe-function-title": "off",
+
+        /**
          * 非同期テストなどで、期待されるアサーションが呼び出されない場合を防ぐ
          *
          * @see https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-expect-assertions.md

--- a/packages/eslint-config/rules/viest.ts
+++ b/packages/eslint-config/rules/viest.ts
@@ -50,7 +50,7 @@ export function viest() {
         "vitest/no-done-callback": "off",
 
         /**
-         * 名前だけのdescribeをdescribe(関数)化して温存する方向に働くためoffにする。describe(関数)は使いたい場面で手書きする。
+         * 関数ごとにファイル分けているのでテストの中であえて関数と明示しなくても良いという判断。
          *
          * @see https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-describe-function-title.md
          */


### PR DESCRIPTION
## 概要

`packages/eslint-config/rules/viest.ts` で `vitest/prefer-describe-function-title` を `off` にする。`@vitest/eslint-plugin` の `configs.all` から `warn` で入っていたものを明示上書きする。

Closes #2352

## なぜ

このルールはタイトルが import 名と一致する `describe('importedName')` を `describe(importedName)`（関数渡し）へ autofix する。効くのはフック・`.each`・モディファイアを持たない「名前だけの describe」が大半で、それは flat にしてテストの文字列タイトルで語る方が読みやすい。結果として「消すべき名前だけ describe」を function-title 化して温存する方向に働くため off にする。

`describe(関数)` 自体（リネーム追従・名前の二重管理解消）は有用なので、使いたい場面で手書きする。

## スコープ外

issue の「関連」で挙がっていた以下は本 PR では扱わない。

- `vitest/prefer-importing-vitest-globals`: `warn` のまま。bun:test consumer 側で対応する方針。
- `configs.all` → `recommended` 移行の検討（`viest.ts` のメモ）。

## 検証

- `pnpm --filter @nozomiishii/eslint-config lint`（max-warnings=0）通過
- `check:ts`（tsc）エラーなし
- `test`（vitest）10 passed
- 解決後 config で `vitest/prefer-describe-function-title` が `off` になることを `eslint --print-config` で確認
- `eslint-typegen.d.ts` に差分なし
