### PR TITLE
fix: disable vitest max-expects rule

### DIFF
--- a/packages/eslint-config/rules/viest.ts
+++ b/packages/eslint-config/rules/viest.ts
@@ -32,9 +32,11 @@ export function viest() {
         "vitest/consistent-test-it": ["warn", { fn: "test" }],
 
         /**
-         * 同一テスト内で複数expectやめる
+         * 1テスト1振る舞いに合わせ、同じ振る舞いを検証する複数 expect は許容する。
+         *
+         * @see https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/max-expects.md
          */
-        "vitest/max-expects": ["error", { max: 1 }],
+        "vitest/max-expects": "off",
 
         /**
          * describeのネストやめる


### PR DESCRIPTION
## 概要

`packages/eslint-config/rules/viest.ts` で `vitest/max-expects` を `off` にする。`@vitest/eslint-plugin` の `configs.all` から `["error", { max: 1 }]` で入っていたものを明示上書きする。

Closes #2354

## なぜ

`max: 1` は「1テスト1アサーション」を強制する。現在の主流は「1テスト1振る舞い」で、同じ振る舞いを検証する複数 expect は許容し、統合 / E2E では複数 expect が普通。

`max-expects` はプラグイン既定が `max: 5` で、vitest / jest とも recommended に入っていない（既定 off）。主要 config（antfu / sxzz / jest-recommended / vitest-recommended / tjw-jest）も有効化しておらず、`max: 1` は既定より厳しく recommended の流儀からも外れた外れ値。

発端は git-harvest（bun:test・統合テスト主体）で `max: 1` が 129 件発火したこと。

## スコープ外

- `configs.all` → `recommended` 移行の検討（`viest.ts` のメモ）。#2352 / #2353 と同根の系統だが、一括対応は別途。

## 検証

- `pnpm --filter @nozomiishii/eslint-config lint`（max-warnings=0）通過
- `check:ts`（tsc）エラーなし
- `test`（vitest）10 passed
- 解決後 config で `vitest/max-expects` が `off`（`eslint --print-config` で `0`）になることを確認
- `eslint-typegen.d.ts` に差分なし

## 出典

- https://stackoverflow.blog/2022/11/03/multiple-assertions-per-test-are-fine/
- https://kentcdodds.com/blog/write-fewer-longer-tests
- https://testing.googleblog.com/2014/04/testing-on-toilet-test-behaviors-not.html
- https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/max-expects.md
