### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@nozomiishii/prettier-config",
   "version": "1.7.0",
+  "bugs": {
+    "url": "https://github.com/nozomiishii/configs/issues"
+  },
   "description": "Nozomi's Recommended Prettier config",
   "keywords": [
     "prettier",


### PR DESCRIPTION
Adds missing `bugs, repository` metadata to `packages/prettier-config/package.json`.