### PR TITLE
fix: disable unicorn/no-top-level-side-effects for instrumentation-client

### DIFF
--- a/packages/eslint-config/rules/unicorn.ts
+++ b/packages/eslint-config/rules/unicorn.ts
@@ -47,11 +47,12 @@ export function unicorn() {
 
     {
       /**
-       * Next.js の instrumentation-client はモジュール読み込み時に初期化コードを実行する仕様
+       * Next.js の instrumentation-client は Sentry, PostHog, Datadog RUM でトップレベル副作用関数を呼ぶ必要がある
        *
+       * @see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-top-level-side-effects.md
        * @see https://nextjs.org/docs/app/api-reference/file-conventions/instrumentation-client
        */
-      files: ["**/instrumentation-client.{ts,tsx,js,jsx,mts,mjs}"],
+      files: ["**/instrumentation-client.ts"],
       name: name("unicorn/instrumentation-client"),
       rules: {
         "unicorn/no-top-level-side-effects": "off",

--- a/packages/eslint-config/rules/unicorn.ts
+++ b/packages/eslint-config/rules/unicorn.ts
@@ -44,5 +44,18 @@ export function unicorn() {
         "unicorn/prefer-export-from": "error",
       },
     },
+
+    {
+      /**
+       * Next.js の instrumentation-client はモジュール読み込み時に初期化コードを実行する仕様
+       *
+       * @see https://nextjs.org/docs/app/api-reference/file-conventions/instrumentation-client
+       */
+      files: ["**/instrumentation-client.{ts,tsx,js,jsx,mts,mjs}"],
+      name: name("unicorn/instrumentation-client"),
+      rules: {
+        "unicorn/no-top-level-side-effects": "off",
+      },
+    },
   ]);
 }


### PR DESCRIPTION
## 概要

- `instrumentation-client.ts` で `unicorn/no-top-level-side-effects` を無効化

## 背景

Next.js v15.3 で導入された `instrumentation-client` はモジュール読み込み時に初期化コードを実行する仕様のファイル。
Sentry, PostHog, Datadog RUM など主要ツールの公式ドキュメントすべてがトップレベルでの `init()` 呼び出しを推奨しており、ルールの意図と根本的に相容れない。

refs:
- https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-top-level-side-effects.md
- https://nextjs.org/docs/app/api-reference/file-conventions/instrumentation-client
- https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
- https://posthog.com/docs/libraries/next-js

https://claude.ai/code/session_013bTG9JVjrzkDR5roQ95Lye