### PR TITLE
chore: adopt .hooks/ and Codex SessionStart hook

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.hooks/startup.sh\""
+            "command": "bash \"$(git rev-parse --show-toplevel)/.hooks/startup.sh\""
           }
         ]
       }

--- a/.hooks/startup.sh
+++ b/.hooks/startup.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# Codex は CODEX_PROJECT_DIR 相当を持たず session cwd で hook を回すため、worktree の
+# サブディレクトリで起動された場合 pnpm install が package.json を見失う。両ツールから
+# 同じ起点で動かすために repo root へ移動する。
+cd "$(git rev-parse --show-toplevel)"
 # セッション開始時に worktree を整える（可能なら origin/main 取り込み、必要なら deps install）。
 
 # Claude Code の worktree 作成(EnterWorktree)が共有 .git/config に core.hooksPath を書き込む。


### PR DESCRIPTION
## 概要

dotfiles の `.hooks/` 化＋Codex hook 配線（[#1150](https://github.com/nozomiishii/dotfiles/pull/1150)）を本 repo に展開する。本 repo は CLAUDE.md を持たないので AGENTS.md 化 ([#1149](https://github.com/nozomiishii/dotfiles/pull/1149)) は対象外。

## 変更点

- `.claude/hooks/startup.sh` を `.hooks/startup.sh` に移動。先頭で `cd "$(git rev-parse --show-toplevel)"`
- `.codex/hooks.json` を新規作成、Codex の SessionStart で同じ startup.sh を呼ぶ