### PR TITLE
feat: ban inline eslint config via noInlineConfig

### DIFF
--- a/packages/eslint-config/presets/base.ts
+++ b/packages/eslint-config/presets/base.ts
@@ -41,6 +41,17 @@ export function base() {
       name: name("languageOptions/parserOptions"),
     },
 
+    /**
+     * inline の disable / 設定コメントを無効化し、config 外から上書きできなくする。
+     * no-use 単体だと no-use 自身を巻き込んで bypass できるため、併用で抜け道を塞ぐ。
+     *
+     * @see https://eslint.org/docs/latest/use/configure/rules
+     */
+    {
+      linterOptions: { noInlineConfig: true },
+      name: name("linterOptions/noInlineConfig"),
+    },
+
     javascript(),
     typescript(),
     importX(),

--- a/packages/eslint-config/presets/base.ts
+++ b/packages/eslint-config/presets/base.ts
@@ -42,7 +42,7 @@ export function base() {
     },
 
     /**
-     * inline の disable / 設定コメントを無効化し、config 外から上書きできなくする。
+     * inline の disableコメントを無効化。必ずeslint.config.tsで設定の変更はする。
      *
      * @see https://eslint.org/docs/latest/use/configure/rules
      */

--- a/packages/eslint-config/presets/base.ts
+++ b/packages/eslint-config/presets/base.ts
@@ -43,7 +43,6 @@ export function base() {
 
     /**
      * inline の disable / 設定コメントを無効化し、config 外から上書きできなくする。
-     * no-use 単体だと no-use 自身を巻き込んで bypass できるため、併用で抜け道を塞ぐ。
      *
      * @see https://eslint.org/docs/latest/use/configure/rules
      */

--- a/packages/eslint-config/presets/base.ts
+++ b/packages/eslint-config/presets/base.ts
@@ -49,7 +49,7 @@ export function base() {
      */
     {
       linterOptions: { noInlineConfig: true },
-      name: name("linterOptions/noInlineConfig"),
+      name: name("linterOptions"),
     },
 
     javascript(),

--- a/packages/eslint-config/rules/eslint-comments.ts
+++ b/packages/eslint-config/rules/eslint-comments.ts
@@ -19,6 +19,11 @@ export function eslintComments() {
           "error",
           { allowWholeFile: true },
         ],
+        /**
+         * disable コメント自体を禁止する。ただし no-use 自身を巻き込んで
+         * disable すれば bypass できるため、base preset の noInlineConfig と
+         * 併用して抜け道を塞ぐ。
+         */
         "@eslint-community/eslint-comments/no-use": "error",
       },
     },


### PR DESCRIPTION
## 背景

inline の eslint disable コメントは、それっぽい理由で雑に付けられ放置されやすい。例外は共有 config に明文化したい、という方針。

`@eslint-community/eslint-comments/no-use: "error"`（disable コメント禁止）は有効化済みだが、no-use は ルール なので `// eslint-disable-next-line @eslint-community/eslint-comments/no-use, <別ルール>` のように no-use 自身を巻き込んで disable すれば bypass できる。

## 変更

base preset（`presets/base.ts`）に `linterOptions: { noInlineConfig: true }` を追加した。base は `node` / `nextjs` が `...base()` で継承するため、全 preset に効く。

`noInlineConfig` は inline の disable / 設定コメントを無効化し、inline からは上書きできない一方通行。no-use（存在を error 化）との併用で「inline disable 禁止・例外は config のみ・抜け道なし」が成立する。no-use 自身も noInlineConfig 下では inline で切れないため、上記 bypass も封じられる。

## 影響調査

リポジトリ全体の inline directive は 1 件のみ（自動生成の `eslint-typegen.d.ts:1` の `/* eslint-disable */`）。このファイルは `.gitignore` 登録済みで base 先頭の `gitignore()` により元々 lint 対象外なので、当該コメントは既に無効。noInlineConfig で壊れる実例外はゼロ（Issue の「無ければ全面適用でよい」条件を満たす）。

## 検証

- `--print-config` で resolved config に `noInlineConfig: true` を確認
- 一時ファイルに `/* eslint-disable */` を付けて lint → disable が無視され `no-unused-vars` が fire、ESLint が `has no effect because you have 'noInlineConfig'` を報告、no-use / no-unlimited-disable / unicorn も error 報告
- `packages/eslint-config`: lint / check:ts / build / test（10 passed）すべて成功
- workspace 全体 lint（実 consumer の `packages/nozo` 含む）成功

Closes #2359