### PR TITLE
chore: hold typescript below v7 until typescript-eslint supports it

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,6 +17,12 @@
       "matchDepNames": ["node"],
       "matchUpdateTypes": ["minor", "patch"],
       "enabled": false
+    },
+    {
+      "description": "Hold typescript below v7 until typescript-eslint supports TS7 (typescript-eslint/typescript-eslint#10940)",
+      "matchManagers": ["npm"],
+      "matchDepNames": ["typescript"],
+      "allowedVersions": "<7"
     }
   ]
 }


### PR DESCRIPTION
## 背景

#2567 (typescript v7 への renovate 更新) で static ジョブが失敗している。

[失敗ログ](https://github.com/nozomiishii/configs/actions/runs/29182212219/job/86621905728?pr=2567)

```
TypeError: Cannot read properties of undefined (reading 'Intrinsic')
    at ts-api-utils@2.5.0/lib/index.cjs:787:57
```

## 原因

- typescript@7 (tsgo / typescript-go ベース) は旧 compiler API を公開しておらず、`ts.TypeFlags` が `undefined` になる
- ts-api-utils 2.5.0 はモジュールロード時に `ts.TypeFlags.Intrinsic` を参照するため、eslint.config.ts の読み込みだけでクラッシュする
- typescript-eslint 8.63.0 (latest) の peerDependencies は `typescript >=4.8.4 <6.1.0` で TS7 未対応
- TS7 対応は upstream で open のまま: typescript-eslint/typescript-eslint#10940

## 対応

renovate の packageRule で typescript を `<7` に制限する。

- [allowedVersions](https://docs.renovatebot.com/configuration-options/#allowedversions) で v7 以降の更新 PR を作らせない
- `renovate-config-validator` で検証済み

## 補足

- マージ後、renovate が #2567 を自動クローズする (手動クローズだと renovate が v7 更新を ignore 扱いにするため触らない)
- oxlint type-aware 移行時は TS7 が必須になるので、その時にこのルールを外す