### PR TITLE
chore: add bugs metadata to published packages

### DIFF
--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -7,6 +7,9 @@
     "config"
   ],
   "homepage": "https://github.com/nozomiishii/configs/blob/main/packages/commitlint-config/README.md",
+  "bugs": {
+    "url": "https://github.com/nozomiishii/configs/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/nozomiishii/configs.git",

--- a/packages/cspell-config/package.json
+++ b/packages/cspell-config/package.json
@@ -7,6 +7,9 @@
     "config"
   ],
   "homepage": "https://github.com/nozomiishii/configs/blob/main/packages/cspell-config/README.md",
+  "bugs": {
+    "url": "https://github.com/nozomiishii/configs/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/nozomiishii/configs.git",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -8,6 +8,9 @@
     "config"
   ],
   "homepage": "https://github.com/nozomiishii/configs/blob/main/packages/eslint-config/README.md",
+  "bugs": {
+    "url": "https://github.com/nozomiishii/configs/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/nozomiishii/configs.git",

--- a/packages/lefthook-config/package.json
+++ b/packages/lefthook-config/package.json
@@ -8,6 +8,9 @@
     "config"
   ],
   "homepage": "https://github.com/nozomiishii/configs/blob/main/packages/lefthook-config/README.md",
+  "bugs": {
+    "url": "https://github.com/nozomiishii/configs/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/nozomiishii/configs.git",

--- a/packages/markdownlint-cli2-config/package.json
+++ b/packages/markdownlint-cli2-config/package.json
@@ -9,6 +9,9 @@
     "config"
   ],
   "homepage": "https://github.com/nozomiishii/configs/blob/main/packages/markdownlint-cli2-config/README.md",
+  "bugs": {
+    "url": "https://github.com/nozomiishii/configs/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/nozomiishii/configs.git",

--- a/packages/nozo/package.json
+++ b/packages/nozo/package.json
@@ -7,6 +7,9 @@
     "config"
   ],
   "homepage": "https://github.com/nozomiishii/configs/blob/main/packages/nozo/README.md",
+  "bugs": {
+    "url": "https://github.com/nozomiishii/configs/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/nozomiishii/configs.git",

--- a/packages/postinstall/package.json
+++ b/packages/postinstall/package.json
@@ -7,6 +7,9 @@
     "scripts"
   ],
   "homepage": "https://github.com/nozomiishii/configs/blob/main/packages/postinstall/README.md",
+  "bugs": {
+    "url": "https://github.com/nozomiishii/configs/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/nozomiishii/configs.git",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -7,6 +7,9 @@
     "config"
   ],
   "homepage": "https://github.com/nozomiishii/configs/blob/main/packages/prettier-config/README.md",
+  "bugs": {
+    "url": "https://github.com/nozomiishii/configs/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/nozomiishii/configs.git",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -7,6 +7,9 @@
     "config"
   ],
   "homepage": "https://github.com/nozomiishii/configs/blob/main/packages/tsconfig/README.md",
+  "bugs": {
+    "url": "https://github.com/nozomiishii/configs/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/nozomiishii/configs.git",


### PR DESCRIPTION
## 概要

公開対象の全パッケージ（9個）の `package.json` に `bugs` メタデータを追加する。URL は root の `package.json` と揃えて issue tracker を指す。

## 背景

各パッケージへ個別に `bugs` を足す細切れの外部 PR が続いているため、まとめて先に付与して解消する

## 変更内容

`homepage` と `repository` の間に以下を追加（sort-package-json 推奨順）:

```json
"bugs": {
  "url": "https://github.com/nozomiishii/configs/issues"
}
```

対象:

- `@nozomiishii/commitlint-config`
- `@nozomiishii/cspell-config`
- `@nozomiishii/eslint-config`
- `@nozomiishii/lefthook-config`
- `@nozomiishii/markdownlint-cli2-config`
- `nozo`
- `@nozomiishii/postinstall`
- `@nozomiishii/prettier-config`
- `@nozomiishii/tsconfig`

root の `package.json` は private で既に `bugs` があるため対象外。

## 確認

- 全 `package.json` の JSON 妥当性
- prettier 整形済み（全ファイル unchanged）