### PR TITLE
chore: add lint troubleshooting guide reference to nozo eslint config

### DIFF
--- a/packages/nozo/eslint.config.ts
+++ b/packages/nozo/eslint.config.ts
@@ -2,4 +2,11 @@ import { defineConfig, node } from "@nozomiishii/eslint-config";
 
 export default defineConfig([
   ...node({ typescript: { tsconfigRootDir: import.meta.dirname } }),
+
+  // エラーの解決手順や、よくある対応パターンはこちらにまとめています:
+  // https://github.com/nozomiishii/configs/blob/main/packages/eslint-config/docs/troubleshooting.md
+  {
+    name: "project/overrides",
+    rules: {},
+  },
 ]);


### PR DESCRIPTION
## 概要

`@nozomiishii/eslint-config` の troubleshooting ガイド（#2411）に合わせ、`packages/nozo` の eslint.config.ts に誘導コメントと `project/overrides` ブロックを追加する。

## 変更

- `packages/nozo/eslint.config.ts` … `...node(...)` の後にガイドへの誘導コメント＋空の `project/overrides` を追加。monorepo の `tsconfigRootDir` 設定は維持。lint ルールの増減なし。
