### PR TITLE
fix: rename unicorn/prevent-abbreviations to unicorn/name-replacements

### DIFF
--- a/packages/eslint-config/rules/unicorn.ts
+++ b/packages/eslint-config/rules/unicorn.ts
@@ -22,6 +22,13 @@ export function unicorn() {
         ...eslintPluginUnicorn.configs.recommended.rules,
 
         /**
+         * 略語の制限。やるなら明示的にreplacementを記載していく
+         *
+         * @see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/name-replacements.md
+         */
+        "unicorn/name-replacements": "off",
+
+        /**
          * React Componentやhooksでは条件によってはnullを返せるようにしたいのでoff
          *
          * @see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-null.md
@@ -35,13 +42,6 @@ export function unicorn() {
          * @see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-export-from.md
          */
         "unicorn/prefer-export-from": "error",
-
-        /**
-         * 略語の制限。やるなら明示的にreplacementを記載していく
-         *
-         * @see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prevent-abbreviations.md
-         */
-        "unicorn/prevent-abbreviations": "off",
       },
     },
   ]);


### PR DESCRIPTION
## Summary

- eslint-plugin-unicorn v68 で `unicorn/prevent-abbreviations` が `unicorn/name-replacements` にリネームされた
- 旧名のまま `off` にしていたため設定が効かず、CI で lint エラーが発生していた
- ルール名と `@see` URL を新名に更新

## Test plan

- [x] `pnpm lint` がパスすること
- [x] pre-push hook の lint がパスすること

https://claude.ai/code/session_01TQZ2kxq4HBoDxK5oVhvP3D