### PR TITLE
fix: disable vitest/prefer-expect-resolves for bun:test compat

### DIFF
--- a/packages/eslint-config/rules/viest.ts
+++ b/packages/eslint-config/rules/viest.ts
@@ -63,7 +63,7 @@ export function viest() {
         ],
 
         /**
-         * `.resolves` を await する形は bun:test で型エラーになる（matcher が void）ため off。
+         * bunが対応してないのと、playwrightっぽくexpectをそのままassertしてもいいという判断
          *
          * @see https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-expect-resolves.md
          */

--- a/packages/eslint-config/rules/viest.ts
+++ b/packages/eslint-config/rules/viest.ts
@@ -63,6 +63,13 @@ export function viest() {
         ],
 
         /**
+         * `.resolves` を await する形は bun:test で型エラーになる（matcher が void）ため off。
+         *
+         * @see https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-expect-resolves.md
+         */
+        "vitest/prefer-expect-resolves": "off",
+
+        /**
          * describe句は必要に応じて使う
          *
          * @see https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/require-top-level-describe.md


### PR DESCRIPTION
Closes #2353

## 概要

`packages/eslint-config/rules/viest.ts` は `@vitest/eslint-plugin` の `configs.all` を適用しており `vitest/prefer-expect-resolves` が有効だった。これを off にする。

## 課題

`prefer-expect-resolves` は `expect(await x).toBe(v)` を `await expect(x).resolves.toBe(v)` へ autofix する。この形は vitest でだけ型が通る。bun:test（bun-types）では `.resolves` が `Matchers<Awaited<T>>` で matcher が void を返すため `await (void)` となり型エラーになる:

- `@typescript-eslint/await-thenable`
- `@typescript-eslint/no-confusing-void-expression`

bun:test では `expect(await x).toBe(v)`（await を expect の中）が型クリーンな形。`viest()` は base 経由で全 consumer に効くため、bun:test を採用する consumer（git-harvest）が壊れる。

## 変更

`vitest/prefer-expect-resolves` を off に追加した。配置と説明コメントは既存の off ルール（`no-done-callback` / `require-top-level-describe`）に合わせている。

## スコープ

#2353 のみ。同じ `configs.all` 由来で bun:test を壊す `prefer-describe-function-title`（#2352）と `prefer-importing-vitest-globals` は `warn` のまま据え置き。

## 検証

- 変更後の `viest()` を評価し、merged config で当該ルールが `off`、対象 files が `**/*.{test,spec}.{ts,tsx}` のままを確認。
- pre-push の `eslint --max-warnings=0` が eslint-config / nozo とも通過。
