### PR TITLE
fix: add unique names to required gate jobs to prevent race condition

### DIFF
--- a/.github/workflows/eslint-config.yaml
+++ b/.github/workflows/eslint-config.yaml
@@ -65,6 +65,8 @@ jobs:
         run: pnpm check:ts
 
   required:
+    # name 変更時は infra 側も更新する
+    name: ESLint Config / required
     needs: [changes, static]
     if: always()
     runs-on: ubuntu-slim

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -51,6 +51,8 @@ jobs:
         run: npx -y markdownlint-cli2 "**/*.md"
 
   required:
+    # name 変更時は infra 側も更新する
+    name: Markdown lint / required
     needs: [changes, markdown-lint]
     if: always()
     runs-on: ubuntu-slim

--- a/.github/workflows/postinstall.yaml
+++ b/.github/workflows/postinstall.yaml
@@ -62,6 +62,8 @@ jobs:
         run: pnpm test
 
   required:
+    # name 変更時は infra 側も更新する
+    name: Postinstall / required
     needs: [changes, test]
     if: always()
     runs-on: ubuntu-slim

--- a/.github/workflows/setting-files.yaml
+++ b/.github/workflows/setting-files.yaml
@@ -40,6 +40,8 @@ jobs:
           echo 'pnpm format:fix'
 
   required:
+    # name 変更時は infra 側も更新する
+    name: Setting File Format Check / required
     needs: [format-check]
     if: always()
     runs-on: ubuntu-slim


### PR DESCRIPTION
## 概要

- 4つのワークフローの required ゲートジョブにユニークな `name` を付与
  - `ESLint Config / required`
  - `Postinstall / required`
  - `Markdown lint / required`
  - `Setting File Format Check / required`

## 背景

同名の `required` チェックコンテキストが複数ワークフローで衝突し、最も早く完了したワークフローの `required` が branch protection を満たして auto-merge が通るレースコンディションが発生していた（[#2480](https://github.com/nozomiishii/configs/pull/2480)）。

infra 側の ruleset 更新（`"required"` → ユニーク名4つ）は適用済み。

Closes #2482

## テスト計画

- [ ] 各ワークフローの required ジョブがユニークなチェック名で CI に表示されることを確認
- [ ] branch protection ruleset がユニーク名で正しくマッチしていることを確認

https://claude.ai/code/session_01TkQRPr4KydLk53utjxtLRJ