### PR TITLE
chore: document nozo-commitlint dlx usage in commitlint-config readme

### DIFF
--- a/packages/commitlint-config/README.ja.md
+++ b/packages/commitlint-config/README.ja.md
@@ -48,11 +48,14 @@ export default {
 
 ## 同梱 bin
 
-このパッケージは pin された `@commitlint/cli` をラップする `nozo-commitlint` という namespace 付きの bin も同梱しています。Lefthook の設定（例: `@nozomiishii/lefthook-config`）からはこの shim を直接呼び出します:
+このパッケージは pin された `@commitlint/cli` をラップする `nozo-commitlint` という namespace 付きの bin も同梱しています。bin 名はパッケージ名と異なるため、`devDependencies` に追加せず実行するときは `--package` でパッケージを指定します:
 
-```yaml
-commit-msg:
-  jobs:
-    - name: commitlint
-      run: node_modules/.bin/nozo-commitlint --edit {1} --verbose
+```sh
+# 直近のコミットを lint
+pnpm --package=@nozomiishii/commitlint-config dlx nozo-commitlint --last --verbose
+
+# 特定の commit-msg ファイルを lint
+pnpm --package=@nozomiishii/commitlint-config dlx nozo-commitlint --edit .git/COMMIT_EDITMSG
 ```
+
+commit-msg の git hook に組み込む方法は [`@nozomiishii/lefthook-config`](../lefthook-config) を参照。

--- a/packages/commitlint-config/README.md
+++ b/packages/commitlint-config/README.md
@@ -49,13 +49,17 @@ export default {
 
 ## Bin
 
-The package also ships a namespaced bin, `nozo-commitlint`, which wraps the
-pinned `@commitlint/cli`. Lefthook configs (e.g. `@nozomiishii/lefthook-config`)
-invoke the shim directly:
+The package also ships a namespaced bin, `nozo-commitlint`, that wraps the
+pinned `@commitlint/cli`. The bin name differs from the package name, so to
+run it without adding the package to your `devDependencies`, pass `--package`:
 
-```yaml
-commit-msg:
-  jobs:
-    - name: commitlint
-      run: node_modules/.bin/nozo-commitlint --edit {1} --verbose
+```sh
+# Lint the most recent commit
+pnpm --package=@nozomiishii/commitlint-config dlx nozo-commitlint --last --verbose
+
+# Lint a specific commit-msg file
+pnpm --package=@nozomiishii/commitlint-config dlx nozo-commitlint --edit .git/COMMIT_EDITMSG
 ```
+
+To wire it into a commit-msg git hook, see
+[`@nozomiishii/lefthook-config`](../lefthook-config).


### PR DESCRIPTION
## 変更内容

commitlint-config の README（日英）の `## Bin` セクションを更新。

- lefthook の YAML サンプルを削除し、commit-msg hook への組み込みは [`@nozomiishii/lefthook-config`](packages/lefthook-config) へのリンクに委譲
- bin `nozo-commitlint` を DevDependency 未追加で実行する例を `pnpm --package=... dlx` 形式で追加

## 背景

README の YAML サンプルが実装（`packages/lefthook-config/hooks/commit-msg/commitlint.yaml`）と `--edit {1}` の quote 有無で食い違っていた。lefthook 固有の記法を commitlint-config 側に複製せず、lefthook-config の README を単一の正とする形へ整理。

## 確認

- `pnpm --package=@nozomiishii/commitlint-config dlx nozo-commitlint --version` → `@commitlint/cli@21.0.2`（実機確認）
- bin 名 `nozo-commitlint` はパッケージ名 `@nozomiishii/commitlint-config` と異なるため `--package` 指定が必須。`--package` を `dlx` の後ろに置くと誤動作するため `pnpm` 直後に置く
- `markdownlint-cli2` 0 error