### PR TITLE
feat: support per-package tsconfigRootDir in eslint-config

### DIFF
--- a/packages/eslint-config/eslint.config.ts
+++ b/packages/eslint-config/eslint.config.ts
@@ -1,4 +1,6 @@
 import { defineConfig } from "eslint/config";
 import { node } from "./presets/node";
 
-export default defineConfig([...node()]);
+export default defineConfig([
+  ...node({ typescript: { tsconfigRootDir: import.meta.dirname } }),
+]);

--- a/packages/eslint-config/index.ts
+++ b/packages/eslint-config/index.ts
@@ -2,4 +2,6 @@ export * from "./presets";
 
 export * from "./rules";
 
+export type * from "./types";
+
 export { defineConfig } from "eslint/config";

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -31,6 +31,7 @@
     "presets",
     "rules",
     "starters",
+    "types",
     "utils",
     "eslint-typegen.d.ts",
     "README.md",

--- a/packages/eslint-config/presets/base.ts
+++ b/packages/eslint-config/presets/base.ts
@@ -1,5 +1,6 @@
 import gitignore from "eslint-config-flat-gitignore";
 import { defineConfig } from "eslint/config";
+import type { Options } from "../types";
 import {
   deMorgan,
   eslintComments,
@@ -21,10 +22,10 @@ import { name } from "../utils/name";
  * prettier は含めない。formatting を最後で打ち消す必要があるため、
  * 各 preset が末尾で prettier() を一度だけ付ける。
  *
- * tsconfigRootDirは指定しない。typescript-eslintはeslint.config.tsの
- * あるディレクトリへ自動解決するため、consumer側で正しいrootになる。
+ * projectService と tsconfigRootDir は typescript() が持つ。
+ * tsconfigRootDir は options.typescript 経由で consumer が渡す。
  */
-export function base() {
+export function base(options: Options = {}) {
   return defineConfig([
     /**
      * eslint-config-flat-gitignore
@@ -33,13 +34,6 @@ export function base() {
      * @see https://github.com/antfu/eslint-config-flat-gitignore
      */
     gitignore(),
-
-    {
-      languageOptions: {
-        parserOptions: { projectService: true },
-      },
-      name: name("languageOptions/parserOptions"),
-    },
 
     /**
      * inline の disableコメントを無効化。必ずeslint.config.tsで設定の変更はする。
@@ -52,7 +46,7 @@ export function base() {
     },
 
     javascript(),
-    typescript(),
+    typescript(options.typescript),
     importX(),
 
     jsdoc(),

--- a/packages/eslint-config/presets/nextjs.ts
+++ b/packages/eslint-config/presets/nextjs.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "eslint/config";
 import globals from "globals";
+import type { Options } from "../types";
 import {
   _nextjs,
   betterTailwindcss,
@@ -21,9 +22,9 @@ import { base } from "./base";
  * node() からは作らず base を元に組む。Next は server コードも持つため
  * Node.js 層(eslint-plugin-n)も含める。prettier は末尾で一度だけ付ける。
  */
-export function nextjs() {
+export function nextjs(options: Options = {}) {
   return defineConfig([
-    ...base(),
+    ...base(options),
 
     {
       languageOptions: {

--- a/packages/eslint-config/presets/node.ts
+++ b/packages/eslint-config/presets/node.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "eslint/config";
 import globals from "globals";
+import type { Options } from "../types";
 import { n, prettier } from "../rules";
 import { name } from "../utils/name";
 import { base } from "./base";
@@ -8,9 +9,9 @@ import { base } from "./base";
  * CLI / library 向け。base + Node.js ランタイム層。
  * base を元に組み、prettier を末尾で一度だけ付ける。
  */
-export function node() {
+export function node(options: Options = {}) {
   return defineConfig([
-    ...base(),
+    ...base(options),
 
     {
       languageOptions: {

--- a/packages/eslint-config/rules/typescript.ts
+++ b/packages/eslint-config/rules/typescript.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "eslint/config";
 import tseslint from "typescript-eslint";
+import type { TypescriptOptions } from "../types";
 import { name } from "../utils/name";
 
 /**
@@ -9,7 +10,7 @@ import { name } from "../utils/name";
  *
  * @see https://typescript-eslint.io/rules
  */
-export function typescript() {
+export function typescript({ tsconfigRootDir }: TypescriptOptions = {}) {
   return defineConfig([
     // typescript-eslint/baseとtypescript-eslint/eslint-recommendedの設定がダブってるからなんとかしたい
     //
@@ -17,6 +18,24 @@ export function typescript() {
     tseslint.configs.strictTypeChecked,
     // https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/flat/stylistic-type-checked.ts
     tseslint.configs.stylisticTypeChecked,
+
+    /**
+     * 型を見る rule を動かすための設定。
+     * projectService が各ファイルに型情報を供給し、
+     * tsconfigRootDir でその基準ディレクトリを固定する。
+     *
+     * @see https://typescript-eslint.io/packages/parser/#projectservice
+     */
+    {
+      languageOptions: {
+        parserOptions: {
+          projectService: true,
+          ...(tsconfigRootDir ? { tsconfigRootDir } : {}),
+        },
+      },
+      name: name("typescript/parserOptions"),
+    },
+
     {
       files: ["**/*.{ts,tsx}"],
       name: name("typescript"),

--- a/packages/eslint-config/src/init/index.test.ts
+++ b/packages/eslint-config/src/init/index.test.ts
@@ -13,14 +13,18 @@ type InitResult = {
 };
 
 // 一時dirでinitを実行し、生成された package.json と eslint.config.ts を読み取る
-async function runInit(preset?: PresetId): Promise<InitResult> {
+async function runInit(preset?: PresetId, monorepo?: boolean): Promise<InitResult> {
   const tmpDir = mkdtempSync(path.join(tmpdir(), "nozo-eslint-init-"));
   writeFileSync(
     path.join(tmpDir, "package.json"),
     `${JSON.stringify({ name: "fixture", version: "1.0.0" }, null, 2)}\n`,
   );
 
-  await init(preset === undefined ? { cwd: tmpDir } : { cwd: tmpDir, preset });
+  await init({
+    cwd: tmpDir,
+    ...(monorepo === undefined ? {} : { monorepo }),
+    ...(preset === undefined ? {} : { preset }),
+  });
 
   const pkg = JSON.parse(
     readFileSync(path.join(tmpDir, "package.json"), "utf8"),
@@ -94,4 +98,20 @@ test("the node starter does not reference nextjs", async () => {
   const { configContent } = await runInit("node");
 
   expect(configContent).not.toContain("nextjs");
+});
+
+// monorepo を選ぶと tsconfigRootDir を渡す形で書き出す
+test("init with monorepo writes tsconfigRootDir", async () => {
+  const { configContent } = await runInit("node", true);
+
+  expect(configContent).toContain(
+    "node({ typescript: { tsconfigRootDir: import.meta.dirname } })",
+  );
+});
+
+// 単一 repo (既定) は tsconfigRootDir を入れない
+test("init without monorepo omits tsconfigRootDir", async () => {
+  const { configContent } = await runInit("node");
+
+  expect(configContent).not.toContain("tsconfigRootDir");
 });

--- a/packages/eslint-config/src/init/index.ts
+++ b/packages/eslint-config/src/init/index.ts
@@ -4,7 +4,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-export type InitOptions = { cwd: string; preset?: PresetId };
+export type InitOptions = { cwd: string; monorepo?: boolean; preset?: PresetId };
 
 export type PresetId = "nextjs" | "node";
 
@@ -16,7 +16,11 @@ type PackageJson = {
   version: string;
 };
 
-export async function init({ cwd, preset = "nextjs" }: InitOptions): Promise<void> {
+export async function init({
+  cwd,
+  monorepo = false,
+  preset = "nextjs",
+}: InitOptions): Promise<void> {
   const root = packageRoot();
 
   const selfPkg = JSON.parse(
@@ -25,7 +29,18 @@ export async function init({ cwd, preset = "nextjs" }: InitOptions): Promise<voi
     peerDependencies: { eslint: string; typescript: string };
   };
 
-  const starter = await readFile(path.join(root, "starters", `${preset}.ts`), "utf8");
+  const starterRaw = await readFile(
+    path.join(root, "starters", `${preset}.ts`),
+    "utf8",
+  );
+
+  // monorepo の per-package config は tsconfigRootDir を明示する。
+  const starter = monorepo
+    ? starterRaw.replace(
+        `${preset}()`,
+        `${preset}({ typescript: { tsconfigRootDir: import.meta.dirname } })`,
+      )
+    : starterRaw;
 
   const targetPath = path.resolve(cwd, "package.json");
   const target = JSON.parse(await readFile(targetPath, "utf8")) as PackageJson;

--- a/packages/eslint-config/types/index.ts
+++ b/packages/eslint-config/types/index.ts
@@ -1,0 +1,24 @@
+/**
+ * preset (base / node / nextjs) に渡す options。
+ */
+export type Options = {
+  typescript?: TypescriptOptions;
+};
+
+/**
+ * typescript preset の options。
+ */
+export type TypescriptOptions = {
+  /**
+   * type-aware linting の基準ディレクトリ。
+   * 各 consumer の eslint.config の `import.meta.dirname` を渡す。
+   *
+   * 未指定だと typescript-eslint は call stack から eslint.config の場所を推測する。
+   * editor は複数 package の config を 1 プロセスで評価するため候補が複数になり
+   * "multiple candidate TSConfigRootDirs" で落ちる。値は consumer の dir でしか
+   * 決められないため consumer が渡す。
+   *
+   * @see https://typescript-eslint.io/packages/parser/#tsconfigrootdir
+   */
+  tsconfigRootDir?: string;
+};

--- a/packages/nozo/eslint.config.ts
+++ b/packages/nozo/eslint.config.ts
@@ -1,3 +1,5 @@
 import { defineConfig, node } from "@nozomiishii/eslint-config";
 
-export default defineConfig([...node()]);
+export default defineConfig([
+  ...node({ typescript: { tsconfigRootDir: import.meta.dirname } }),
+]);

--- a/packages/nozo/src/commands/init.ts
+++ b/packages/nozo/src/commands/init.ts
@@ -12,13 +12,19 @@ import { type AgentName, detect, getUserAgent } from "package-manager-detector";
 const exec = promisify(execFile);
 
 type Tool = {
-  configure?: () => Promise<null | { preset: PresetId }>;
+  configure?: () => Promise<null | ToolConfig>;
   description: string;
   label: string;
   run: ToolInit;
 };
 
-type ToolInit = (options: { cwd: string; preset?: PresetId }) => Promise<void>;
+type ToolConfig = { monorepo: boolean; preset: PresetId };
+
+type ToolInit = (options: {
+  cwd: string;
+  monorepo?: boolean;
+  preset?: PresetId;
+}) => Promise<void>;
 
 export const tools = {
   commitlint: {
@@ -41,7 +47,28 @@ export const tools = {
         return null;
       }
 
-      return { preset };
+      const monorepo = await p.select<boolean>({
+        initialValue: false,
+        message: "Is this a per-package config in a monorepo?",
+        options: [
+          {
+            hint: "one eslint.config for the whole repo",
+            label: "single repo",
+            value: false,
+          },
+          {
+            hint: "each package has its own; sets tsconfigRootDir",
+            label: "monorepo (per-package)",
+            value: true,
+          },
+        ],
+      });
+
+      if (p.isCancel(monorepo)) {
+        return null;
+      }
+
+      return { monorepo, preset };
     },
     description: "JS/TS linting via ESLint",
     label: "@nozomiishii/eslint-config",
@@ -115,7 +142,7 @@ export default defineCommand({
     }
 
     // 追加設定が要るツールは install 前にまとめて尋ねる
-    const presets: Partial<Record<ToolId, PresetId>> = {};
+    const configs: Partial<Record<ToolId, ToolConfig>> = {};
 
     for (const id of selected) {
       const tool = tools[id];
@@ -132,7 +159,7 @@ export default defineCommand({
         return;
       }
 
-      presets[id] = configured.preset;
+      configs[id] = configured;
     }
 
     const cwd = process.cwd();
@@ -149,8 +176,8 @@ export default defineCommand({
       spinner.start(`Installing ${tool.label}`);
 
       try {
-        const preset = presets[id];
-        await tool.run(preset === undefined ? { cwd } : { cwd, preset });
+        const config = configs[id];
+        await tool.run(config === undefined ? { cwd } : { cwd, ...config });
         spinner.stop(`${tool.label}: ok`);
       } catch (error) {
         spinner.stop(`${tool.label}: failed`);


### PR DESCRIPTION
## What

Threads a `tsconfigRootDir` option through the `node` / `nextjs` / `base` presets so each consumer can pin typed-linting to its own config dir:

```ts
node({ typescript: { tsconfigRootDir: import.meta.dirname } })
```

## Why

In a monorepo with per-package `eslint.config.ts` files, the editor (a single ESLint process) evaluates several configs at once. The `tseslint.configs.*TypeChecked` getters register each config dir as a candidate `tsconfigRootDir` in a process-global set, so typescript-eslint throws `No tsconfigRootDir was set, and multiple candidate TSConfigRootDirs are present`. Pinning `tsconfigRootDir` to each config's own dir removes the ambiguity.

## Changes

- Move `projectService` into the `typescript()` rule and co-locate the new `tsconfigRootDir` there.
- Pass an options object (antfu-style) through the presets.
- The option is optional; single-config consumers keep `node()` (the error only affects monorepo + per-package configs).
- `nozo init` now asks single-repo vs monorepo and scaffolds `tsconfigRootDir` for the monorepo case.
- Fix our own `packages/eslint-config` and `packages/nozo` configs.

## Test plan

- eslint-config: `lint` / `check:ts` / `test` (12 tests, incl. 2 new for the init layout)
- nozo: `lint` / `test`
- Reproduced the multi-candidate error in a single-process multi-config run and confirmed it no longer throws.