### PR TITLE
fix: update nozo-git-harvest to resolve git-harvest v0.3.1 entry point

### DIFF
--- a/packages/lefthook-config/src/cli.ts
+++ b/packages/lefthook-config/src/cli.ts
@@ -2,8 +2,8 @@ import { spawn } from "node:child_process";
 import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
-const cli = require.resolve("git-harvest/lib/git-harvest");
+const cli = require.resolve("git-harvest/dist/cli.mjs");
 
-spawn("bash", [cli, ...process.argv.slice(2)], { stdio: "inherit" }).on("exit", (code) =>
+spawn(process.execPath, [cli, ...process.argv.slice(2)], { stdio: "inherit" }).on("exit", (code) =>
   process.exit(code ?? 1),
 );


### PR DESCRIPTION
## Summary
- git-harvest v0.3.1 でエントリポイントが `lib/git-harvest`(bash スクリプト）から `dist/cli.mjs`（Node.js ESM）に変更された
- `require.resolve` のパスと `spawn` の実行方法を更新して `cleanup-worktrees-and-branches` routine の `MODULE_NOT_FOUND` エラーを修正

## Test plan
- [x] `nozo-git-harvest --help` が正常に動作することを確認
- [ ] `cleanup-worktrees-and-branches` routine が正常に動作することを確認

https://claude.ai/code/session_01Wqh53ij1d7jzFBwhNFEDzq