### PR TITLE
fix: move Next.js overrides to preset

### DIFF
--- a/packages/eslint-config/presets/nextjs.ts
+++ b/packages/eslint-config/presets/nextjs.ts
@@ -48,6 +48,56 @@ export function nextjs(options: Options = {}) {
     jsxA11yX(),
 
     _nextjs(),
+
+    {
+      /**
+       * Next.js の instrumentation-client は Sentry, PostHog, Datadog RUM でトップレベル副作用関数を呼ぶ必要がある
+       *
+       * @see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-top-level-side-effects.md
+       * @see https://nextjs.org/docs/app/api-reference/file-conventions/instrumentation-client
+       */
+      files: ["**/instrumentation-client.ts"],
+      name: name("unicorn/instrumentation-client"),
+      rules: {
+        "unicorn/no-top-level-side-effects": "off",
+      },
+    },
+
+    {
+      /**
+       * next-intl越しにnext/linkやnext/navigationを使う
+       *
+       * @see https://next-intl-docs.vercel.app/docs/workflows/linting#consistent-usage-of-navigation-apis
+       */
+      name: name("next-intl"),
+      rules: {
+        "no-restricted-imports": [
+          "error",
+          {
+            message: "Please import from `libs/next-intl` instead.",
+            name: "next/link",
+          },
+          {
+            importNames: [
+              "getPathname",
+              "permanentRedirect",
+              "redirect",
+              "usePathname",
+              "useRouter",
+            ],
+            message: "Please import from `libs/next-intl` instead.",
+            name: "next/navigation",
+          },
+
+          {
+            importNames: ["getLocale"],
+            message: "Please import from `libs/next-intl` instead.",
+            name: "next-intl/server",
+          },
+        ],
+      },
+    },
+
     betterTailwindcss(options.betterTailwindcss),
 
     storybook(),

--- a/packages/eslint-config/rules/nextjs.ts
+++ b/packages/eslint-config/rules/nextjs.ts
@@ -18,40 +18,5 @@ export function _nextjs() {
       ...eslintPluginNext.configs.recommended,
       name: name("nextjs"),
     },
-
-    {
-      /**
-       * next-intl越しにnext/linkやnext/navigationを使う
-       *
-       * @see https://next-intl-docs.vercel.app/docs/workflows/linting#consistent-usage-of-navigation-apis
-       */
-      name: name("next-intl"),
-      rules: {
-        "no-restricted-imports": [
-          "error",
-          {
-            message: "Please import from `libs/next-intl` instead.",
-            name: "next/link",
-          },
-          {
-            importNames: [
-              "getPathname",
-              "permanentRedirect",
-              "redirect",
-              "usePathname",
-              "useRouter",
-            ],
-            message: "Please import from `libs/next-intl` instead.",
-            name: "next/navigation",
-          },
-
-          {
-            importNames: ["getLocale"],
-            message: "Please import from `libs/next-intl` instead.",
-            name: "next-intl/server",
-          },
-        ],
-      },
-    },
   ]);
 }

--- a/packages/eslint-config/rules/unicorn.ts
+++ b/packages/eslint-config/rules/unicorn.ts
@@ -44,19 +44,5 @@ export function unicorn() {
         "unicorn/prefer-export-from": "error",
       },
     },
-
-    {
-      /**
-       * Next.js の instrumentation-client は Sentry, PostHog, Datadog RUM でトップレベル副作用関数を呼ぶ必要がある
-       *
-       * @see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-top-level-side-effects.md
-       * @see https://nextjs.org/docs/app/api-reference/file-conventions/instrumentation-client
-       */
-      files: ["**/instrumentation-client.ts"],
-      name: name("unicorn/instrumentation-client"),
-      rules: {
-        "unicorn/no-top-level-side-effects": "off",
-      },
-    },
   ]);
 }


### PR DESCRIPTION
## 概要

- instrumentation-client の Unicorn ルール例外を Next.js preset へ移動
- next-intl の import 制約を Next.js preset へ移動
- plugin ごとの rules を plugin 設定だけに整理

## 確認

- pnpm --filter @nozomiishii/eslint-config lint
- pnpm --filter @nozomiishii/eslint-config check:ts
- pnpm --filter @nozomiishii/eslint-config test
- pnpm --filter @nozomiishii/eslint-config build