### PR TITLE
feat: exclude Claude Code's .claude/settings.json from formatting

### DIFF
--- a/packages/prettier-config/README.ja.md
+++ b/packages/prettier-config/README.ja.md
@@ -33,9 +33,12 @@ pnpx nozo init
 ### ファイル除外: `.prettierignore` ではなく `requirePragma` を使う
 
 format 対象外にしたいファイル (`pnpm-lock.yaml` / `submodules/**` /
-`next-env.d.ts` / `*.md` / `*.mdx`) は、このパッケージの `overrides` で
-`requirePragma: true` を指定することで除外している。`.prettierignore`
-ファイルは作らない。
+`next-env.d.ts` / `*.md` / `*.mdx` / `**/.claude/settings.json`) は、この
+パッケージの `overrides` で `requirePragma: true` を指定して除外している。
+`.prettierignore` ファイルは作らない。
+
+`**/.claude/settings.json` は `parser: jsonc` も要る。Claude Code が多行配列で
+書き戻すうえ、`json` parser は `requirePragma` を無視するため (`jsonc` は尊重する)。
 
 `.prettierignore` を導入すると `.gitignore` と二重管理になり、片方だけ
 更新する事故を起こしやすい。Prettier 3.x は `.gitignore` を自動で尊重

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -36,8 +36,13 @@ re-exports the shared config.
 ### File exclusion: `requirePragma` over `.prettierignore`
 
 Files that should never be formatted (`pnpm-lock.yaml`, `submodules/**`,
-`next-env.d.ts`, `*.md`, `*.mdx`) are excluded via `requirePragma: true`
-overrides in this config rather than a `.prettierignore` file.
+`next-env.d.ts`, `*.md`, `*.mdx`, `**/.claude/settings.json`) are excluded
+via `requirePragma: true` overrides in this config rather than a
+`.prettierignore` file.
+
+`**/.claude/settings.json` also needs `parser: jsonc`: Claude Code writes it
+with multi-line arrays, and the `json` parser ignores `requirePragma` while
+`jsonc` honors it.
 
 A `.prettierignore` would duplicate patterns already in `.gitignore` and
 invite drift between the two. Prettier 3.x already honors `.gitignore`

--- a/packages/prettier-config/src/index.ts
+++ b/packages/prettier-config/src/index.ts
@@ -88,6 +88,15 @@ export default {
       },
     },
     {
+      // Claude Code が多行で書き戻す settings.json を prettier に整形させない。
+      // json parser は requirePragma を無視するので、尊重する jsonc に切替える。
+      files: ["**/.claude/settings.json"],
+      options: {
+        parser: "jsonc",
+        requirePragma: true,
+      },
+    },
+    {
       // JSONC / JSON5 は native parser に委ねコメント等の言語機能を保つ。
       // ただし VSCode の JSONC モードは trailing comma を allowed-but-discouraged 扱いで warning を出す
       // ({@link https://code.visualstudio.com/docs/languages/json}) ため、自動付与は止める


### PR DESCRIPTION
## 概要

prettier が `**/.claude/settings.json` を整形しないよう、`overrides` を 1 件追加する。

## 背景

Claude Code は settings.json を `JSON.stringify(value, null, 2)` で丸ごと書き戻すため、配列が常に多行になる。prettier は短い配列を単一行へ潰すので、Claude Code が触るたびに往復 diff（churn）が出る。

## 対応

`requirePragma` だけでは除外できない。`json` パーサーは `hasPragma` を true 固定にしていて `requirePragma` を無視するため。`requirePragma` を尊重する `jsonc` パーサーに切替えると除外が効く。

```ts
{
  files: ["**/.claude/settings.json"],
  options: { parser: "jsonc", requirePragma: true },
}
```

## 検証

- 手元の prettier で確認: 多行配列の settings.json は無変更、`.claude` 外の json は通常どおり整形
- `tsc --noEmit` クリーン、prettier クリーン
- README.md / README.ja.md を同期更新

## 後続

release 後、利用側（dotfiles 等）で `@nozomiishii/prettier-config` を bump し、ローカルの回避策を外す。
