### PR TITLE
feat: allow experimental Node.js APIs in n/no-unsupported-features/node-builtins

### DIFF
--- a/packages/eslint-config/rules/n.ts
+++ b/packages/eslint-config/rules/n.ts
@@ -21,6 +21,16 @@ export function n() {
          * TypeScriptやeslint-plugin-import-xで解決する
          */
         "n/no-missing-import": "off",
+
+        /**
+         * experimental な Node.js API の使用を許可する
+         *
+         * @see https://github.com/eslint-community/eslint-plugin-n/blob/master/docs/rules/no-unsupported-features/node-builtins.md
+         */
+        "n/no-unsupported-features/node-builtins": [
+          "error",
+          { allowExperimental: true },
+        ],
       },
       // pnpmでnode管理したいので設定。engines設定してるならここは省略できる。
       // pnpm.executionEnv.nodeVersionがcustomManagers書いてもenginesと同じタイミングでアップデートしてくれない。


### PR DESCRIPTION
## Summary
- `n/no-unsupported-features/node-builtins` ルールに `allowExperimental: true` を設定
- experimental な Node.js API の使用時にエラーが出なくなる

## Test plan
- [x] eslint-config パッケージのビルド確認
- [x] lint 実行で既存コードにエラーが出ないことを確認

https://claude.ai/code/session_01SfrXfB9Jopg8gtitrZJKGL