### PR TITLE
fix: enable curly all after the prettier layer

### DIFF
--- a/packages/eslint-config/rules/javascript.ts
+++ b/packages/eslint-config/rules/javascript.ts
@@ -18,6 +18,9 @@ export function javascript() {
       rules: {
         ...eslintConfigJavascript.configs.recommended.rules,
         /**
+         * prettier 層が off にするため ./prettier.ts(prettier/overrides)で有効化中。
+         * stylistic へ移行したらここを復活させる。
+         *
          * if, else, while, for などで波括弧を省略しないように統一
          *
          * @see https://github.com/prettier/eslint-config-prettier?tab=readme-ov-file#curly

--- a/packages/eslint-config/rules/prettier.ts
+++ b/packages/eslint-config/rules/prettier.ts
@@ -13,5 +13,18 @@ export function prettier() {
       ...eslintConfigPrettier,
       name: name("prettier"),
     },
+
+    {
+      name: name("prettier/overrides"),
+      rules: {
+        /**
+         * eslint-config-prettier が off にする safe な special rule を後段で再有効化。
+         * "all" は Prettier と競合しないため、prettier 適用後の再設定が推奨されている。
+         *
+         * @see https://github.com/prettier/eslint-config-prettier?tab=readme-ov-file#curly
+         */
+        curly: ["warn", "all"],
+      },
+    },
   ]);
 }


### PR DESCRIPTION
## 変更内容

`@nozomiishii/eslint-config` の `curly: ["warn", "all"]` が prettier 層（`eslint-config-prettier`）に severity off で上書きされ、consumer で `curly = [0, "all"]` と無効化されていた問題を修正。

- `rules/prettier.ts`: prettier 適用後の `prettier/overrides` 層を追加し `curly: ["warn", "all"]` を再有効化（eslint-config-prettier 公式の作法）。`prettier()` は各 preset が末尾で 1 回付ける規約なので、新 preset でも順序が自動で保証され再発しない
- `rules/javascript.ts`: curly の定義はそのまま残し、prettier 層との関係と stylistic 移行時の扱いをコメントで明記

## 背景

`eslint-config-prettier` は `curly` の `multi-line` / `multi-or-nest` が Prettier の行折りと競合し得るため `specialRule = 0` でルールごと off にする（`all` は safe）。公式の作法は「eslint-config-prettier 適用の後で safe オプションの curly を再設定する」。現状は javascript 層（前）→ prettier 層（後）の順で、再設定が prettier の前にあり潰されていた。

`specialRule = 0` 群（`@stylistic/quotes`, `max-len`, `unicorn/template-indent` 等）のうち自分たちの preset で設定しているのは `curly` のみと棚卸し済み。他に潰されている safe オプションは無い。

## 確認

- `eslint --print-config` の resolved `curly`: 修正前 `[0, "all"]` → 修正後 `[1, "all"]`
- `pnpm lint` / `pnpm check:ts`: OK
- consumer の `nozo`（workspace 利用）lint: clean（curly 有効化で破綻なし）

Closes #2384
