### PR TITLE
feat: add betterTailwindcss options to eslint-config presets

### DIFF
--- a/packages/eslint-config/presets/nextjs.ts
+++ b/packages/eslint-config/presets/nextjs.ts
@@ -48,7 +48,7 @@ export function nextjs(options: Options = {}) {
     jsxA11yX(),
 
     _nextjs(),
-    betterTailwindcss(),
+    betterTailwindcss(options.betterTailwindcss),
 
     storybook(),
     playwright(),

--- a/packages/eslint-config/rules/tailwindcss.ts
+++ b/packages/eslint-config/rules/tailwindcss.ts
@@ -1,17 +1,14 @@
 import eslintPluginBetterTailwindcss from "eslint-plugin-better-tailwindcss";
 import { defineConfig } from "eslint/config";
+import type { BetterTailwindcssOptions } from "../types";
 import { name } from "../utils/name";
-
-type Options = {
-  entryPoint?: string;
-};
 
 /**
  * @returns eslint-plugin-better-tailwindcss
  *
  * @see https://github.com/schoero/eslint-plugin-better-tailwindcss
  */
-export function betterTailwindcss(options?: Options) {
+export function betterTailwindcss(options?: BetterTailwindcssOptions) {
   return defineConfig([
     {
       name: name("tailwindcss"),
@@ -26,6 +23,7 @@ export function betterTailwindcss(options?: Options) {
       },
       settings: {
         "better-tailwindcss": {
+          ...(options?.cwd && { cwd: options.cwd }),
           entryPoint: options?.entryPoint ?? "src/global.css",
         },
       },

--- a/packages/eslint-config/types/index.ts
+++ b/packages/eslint-config/types/index.ts
@@ -2,7 +2,39 @@
  * preset (base / node / nextjs) に渡す options。
  */
 export type Options = {
+  betterTailwindcss?: BetterTailwindcssOptions;
   typescript?: TypescriptOptions;
+};
+
+/**
+ * better-tailwindcss preset の options。
+ *
+ * @see https://github.com/schoero/eslint-plugin-better-tailwindcss/blob/main/docs/settings/settings.md
+ */
+export type BetterTailwindcssOptions = {
+  /**
+   * tailwindcss と config を解決する作業ディレクトリ。
+   * パッケージごとに eslint.config.ts がある場合は不要。
+   * root に 1 つだけ eslint.config.ts を置き files で振り分ける構成で使う。
+   *
+   * @example
+   * // root に 1 つだけ eslint.config.ts を置く構成
+   * // {
+   * //   files: ["packages/website/**\/*.{ts,tsx}"],
+   * //   settings: {
+   * //     "better-tailwindcss": {
+   * //       cwd: import.meta.dirname + "/packages/website",
+   * //       entryPoint: "src/styles/globals.css",
+   * //     },
+   * //   },
+   * // }
+   */
+  cwd?: string;
+  /**
+   * Tailwind v4 の CSS エントリーファイルへのパス。
+   * 未指定だとデフォルトの tailwind クラスにフォールバックする。
+   */
+  entryPoint?: string;
 };
 
 /**

--- a/packages/eslint-config/types/index.ts
+++ b/packages/eslint-config/types/index.ts
@@ -1,12 +1,4 @@
 /**
- * preset (base / node / nextjs) に渡す options。
- */
-export type Options = {
-  betterTailwindcss?: BetterTailwindcssOptions;
-  typescript?: TypescriptOptions;
-};
-
-/**
  * better-tailwindcss preset の options。
  *
  * @see https://github.com/schoero/eslint-plugin-better-tailwindcss/blob/main/docs/settings/settings.md
@@ -35,6 +27,14 @@ export type BetterTailwindcssOptions = {
    * 未指定だとデフォルトの tailwind クラスにフォールバックする。
    */
   entryPoint?: string;
+};
+
+/**
+ * preset (base / node / nextjs) に渡す options。
+ */
+export type Options = {
+  betterTailwindcss?: BetterTailwindcssOptions;
+  typescript?: TypescriptOptions;
 };
 
 /**


### PR DESCRIPTION
## Summary

- eslint-config の `Options` 型に `betterTailwindcss` を追加し、`entryPoint` と `cwd` を preset 経由で渡せるようにした
- TypeScript の `tsconfigRootDir` と同じパターンで consumer が `import.meta.dirname` ベースのパスを指定できる
- `rules/tailwindcss.ts` のローカル型を `BetterTailwindcssOptions` に統合

## Test plan

- [x] `tsc --noEmit` 通過
- [x] `pnpm eslint .` 通過
- [x] `tsdown` ビルド成功