### PR TITLE
feat: add ignore options to no-unused-vars

### DIFF
--- a/packages/eslint-config/rules/typescript.ts
+++ b/packages/eslint-config/rules/typescript.ts
@@ -39,16 +39,27 @@ export function typescript() {
         ],
 
         /**
-         * 使ってない引数はアンダースコア始まりにする
+         * 未使用の変数・引数を検出する
          *
          * @see https://typescript-eslint.io/rules/no-unused-vars
          */
         "@typescript-eslint/no-unused-vars": [
           "warn",
           {
+            // 未使用の引数は _ 始まりで許容
             argsIgnorePattern: "^_",
+            // catch の未使用エラーは _ 始まりで許容
             caughtErrorsIgnorePattern: "^_",
+            // 配列分割代入の未使用要素は _ 始まりで許容
             destructuredArrayIgnorePattern: "^_",
+            // --fix で未使用 import を自動削除する
+            enableAutofixRemoval: { imports: true },
+            // { a, ...rest } で抜き出した a を未使用扱いしない
+            ignoreRestSiblings: true,
+            // using / await using は未使用でも許容
+            ignoreUsingDeclarations: true,
+            // 未使用の局所変数は _ 始まりで許容
+            varsIgnorePattern: "^_",
           },
         ],
       },


### PR DESCRIPTION
## 概要

`@typescript-eslint/no-unused-vars`（`packages/eslint-config/rules/typescript.ts`）に、意図的な未使用束縛を素直に通すためのオプションを追加する。

## 変更

| オプション | 効果 |
|---|---|
| `varsIgnorePattern: "^_"` | `_` 始まりの未使用局所変数を許容（Issue #2371 本体） |
| `ignoreUsingDeclarations: true` | `using` / `await using` を未使用扱いしない。意味のある名前で書け、複数 `using` の `_` 衝突も回避 |
| `ignoreRestSiblings: true` | `const { password, ...rest }` の omit パターンが素通り |
| `enableAutofixRemoval: { imports: true }` | `--fix` で未使用 import を自動削除 |

各オプションには 1 行コメントを添えた。冒頭 JSDoc は `_` 規約を各行へ移したぶん、ルール本来の目的を示す一文に戻した。

## 文脈

git-harvest（bun:test→vitest 移行）で `using _ = withNoColor()` 等のためローカル override していた `varsIgnorePattern` を共有 config に取り込む。あわせて `using` は dispose 副作用が目的でそもそも未使用概念が当てはまらないため `ignoreUsingDeclarations` も入れ、`using _` の `_` 縛り（複数 `using` でブロックスコープ衝突）を解消する。

## 検証

- `pnpm --filter @nozomiishii/eslint-config build` 成功
- `tsc --noEmit`（typegen 型が新キーを受理）成功
- `eslint` 警告・エラーなし
- pre-push lint 通過

Closes #2371