### PR TITLE
feat: add const preference lint rules

### DIFF
--- a/packages/eslint-config/CLAUDE.md
+++ b/packages/eslint-config/CLAUDE.md
@@ -5,6 +5,10 @@
 - 各 rule には概要を掴める短い 1 文だけ書く。
 - 詳細は公式ドキュメントへの `@see` リンクに委ねる。
 
+## rule の severity 方針
+
+- Auto Fix できる rule は `warn`、Auto Fix できない rule は `error` を基本にする。
+
 ## vitest ルールの方針
 
 - `rules/vitest.ts` は今 `configs.all`。実体験ベースで不要ルールを off にし、いずれ `recommended` へ切替予定。判定の追跡は [#2358](https://github.com/nozomiishii/configs/issues/2358)。

--- a/packages/eslint-config/rules/javascript.ts
+++ b/packages/eslint-config/rules/javascript.ts
@@ -49,6 +49,20 @@ export function javascript() {
         "no-useless-rename": "warn",
 
         /**
+         * var を禁止し、ブロックスコープの let / const に統一
+         *
+         * @see https://eslint.org/docs/latest/rules/no-var
+         */
+        "no-var": "warn",
+
+        /**
+         * 再代入しない let は const に統一
+         *
+         * @see https://eslint.org/docs/latest/rules/prefer-const
+         */
+        "prefer-const": "warn",
+
+        /**
          * 比較式において、リテラルを前に置く「ヨーダ条件」を禁止
          *
          * @see https://eslint.org/docs/latest/rules/yoda


### PR DESCRIPTION
## Summary
- Enable `no-var` and `prefer-const` as warnings in the shared JavaScript ESLint rules.
- Document the eslint-config severity policy: autofixable rules default to `warn`, non-autofixable rules default to `error`.

## Test plan
- [x] `pnpm --filter @nozomiishii/eslint-config lint`
- [x] pre-commit `format` and `lint-markdown`
- [x] commit-msg `commitlint`