### PR TITLE
chore: quote {1} in lefthook-config readme to match the hook impl

### DIFF
--- a/packages/lefthook-config/README.ja.md
+++ b/packages/lefthook-config/README.ja.md
@@ -93,10 +93,10 @@ bin はフラットな namespace に置かれます。`commitlint-config` は `@
 
 ```yaml
 # 速い経路
-run: node_modules/.bin/nozo-commitlint --edit {1}
+run: node_modules/.bin/nozo-commitlint --edit "{1}"
 
 # 余分な spawn が発生する経路（lefthook -> nozo -> shim -> commitlint）
-run: node_modules/.bin/nozo run commitlint --edit {1}
+run: node_modules/.bin/nozo run commitlint --edit "{1}"
 ```
 
 ### Rule 5: 各 shim は対応する config パッケージに同梱する

--- a/packages/lefthook-config/README.md
+++ b/packages/lefthook-config/README.md
@@ -102,10 +102,10 @@ Bins are in a flat namespace. `commitlint-config` exposes its shim as `nozo-comm
 
 ```yaml
 # fast path
-run: node_modules/.bin/nozo-commitlint --edit {1}
+run: node_modules/.bin/nozo-commitlint --edit "{1}"
 
 # extra spawn (lefthook -> nozo -> shim -> commitlint)
-run: node_modules/.bin/nozo run commitlint --edit {1}
+run: node_modules/.bin/nozo run commitlint --edit "{1}"
 ```
 
 ### Rule 5: each shim lives where its config package lives


### PR DESCRIPTION
## 変更内容

`packages/lefthook-config/README.md` / `README.ja.md` の Rule 4 の例で `--edit {1}` → `--edit "{1}"` に揃えた（各ファイル2箇所、計4箇所）。

## 背景

実装の commit-msg フラグメント `packages/lefthook-config/hooks/commit-msg/commitlint.yaml` は `--edit "{1}"`（quote あり）。lefthook の `{1}`（commit-msg ファイルパス）にスペースが入っても壊れないための quote。README の例が quote なしで実装と食い違っていたため揃えた。

[#2381](https://github.com/nozomiishii/configs/pull/2381) で commitlint-config 側の lefthook サンプルを撤去した際の横断確認で見つけた残件。

## 確認

- `markdownlint-cli2` 0 error
- Rule 4 の主眼（shim 直叩き vs `nozo` 経由）は不変。差分は quote のみ