### PR TITLE
feat: add max-depth and no-else-return rules to eslint-config

### DIFF
--- a/packages/eslint-config/rules/javascript.ts
+++ b/packages/eslint-config/rules/javascript.ts
@@ -35,11 +35,25 @@ export function javascript() {
         eqeqeq: ["warn", "allow-null"],
 
         /**
+         * ブロックのネスト深さを制限し、深い入れ子を防ぐ。
+         *
+         * @see https://eslint.org/docs/latest/rules/max-depth
+         */
+        "max-depth": "error",
+
+        /**
          * consoleの消し忘れ防止
          *
          * @see https://eslint.org/docs/latest/rules/no-console
          */
         "no-console": ["warn", { allow: ["warn", "error"] }],
+
+        /**
+         * 早期 return 後の不要な else を禁止し、ガード句を促す。
+         *
+         * @see https://eslint.org/docs/latest/rules/no-else-return
+         */
+        "no-else-return": ["warn", { allowElseIf: false }],
 
         /**
          * 不必要な再命名防止


### PR DESCRIPTION
## 概要

ネストした `if` が読みづらい問題への対策として、`eslint-config` に深さ制限とガード句促進の2ルールを追加します。

## 追加ルール

`packages/eslint-config/rules/javascript.ts`

- `max-depth: "error"` — ブロックのネスト深さをデフォルト4に制限（autofix不可なので error）
- `no-else-return: ["warn", { allowElseIf: false }]` — 早期 return 後の不要な else を禁止し、ガード句を促す（autofix可なので warn）

## 背景・調査

- 主要config（airbnb / antfu / typescript-eslint）を確認したところ、`max-depth` は off / 未設定が主流で、ガード句は `no-else-return` で促す流儀（airbnb は `allowElseIf: false` を採用）
- severity はパッケージ方針（autofix不可=error, autofix可=warn）に準拠
- 既存の `unicorn/no-lonely-if`（recommended 由来・有効済み）と補完関係
- `allowElseIf: false` はデフォルト（`true`）と異なるため明示。`max-depth` の `4` はデフォルトなので省略

## 検証

- 最終マージ config に両ルールが反映されることを `calculateConfigForFile` で確認（`max-depth => [2,4]`, `no-else-return => [1,{allowElseIf:false}]`）
- 5段ネスト → `error max-depth`、早期 return 後 else → `warning no-else-return` を実走で確認
- 既存コード（eslint-config / nozo）への違反は0件（pre-push の `eslint --max-warnings=0` も通過）

## 注意

`base.ts` の `noInlineConfig: true` により、このconfigを使う側ではインライン `// eslint-disable` で逃がせません。深いネストは関数分割で対応する想定です。
