### PR TITLE
feat: add required summary gate jobs to CI workflows

### DIFF
--- a/.github/workflows/eslint-config.yaml
+++ b/.github/workflows/eslint-config.yaml
@@ -20,7 +20,7 @@ defaults:
 jobs:
   changes:
     if: ${{ !github.event.pull_request.draft }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions:
       contents: read
@@ -68,7 +68,7 @@ jobs:
   required:
     needs: [changes, static]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 1
     steps:
       - name: Fail if any required job failed or was cancelled

--- a/.github/workflows/eslint-config.yaml
+++ b/.github/workflows/eslint-config.yaml
@@ -26,16 +26,15 @@ jobs:
       contents: read # required by actions/checkout to fetch repository code
       pull-requests: read # required by dorny/paths-filter to list PR files via the GitHub API
     outputs:
-      src: ${{ steps.filter.outputs.src }}
+      src: ${{ steps.changes.outputs.src }}
     steps:
       - name: Check out
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - name: Detect changes
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: filter
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: changes
         with:
           filters: |
             src:

--- a/.github/workflows/eslint-config.yaml
+++ b/.github/workflows/eslint-config.yaml
@@ -23,8 +23,8 @@ jobs:
     runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions:
-      contents: read
-      pull-requests: read
+      contents: read # required by actions/checkout to fetch repository code
+      pull-requests: read # required by dorny/paths-filter to list PR files via the GitHub API
     outputs:
       src: ${{ steps.filter.outputs.src }}
     steps:

--- a/.github/workflows/eslint-config.yaml
+++ b/.github/workflows/eslint-config.yaml
@@ -18,14 +18,37 @@ defaults:
     working-directory: packages/eslint-config
 
 jobs:
-  static:
+  changes:
     if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Detect changes
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            src:
+              - 'packages/eslint-config/**'
+              - '.github/workflows/eslint-config.yaml'
+
+  static:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-slim
     timeout-minutes: 10
-
     permissions:
-      contents: read # required by actions/checkout to fetch repository code
-      pull-requests: read # required by dorny/paths-filter to list PR files via the GitHub API
+      contents: read
 
     steps:
       - name: Check out
@@ -33,29 +56,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Check for changes
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: changes
-        with:
-          filters: |
-            src:
-              - 'packages/eslint-config/**'
-              - '.github/workflows/eslint-config.yaml'
-
       - name: Setup Node
-        if: steps.changes.outputs.src == 'true'
         uses: ./.github/actions/setup-node
 
       - name: Lint
-        if: steps.changes.outputs.src == 'true'
         run: pnpm lint
 
       - name: Compiler check
-        if: steps.changes.outputs.src == 'true'
         run: pnpm check:ts
 
   required:
-    needs: [static]
+    needs: [changes, static]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 1

--- a/.github/workflows/eslint-config.yaml
+++ b/.github/workflows/eslint-config.yaml
@@ -53,3 +53,15 @@ jobs:
       - name: Compiler check
         if: steps.changes.outputs.src == 'true'
         run: pnpm check:ts
+
+  required:
+    needs: [static]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Fail if any required job failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "A required job failed or was cancelled"
+          exit 1

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions:
-      contents: read
-      pull-requests: read
+      contents: read # required by actions/checkout to fetch repository code
+      pull-requests: read # required by dorny/paths-filter to list PR files via the GitHub API
     outputs:
       md: ${{ steps.filter.outputs.md }}
     steps:

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -10,12 +10,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  markdown-lint:
-    runs-on: ubuntu-slim
-
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
-      contents: read # required by actions/checkout to fetch repository code
-      pull-requests: read # required by dorny/paths-filter to list PR files via the GitHub API
+      contents: read
+      pull-requests: read
+    outputs:
+      md: ${{ steps.filter.outputs.md }}
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Detect changes
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            md:
+              - '**/*.md'
+
+  markdown-lint:
+    needs: changes
+    if: needs.changes.outputs.md == 'true'
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
 
     steps:
       - name: Check out
@@ -23,24 +45,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Check for changes
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: changes
-        with:
-          filters: |
-            md:
-              - '**/*.md'
-
       - name: Setup Node
-        if: steps.changes.outputs.md == 'true'
         uses: ./.github/actions/setup-node
 
       - name: lint
-        if: steps.changes.outputs.md == 'true'
         run: npx -y markdownlint-cli2 "**/*.md"
 
   required:
-    needs: [markdown-lint]
+    needs: [changes, markdown-lint]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 1

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions:
       contents: read
@@ -54,7 +54,7 @@ jobs:
   required:
     needs: [changes, markdown-lint]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 1
     steps:
       - name: Fail if any required job failed or was cancelled

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -17,24 +17,23 @@ jobs:
       contents: read # required by actions/checkout to fetch repository code
       pull-requests: read # required by dorny/paths-filter to list PR files via the GitHub API
     outputs:
-      md: ${{ steps.filter.outputs.md }}
+      src: ${{ steps.changes.outputs.src }}
     steps:
       - name: Check out
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - name: Detect changes
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: filter
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: changes
         with:
           filters: |
-            md:
+            src:
               - '**/*.md'
 
   markdown-lint:
     needs: changes
-    if: needs.changes.outputs.md == 'true'
+    if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -38,3 +38,15 @@ jobs:
       - name: lint
         if: steps.changes.outputs.md == 'true'
         run: npx -y markdownlint-cli2 "**/*.md"
+
+  required:
+    needs: [markdown-lint]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Fail if any required job failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "A required job failed or was cancelled"
+          exit 1

--- a/.github/workflows/postinstall.yaml
+++ b/.github/workflows/postinstall.yaml
@@ -26,16 +26,15 @@ jobs:
       contents: read # required by actions/checkout to fetch repository code
       pull-requests: read # required by dorny/paths-filter to list PR files via the GitHub API
     outputs:
-      src: ${{ steps.filter.outputs.src }}
+      src: ${{ steps.changes.outputs.src }}
     steps:
       - name: Check out
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - name: Detect changes
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: filter
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: changes
         with:
           filters: |
             src:

--- a/.github/workflows/postinstall.yaml
+++ b/.github/workflows/postinstall.yaml
@@ -18,14 +18,37 @@ defaults:
     working-directory: packages/postinstall
 
 jobs:
-  test:
+  changes:
     if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Detect changes
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            src:
+              - 'packages/postinstall/**'
+              - '.github/workflows/postinstall.yaml'
+
+  test:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-slim
     timeout-minutes: 10
-
     permissions:
-      contents: read # required by actions/checkout to fetch repository code
-      pull-requests: read # required by dorny/paths-filter to list PR files via the GitHub API
+      contents: read
 
     steps:
       - name: Check out
@@ -33,25 +56,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Check for changes
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: changes
-        with:
-          filters: |
-            src:
-              - 'packages/postinstall/**'
-              - '.github/workflows/postinstall.yaml'
-
       - name: Setup Node
-        if: steps.changes.outputs.src == 'true'
         uses: ./.github/actions/setup-node
 
       - name: Test
-        if: steps.changes.outputs.src == 'true'
         run: pnpm test
 
   required:
-    needs: [test]
+    needs: [changes, test]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 1

--- a/.github/workflows/postinstall.yaml
+++ b/.github/workflows/postinstall.yaml
@@ -20,7 +20,7 @@ defaults:
 jobs:
   changes:
     if: ${{ !github.event.pull_request.draft }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions:
       contents: read
@@ -65,7 +65,7 @@ jobs:
   required:
     needs: [changes, test]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 1
     steps:
       - name: Fail if any required job failed or was cancelled

--- a/.github/workflows/postinstall.yaml
+++ b/.github/workflows/postinstall.yaml
@@ -49,3 +49,15 @@ jobs:
       - name: Test
         if: steps.changes.outputs.src == 'true'
         run: pnpm test
+
+  required:
+    needs: [test]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Fail if any required job failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "A required job failed or was cancelled"
+          exit 1

--- a/.github/workflows/postinstall.yaml
+++ b/.github/workflows/postinstall.yaml
@@ -23,8 +23,8 @@ jobs:
     runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions:
-      contents: read
-      pull-requests: read
+      contents: read # required by actions/checkout to fetch repository code
+      pull-requests: read # required by dorny/paths-filter to list PR files via the GitHub API
     outputs:
       src: ${{ steps.filter.outputs.src }}
     steps:

--- a/.github/workflows/setting-files.yaml
+++ b/.github/workflows/setting-files.yaml
@@ -42,7 +42,7 @@ jobs:
   required:
     needs: [format-check]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 1
     steps:
       - name: Fail if any required job failed or was cancelled

--- a/.github/workflows/setting-files.yaml
+++ b/.github/workflows/setting-files.yaml
@@ -38,3 +38,15 @@ jobs:
         run: |
           echo 'Try the following command in the project root'
           echo 'pnpm format:fix'
+
+  required:
+    needs: [format-check]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Fail if any required job failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "A required job failed or was cancelled"
+          exit 1


### PR DESCRIPTION
## 概要

- 4つの CI ワークフローに `required` サマリーゲートジョブを追加
  - `setting-files.yaml`: `format-check` に依存
  - `markdown.yaml`: `markdown-lint` に依存
  - `postinstall.yaml`: `test` に依存
  - `eslint-config.yaml`: `static` に依存
- nozomiishii/dev#2928 のパターンに従い、branch protection の required status check を `required` ジョブに統一

## テスト計画

- [ ] 各ワークフローの `required` ジョブが CI で正常に実行されることを確認
- [ ] branch protection の required status check を `required` ジョブに更新

https://claude.ai/code/session_01WT3uDc26XFEw3aMy8rJgJ3