### PR TITLE
fix: disable unicorn/no-unsafe-string-replacement due to false positives

### DIFF
--- a/packages/eslint-config/rules/unicorn.ts
+++ b/packages/eslint-config/rules/unicorn.ts
@@ -41,6 +41,13 @@ export function unicorn() {
          *
          * @see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-export-from.md
          */
+        /**
+         * router.replace() など String#replace() 以外の .replace() メソッドで false positive が発生する
+         *
+         * @see https://github.com/sindresorhus/eslint-plugin-unicorn/issues/3437
+         */
+        "unicorn/no-unsafe-string-replacement": "off",
+
         "unicorn/prefer-export-from": "error",
       },
     },

--- a/packages/eslint-config/rules/unicorn.ts
+++ b/packages/eslint-config/rules/unicorn.ts
@@ -41,14 +41,19 @@ export function unicorn() {
          *
          * @see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-export-from.md
          */
-        /**
-         * router.replace() など String#replace() 以外の .replace() メソッドで false positive が発生する
-         *
-         * @see https://github.com/sindresorhus/eslint-plugin-unicorn/issues/3437
-         */
-        "unicorn/no-unsafe-string-replacement": "off",
-
         "unicorn/prefer-export-from": "error",
+      },
+    },
+
+    {
+      /**
+       * router.replace() など String#replace() 以外の .replace() メソッドで false positive が発生する
+       *
+       * @see https://github.com/sindresorhus/eslint-plugin-unicorn/issues/3437
+       */
+      name: name("unicorn/workaround"),
+      rules: {
+        "unicorn/no-unsafe-string-replacement": "off",
       },
     },
 


### PR DESCRIPTION
## 概要

- `unicorn/no-unsafe-string-replacement` を global で off に設定

## 背景

router.replace() など String#replace() 以外の .replace() メソッドで false positive が発生する。
ルールが AST の形状（メソッド名 + 引数2つ）だけで判定し、レシーバーの型を確認しないことが原因。

refs:
- https://github.com/sindresorhus/eslint-plugin-unicorn/issues/3437

https://claude.ai/code/session_013bTG9JVjrzkDR5roQ95Lye