### PR TITLE
feat: ban nested ternary

### DIFF
--- a/packages/eslint-config/rules/javascript.ts
+++ b/packages/eslint-config/rules/javascript.ts
@@ -56,6 +56,13 @@ export function javascript() {
         "no-else-return": ["warn", { allowElseIf: false }],
 
         /**
+         * 入れ子の三項演算子を禁止
+         *
+         * @see https://eslint.org/docs/latest/rules/no-nested-ternary
+         */
+        "no-nested-ternary": "error",
+
+        /**
          * 不必要な再命名防止
          *
          * @see https://eslint.org/docs/latest/rules/no-useless-rename


### PR DESCRIPTION
## 概要

- ESLint core rule の `no-nested-ternary` を `error` で有効化

## 確認

- `pnpm --filter @nozomiishii/eslint-config test`
- `pnpm --filter @nozomiishii/eslint-config lint`
- `pnpm --filter @nozomiishii/eslint-config check:ts`

## 参考

- https://eslint.org/docs/latest/rules/no-nested-ternary