### PR TITLE
chore(commitlint-config): add bugs metadata

### DIFF
--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -12,6 +12,9 @@
     "url": "https://github.com/nozomiishii/configs.git",
     "directory": "packages/commitlint-config"
   },
+  "bugs": {
+    "url": "https://github.com/nozomiishii/configs/issues"
+  },
   "license": "MIT",
   "author": "Nozomi Ishii",
   "type": "module",


### PR DESCRIPTION
## Summary
- add npm `bugs.url` metadata for `@nozomiishii/commitlint-config`
- keep runtime code, dependencies, generated files, version, and exports unchanged

## Verification
- `node - <<'NODE' ...` metadata assertion for `name` and `bugs.url`
- `npm pack --dry-run --ignore-scripts --json` in `packages/commitlint-config`
- `git diff --check`