### PR TITLE
chore: use onTestFinished for env cleanup in nozo init tests

### DIFF
--- a/packages/nozo/src/commands/init.test.ts
+++ b/packages/nozo/src/commands/init.test.ts
@@ -1,19 +1,16 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { test as baseTest, expect, vi } from "vitest";
+import { test as baseTest, expect, onTestFinished, vi } from "vitest";
 import { resolvePackageManager, toolIds, tools } from "./init";
 
-// npm_config_user_agent を一時的に差し替える。value 省略でランナー無しを再現する。
+// npm_config_user_agent を一時的に差し替え、テスト終了時に元へ戻す。value 省略でランナー無しを再現する。
 // process.env 直接操作は n/no-process-env で禁止のため vi.stubEnv を使う。
 function stubUserAgent(value?: string) {
   vi.stubEnv("npm_config_user_agent", value);
-
-  return {
-    [Symbol.dispose]() {
-      vi.unstubAllEnvs();
-    },
-  };
+  onTestFinished(() => {
+    vi.unstubAllEnvs();
+  });
 }
 
 const test = baseTest.extend<{ cwd: string }>({
@@ -42,8 +39,7 @@ test("happy path: every tool's install script completes without throwing", async
 
 // lockfile も packageManager フィールドも無いとき、nozo を起動したランナーを使う。
 test("falls back to the launching runner when the project has no config", async ({ cwd }) => {
-  using ua = stubUserAgent("bun/1.3.11 npm/? node/v24 darwin arm64");
-  void ua;
+  stubUserAgent("bun/1.3.11 npm/? node/v24 darwin arm64");
 
   await expect(resolvePackageManager(cwd)).resolves.toStrictEqual({
     agent: "bun",
@@ -53,8 +49,7 @@ test("falls back to the launching runner when the project has no config", async 
 
 // 設定もランナーも無いときは throw する。
 test("throws when neither project config nor runner is available", async ({ cwd }) => {
-  using ua = stubUserAgent();
-  void ua;
+  stubUserAgent();
 
   await expect(resolvePackageManager(cwd)).rejects.toThrow(
     "Could not determine a package manager",
@@ -64,8 +59,7 @@ test("throws when neither project config nor runner is available", async ({ cwd 
 // プロジェクトの lockfile はランナーより優先される。
 test("prefers project config over the launching runner", async ({ cwd }) => {
   writeFileSync(path.join(cwd, "pnpm-lock.yaml"), "");
-  using ua = stubUserAgent("bun/1.3.11 npm/? node/v24 darwin arm64");
-  void ua;
+  stubUserAgent("bun/1.3.11 npm/? node/v24 darwin arm64");
 
   await expect(resolvePackageManager(cwd)).resolves.toStrictEqual({
     agent: "pnpm",


### PR DESCRIPTION
## 背景

#2367 で追加した `nozo init` のテストは、env 差し替えの teardown を `using` の disposable で組んでいた。`using` は変数束縛が必須（式直付け `using stubUserAgent()` は構文エラー）で、その束縛変数を `@typescript-eslint/no-unused-vars`（`--max-warnings=0`）が未使用扱いするため `void ua;` を 1 行足して黙らせていた。`_ua` プレフィックスでも回避できないことは確認済み。

## 変更

`packages/nozo/src/commands/init.test.ts`

- env cleanup を `using` disposable から vitest の `onTestFinished` に変更
- 各テストの `using ua = stubUserAgent(...); void ua;`（2 行）が `stubUserAgent(...)`（1 行）になり、`void` と捨て束縛が消えた
- `onTestFinished` はテスト本体から明示的に呼ぶ per-test teardown なので、`beforeEach`/`afterEach` の共有フックは使わず self-contained を維持

挙動は不変。

## テスト

- `pnpm --filter nozo lint` 0 errors / 0 warnings
- `pnpm --filter nozo test` 4/4 pass
- `pnpm --filter nozo tsc` 型エラーなし
