### PR TITLE
feat: add lint-docs pre-commit hook to block superpowers specs

### DIFF
--- a/packages/lefthook-config/hooks/pre-commit/docs.yaml
+++ b/packages/lefthook-config/hooks/pre-commit/docs.yaml
@@ -1,0 +1,8 @@
+pre-commit:
+  jobs:
+    - name: lint-docs
+      run: |
+        if git diff --cached --diff-filter=d --name-only | grep -q '^docs/superpowers/specs/'; then
+          echo "docs/superpowers/specs/ へのコミットは禁止。設計は GitHub issue にまとめる" >&2
+          exit 1
+        fi

--- a/packages/lefthook-config/recommended.yaml
+++ b/packages/lefthook-config/recommended.yaml
@@ -14,6 +14,7 @@ extends:
   - node_modules/@nozomiishii/lefthook-config/hooks/post-merge/update-node-modules.yaml
   - node_modules/@nozomiishii/lefthook-config/hooks/post-merge/cleanup-worktrees-and-branches.yaml
   - node_modules/@nozomiishii/lefthook-config/hooks/pre-commit/yaml.yaml
+  - node_modules/@nozomiishii/lefthook-config/hooks/pre-commit/docs.yaml
 
 commit-msg:
   parallel: true


### PR DESCRIPTION
## 概要

`docs/superpowers/specs/` への新規ファイル追加をブロックする pre-commit hook を追加。設計ドキュメントは GitHub issue にまとめる運用のため、ツールが自動生成する spec ファイルのコミットを防ぐ。

## 変更内容

- `packages/lefthook-config/hooks/pre-commit/docs.yaml` 新規作成（`lint-docs` job）
- `packages/lefthook-config/recommended.yaml` に extends 追加