### PR TITLE
feat: add revert to allowed commit types

### DIFF
--- a/packages/commitlint-config/README.ja.md
+++ b/packages/commitlint-config/README.ja.md
@@ -26,7 +26,7 @@ pnpx nozo init
 
 ## デフォルト挙動
 
-- `type-enum`: `feat` / `fix` / `chore` のみ許可。
+- `type-enum`: `feat` / `fix` / `chore` / `revert` のみ許可。
 - `scope-empty`: デフォルトで scope 禁止。`feat: subject` は通り、`feat(api): subject` は弾かれる。
 - `commit-message-ascii-only`: body / footer / notes は ASCII のみ（コミットメッセージは英語で書く）。
 - `breaking-change-requires-bang`: 破壊的変更は header の `!` で宣言する。`BREAKING CHANGE:` footer 単独（header に `!` なし）は弾かれる。GitHub の squash commit では footer が畳まれて見えないため。

--- a/packages/commitlint-config/README.md
+++ b/packages/commitlint-config/README.md
@@ -27,7 +27,7 @@ and writes a `commitlint.config.ts` that re-exports the shared config.
 
 ## Defaults
 
-- `type-enum`: only `feat` / `fix` / `chore` are allowed.
+- `type-enum`: only `feat` / `fix` / `chore` / `revert` are allowed.
 - `scope-empty`: scope must be empty by default. `feat: subject` passes; `feat(api): subject` is rejected.
 - `commit-message-ascii-only`: body / footer / notes must be ASCII (write commit messages in English).
 - `breaking-change-requires-bang`: declare breaking changes with `!` in the header. A `BREAKING CHANGE:` footer alone (no `!` in the header) is rejected, since GitHub collapses the footer in squash commits.

--- a/packages/commitlint-config/src/index.ts
+++ b/packages/commitlint-config/src/index.ts
@@ -23,7 +23,7 @@ const config: UserConfig = {
   extends: ["@commitlint/config-conventional"],
   plugins: [{ rules: pluginRules }],
   rules: {
-    "type-enum": [2, "always", ["feat", "fix", "chore"]],
+    "type-enum": [2, "always", ["feat", "fix", "chore", "revert"]],
     "scope-empty": [2, "always"],
     ...customSeverities,
   },


### PR DESCRIPTION
## Summary

- commitlint の許可 type に `revert` を追加
- GitHub の Revert ボタンで生成される PR をマージした際のコミットメッセージが commitlint を通るようにする
- 関連: https://github.com/nozomiishii/workflows/pull/71

## Test plan

- [ ] `revert: something` が commitlint を通ること
- [ ] 既存の `feat` / `fix` / `chore` が引き続き通ること