### PR TITLE
fix: correct viest typo to vitest in eslint-config

### DIFF
--- a/packages/eslint-config/CLAUDE.md
+++ b/packages/eslint-config/CLAUDE.md
@@ -7,4 +7,4 @@
 
 ## vitest ルールの方針
 
-- `rules/viest.ts` は今 `configs.all`。実体験ベースで不要ルールを off にし、いずれ `recommended` へ切替予定。判定の追跡は [#2358](https://github.com/nozomiishii/configs/issues/2358)。
+- `rules/vitest.ts` は今 `configs.all`。実体験ベースで不要ルールを off にし、いずれ `recommended` へ切替予定。判定の追跡は [#2358](https://github.com/nozomiishii/configs/issues/2358)。

--- a/packages/eslint-config/CLAUDE.md
+++ b/packages/eslint-config/CLAUDE.md
@@ -4,3 +4,7 @@
 
 - 各 rule には概要を掴める短い 1 文だけ書く。
 - 詳細は公式ドキュメントへの `@see` リンクに委ねる。
+
+## vitest ルールの方針
+
+- `rules/viest.ts` は今 `configs.all`。実体験ベースで不要ルールを off にし、いずれ `recommended` へ切替予定。判定の追跡は [#2358](https://github.com/nozomiishii/configs/issues/2358)。

--- a/packages/eslint-config/presets/base.ts
+++ b/packages/eslint-config/presets/base.ts
@@ -11,7 +11,7 @@ import {
   stylistic,
   typescript,
   unicorn,
-  viest,
+  vitest,
 } from "../rules";
 import { name } from "../utils/name";
 
@@ -51,7 +51,7 @@ export function base() {
     deMorgan(),
     regexp(),
 
-    viest(),
+    vitest(),
 
     perfectionist(),
     stylistic(),

--- a/packages/eslint-config/rules/index.ts
+++ b/packages/eslint-config/rules/index.ts
@@ -42,4 +42,4 @@ export { typescript } from "./typescript";
 
 export { unicorn } from "./unicorn";
 
-export { viest } from "./viest";
+export { vitest } from "./vitest";

--- a/packages/eslint-config/rules/vitest.ts
+++ b/packages/eslint-config/rules/vitest.ts
@@ -7,13 +7,13 @@ import { name } from "../utils/name";
  *
  * @see https://github.com/vitest-dev/eslint-plugin-vitest
  */
-export function viest() {
+export function vitest() {
   return defineConfig([
     {
       ...eslintPluginVitest.configs.all,
       files: ["**/*.{test,spec}.{ts,tsx}"],
       ignores: ["**/e2e/**"],
-      name: name("viest"),
+      name: name("vitest"),
 
       rules: {
         ...eslintPluginVitest.configs.all.rules,


### PR DESCRIPTION
## 概要

eslint-config の `viest` というタイポを `vitest` に修正する。あわせて先に追記した vitest ルールの運用方針メモも含む。

## 背景

vitest ルールの preset 関数が `viest` と誤記されていた。ファイル名・export 名・`name()` の識別子すべてが `viest`。ルート `index.ts` が `export * from "./rules"` で再 export しているため、この誤記は公開 API 面にも露出していた。

## 変更内容

- `rules/viest.ts` → `rules/vitest.ts` にリネーム
- 関数名 `viest()` → `vitest()`、`name("viest")` → `name("vitest")`
- `rules/index.ts` の re-export を `vitest` に修正
- `presets/base.ts` の import と呼び出しを `vitest` に修正
- `CLAUDE.md` に vitest ルールの方針を追記（参照パスも `rules/vitest.ts` に統一）

`CHANGELOG.md` 内の過去の `viest` 表記は release-please 管理の履歴（当時のコミットメッセージのスナップショット）のため、意図的に残している。

## 検証

ローカルで以下を確認:

- `check:ts`（tsc）: エラーなし
- `lint`（eslint --max-warnings=0）: pass
- `test`（vitest run）: 10 passed
- `build`（tsdown）: 成功

## breaking change の扱いについて

`viest` はルート経由で公開 export されていたため、`import { viest }` していた consumer には厳密には breaking。ただし誤記で実用上参照され得ない前提で `fix:`（patch bump）として扱っている。major 扱いにしたい場合は教えてください。

## 関連

- #2358