### PR TITLE
fix: update tsconfig target and lib from ES2024 to ES2025

### DIFF
--- a/packages/tsconfig/tsconfig.json
+++ b/packages/tsconfig/tsconfig.json
@@ -18,9 +18,9 @@
     // どのJavaScriptのバージョンに変換するか
     // 使うnodeバージョンによって変更する
     // 対応表 https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping
-    // ES2024でObject.groupBy / Promise.withResolvers / ArrayBuffer.prototype.transfer等の型が利用可能
-    // Node 22 LTS / Node 24 / 主要モダンブラウザは2026年時点でES2024をネイティブサポート
-    "target": "ES2024",
+    // ES2025でIterator helpers / Set methods / Promise.try等の型が利用可能
+    // Node 22 LTS / Node 24 / 主要モダンブラウザは2026年時点でES2025をネイティブサポート
+    "target": "ES2025",
 
     // バンドラー / トランスパイラ前提のmoduleモード (TS 5.4+)
     // ECMAScript imports/exportsを変換せず保持し、moduleResolution: "bundler" を暗黙的に指定する
@@ -103,9 +103,9 @@
     // Libs
     // ----------------------------------------------------------------
     /* If your code runs in the DOM: */
-    // "lib": ["ES2024", "dom"]
+    // "lib": ["ES2025", "dom"]
     /* If your code doesn't run in the DOM: */
-    "lib": ["ES2024"]
+    "lib": ["ES2025"]
 
     // ----------------------------------------------------------------
     // Types


### PR DESCRIPTION
## Summary
- `target` と `lib` を `ES2024` → `ES2025` に更新
- Node 22 LTS / Node 24 は ES2025 をネイティブサポート済み
- Iterator helpers (`Iterator#toArray()` 等)、Set methods、`Promise.try` の型が利用可能に

## 背景
`unicorn/prefer-iterator-to-array` ルールが `Iterator#toArray()` を要求するが、`lib: "ES2024"` では型定義がなく TypeScript エラーになる。
`ESNext` は Temporal 等 Node 未実装の API も含むため、`ES2025` が安全な選択。

## 影響
- `tsconfig.bundler.json` を extends しているプロジェクトの `lib` が `ES2025` に上がる
- `tsconfig.nextjs.json` は既に `lib: ["dom", "ESNext"]` のため影響なし