### PR TITLE
fix: add commitlint config bugs metadata

### DIFF
--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -7,6 +7,9 @@
     "config"
   ],
   "homepage": "https://github.com/nozomiishii/configs/blob/main/packages/commitlint-config/README.md",
+  "bugs": {
+    "url": "https://github.com/nozomiishii/configs/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/nozomiishii/configs.git",


### PR DESCRIPTION
## Summary
- Add the missing `bugs` metadata to `@nozomiishii/commitlint-config` package.json.
- Point bug reports to the repository issue tracker, matching the root package metadata.

## Verification
- `python3 -m json.tool packages/commitlint-config/package.json >/dev/null`
- `npm pack --dry-run --json` (from `packages/commitlint-config`)