### PR TITLE
feat: infer package manager from runner in nozo init

### DIFF
--- a/packages/nozo/src/commands/init.test.ts
+++ b/packages/nozo/src/commands/init.test.ts
@@ -1,8 +1,20 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { test as baseTest, expect } from "vitest";
-import { toolIds, tools } from "./init";
+import { test as baseTest, expect, vi } from "vitest";
+import { resolvePackageManager, toolIds, tools } from "./init";
+
+// npm_config_user_agent を一時的に差し替える。value 省略でランナー無しを再現する。
+// process.env 直接操作は n/no-process-env で禁止のため vi.stubEnv を使う。
+function stubUserAgent(value?: string) {
+  vi.stubEnv("npm_config_user_agent", value);
+
+  return {
+    [Symbol.dispose]() {
+      vi.unstubAllEnvs();
+    },
+  };
+}
 
 const test = baseTest.extend<{ cwd: string }>({
   cwd: async ({ task: _ }, provide) => {
@@ -26,4 +38,37 @@ test("happy path: every tool's install script completes without throwing", async
   for (const id of toolIds) {
     await expect(tools[id].run({ cwd })).resolves.toBeUndefined();
   }
+});
+
+// lockfile も packageManager フィールドも無いとき、nozo を起動したランナーを使う。
+test("falls back to the launching runner when the project has no config", async ({ cwd }) => {
+  using ua = stubUserAgent("bun/1.3.11 npm/? node/v24 darwin arm64");
+  void ua;
+
+  await expect(resolvePackageManager(cwd)).resolves.toStrictEqual({
+    agent: "bun",
+    source: "runner",
+  });
+});
+
+// 設定もランナーも無いときは throw する。
+test("throws when neither project config nor runner is available", async ({ cwd }) => {
+  using ua = stubUserAgent();
+  void ua;
+
+  await expect(resolvePackageManager(cwd)).rejects.toThrow(
+    "Could not determine a package manager",
+  );
+});
+
+// プロジェクトの lockfile はランナーより優先される。
+test("prefers project config over the launching runner", async ({ cwd }) => {
+  writeFileSync(path.join(cwd, "pnpm-lock.yaml"), "");
+  using ua = stubUserAgent("bun/1.3.11 npm/? node/v24 darwin arm64");
+  void ua;
+
+  await expect(resolvePackageManager(cwd)).resolves.toStrictEqual({
+    agent: "pnpm",
+    source: "project",
+  });
 });

--- a/packages/nozo/src/commands/init.ts
+++ b/packages/nozo/src/commands/init.ts
@@ -7,7 +7,7 @@ import { init as initPrettier } from "@nozomiishii/prettier-config/init";
 import { defineCommand } from "citty";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { type AgentName, detect } from "package-manager-detector";
+import { type AgentName, detect, getUserAgent } from "package-manager-detector";
 
 const exec = promisify(execFile);
 
@@ -68,14 +68,25 @@ export type ToolId = keyof typeof tools;
 
 export const toolIds = Object.keys(tools) as ToolId[];
 
-async function detectPackageManager(cwd: string): Promise<AgentName> {
-  const result = await detect({ cwd });
+export async function resolvePackageManager(
+  cwd: string,
+): Promise<{ agent: AgentName; source: "project" | "runner" }> {
+  const detected = await detect({ cwd });
 
-  if (result === null) {
-    throw new Error("Could not detect package manager (no lockfile or packageManager field).");
+  if (detected !== null) {
+    return { agent: detected.name, source: "project" };
   }
 
-  return result.name;
+  // lockfile も packageManager フィールドも無い → nozo を起動したランナーを使う
+  const runner = getUserAgent();
+
+  if (runner !== null) {
+    return { agent: runner, source: "runner" };
+  }
+
+  throw new Error(
+    "Could not determine a package manager. Run nozo through a package manager such as `pnpm dlx nozo init`, `npx nozo init`, or `bunx nozo init`.",
+  );
 }
 
 export default defineCommand({
@@ -125,8 +136,12 @@ export default defineCommand({
     }
 
     const cwd = process.cwd();
-    const agent = await detectPackageManager(cwd);
-    p.log.info(`Detected package manager: ${agent}`);
+    const { agent, source } = await resolvePackageManager(cwd);
+    p.log.info(
+      source === "project"
+        ? `Detected package manager: ${agent}`
+        : `No package manager configured; using ${agent} from the current runner`,
+    );
 
     for (const id of selected) {
       const tool = tools[id];


### PR DESCRIPTION
## 背景

`bunx nozo@latest init` を lockfile も `packageManager` フィールドも無いディレクトリで実行すると、`detect()` が null を返し `Error: Could not detect package manager` で落ちていた。新規プロジェクトで不親切なため改善する。

## 変更

`packages/nozo/src/commands/init.ts`

- `detectPackageManager` を `resolvePackageManager` にリネーム・export し、戻り値を `{ agent, source }` に変更
- 解決順を 3 段に: プロジェクト設定（lockfile / `packageManager` フィールド）→ なければ `getUserAgent()` の起動ランナー → 両方無いときだけ throw
- `getUserAgent()` は `package-manager-detector` 公開 API（`npm_config_user_agent` 先頭を `AGENTS` で検証）。手組みなし
- throw 時のメッセージを `pnpm dlx`/`npx`/`bunx` 経由の実行を案内する形に改善
- ログを検出元で出し分け（project / runner）

`packages/nozo/src/commands/init.test.ts`

- 振る舞い単位で 3 テスト追加: ランナー推定 / 両方無しで throw / プロジェクト設定がランナーより優先
- env 差し替えは `n/no-process-env` を避けて `vi.stubEnv` + `using` disposable で self-contained に

## 効果

`bunx nozo init` を新規ディレクトリで実行すると `npm_config_user_agent` が `bun/...` になるため bun が選ばれ、`bun install` まで通る。各ランナーで実測済み（`pnpm exec`→pnpm / `npm exec`→npm / `bunx`→bun / `node` 直叩き→null）。

## テスト

- `pnpm --filter nozo lint` 0 errors / 0 warnings
- `pnpm --filter nozo test` 4/4 pass
- `pnpm --filter nozo tsc` 型エラーなし
- `pnpm --filter nozo build` 成功
