### PR TITLE
chore: self-heal release PR lockfile drift via always-update

### DIFF
--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -3,6 +3,8 @@
 
   "bootstrap-sha": "362a8e8f6891e6ce9111e2f167151426ac22df6a",
 
+  "always-update": true,
+
   "group-pull-request-title-pattern": "chore: release ${version}",
 
   "changelog-sections": [

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,6 +65,10 @@ jobs:
           # 403 "Resource not accessible by integration".
           permission-workflows: write
 
+      # TOCTOU 対策。release-please は package.json の読込時刻と commit の base_tree 解決時刻に
+      # SHA pinning が無く、間に依存 PR が main へ merge されると package.json だけ巻き戻り
+      # pnpm-lock.yaml と乖離する。v5.0.0 が最新タグで upstream 修正は無いため、config の
+      # always-update:true で後続 run が release PR を最新 main へ再生成し自己修復させる。
       - name: Run release-please
         id: release-please
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,10 +65,6 @@ jobs:
           # 403 "Resource not accessible by integration".
           permission-workflows: write
 
-      # TOCTOU 対策。release-please は package.json の読込時刻と commit の base_tree 解決時刻に
-      # SHA pinning が無く、間に依存 PR が main へ merge されると package.json だけ巻き戻り
-      # pnpm-lock.yaml と乖離する。v5.0.0 が最新タグで upstream 修正は無いため、config の
-      # always-update:true で後続 run が release PR を最新 main へ再生成し自己修復させる。
       - name: Run release-please
         id: release-please
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0


### PR DESCRIPTION
## 概要

release PR (`chore: release X.Y.Z`) の CI が lockfile 不整合でたびたび落ちる問題 ([#2388](https://github.com/nozomiishii/configs/pull/2388) で再発) の対処。

## 原因 (release-please の TOCTOU)

release-please は `package.json` を読む時刻と、commit の base_tree を解決する時刻に SHA pinning が無い。release run の最中に renovate の依存 PR が main へ merge されると、`package.json` は古い読込結果のまま version bump されるのに、`pnpm-lock.yaml` は後の main 由来のまま残り乖離する。結果 `pnpm install --frozen-lockfile` が `ERR_PNPM_OUTDATED_LOCKFILE` で落ち、release PR の CI (static / test / format-check / markdown-lint) が連鎖失敗する。

[#2388](https://github.com/nozomiishii/configs/pull/2388) の実例: `typescript-eslint` が `package.json=8.60.0` / `pnpm-lock.yaml=8.60.1` で乖離 ([#2397](https://github.com/nozomiishii/configs/pull/2397) の automerge が release run 後に入った)。release-please は version + changelog (PR body) が一致する限り PR を更新しないため、この乖離を自己修復しない。

## 対応

`.github/.release-please-config.json` に `always-update: true` を追加。release notes が変わらなくても後続の release run が release PR を最新 main へ再生成し直すので、乖離が自己修復する。

- 公式ドキュメント (Configfile): <https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#configfile>
- 追加 PR: <https://github.com/googleapis/release-please/pull/1459>

`release.yaml` の変更は、なぜ always-update を入れたかの説明コメントのみ (config は JSON でコメント不可のため)。

## 検討して今回は見送った案

- renovate の連続 merge 抑制 (`automergeSchedule`): 窓集約が逆効果になり得るため見送り
- release を cron trigger 化: push 維持 + always-update の方が自己修復が速く遅延も無いため見送り
- drift 検知 job: 既存の release PR チェックと検知が重複するため、まず always-update 単体で様子見

## 検証

- `always-update` は config schema の top-level / per-package 両方で定義済みを確認
- prettier / commitlint 通過

## 補足

マージ後の次の release run で [#2388](https://github.com/nozomiishii/configs/pull/2388) が `8.60.1` へ再生成・自己修復される見込み。効かなければ手動で `gh pr close 2388 && gh workflow run release.yaml --ref main`。