### PR TITLE
feat: cover .storybook in tsconfig include on init

### DIFF
--- a/packages/eslint-config/README.ja.md
+++ b/packages/eslint-config/README.ja.md
@@ -24,6 +24,8 @@ pnpx nozo init
 
 これで `@nozomiishii/eslint-config` / `eslint` / `typescript` が pin で `devDependencies` に追加され、`eslint` / `lint` / `lint:fix` の scripts が追加され、選んだ preset を compose する `eslint.config.ts` が生成される。
 
+`tsconfig.json` に `include` 配列があれば `.storybook/**/*` も足す。TypeScript はディレクトリ名を展開するときドット始まりを拾わないため、`.storybook` と書いても `.storybook/main.ts` は project に入らず、preset の Storybook ルールが parse error になる。`include` が無い `tsconfig.json` は既定の `**/*` を壊さないよう触らず、CLI が警告を出す。
+
 preset は2つから選ぶ:
 
 - `nextjs`: React / Next.js / Tailwind / Storybook 込みの web アプリ向け

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -26,6 +26,13 @@ This adds `@nozomiishii/eslint-config`, `eslint`, and `typescript` to your
 `devDependencies` (pinned), adds `eslint` / `lint` / `lint:fix` scripts, and
 writes an `eslint.config.ts` that composes the preset you pick.
 
+It also appends `.storybook/**/*` when `tsconfig.json` has an `include` array.
+TypeScript skips dot directories while expanding a bare directory name, so
+`.storybook` alone leaves `.storybook/main.ts` out of the project and the
+preset's Storybook rules fail with a parse error. A `tsconfig.json` without
+`include` is left alone so its default `**/*` stays intact, and the CLI warns
+instead.
+
 Pick one of two presets:
 
 - `nextjs`: web apps, with React / Next.js / Tailwind / Storybook

--- a/packages/eslint-config/src/init/bin.ts
+++ b/packages/eslint-config/src/init/bin.ts
@@ -1,4 +1,5 @@
-import { init } from ".";
+import { init, tsconfigIncludeReports } from ".";
 
-await init({ cwd: process.cwd() });
+const { tsconfigInclude } = await init({ cwd: process.cwd() });
 process.stdout.write("✓ @nozomiishii/eslint-config installed\n");
+process.stdout.write(`${tsconfigIncludeReports[tsconfigInclude].message}\n`);

--- a/packages/eslint-config/src/init/index.test.ts
+++ b/packages/eslint-config/src/init/index.test.ts
@@ -1,8 +1,8 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { expect, test } from "vitest";
-import { init, type PresetId } from ".";
+import { init, type PresetId, type TsconfigIncludeOutcome } from ".";
 
 type InitResult = {
   configContent: string;
@@ -10,6 +10,11 @@ type InitResult = {
     devDependencies?: Record<string, string>;
     scripts?: Record<string, string>;
   };
+};
+
+type TsconfigInitResult = {
+  outcome: TsconfigIncludeOutcome;
+  tsconfig: null | string;
 };
 
 // 一時dirでinitを実行し、生成された package.json と eslint.config.ts を読み取る
@@ -34,6 +39,28 @@ async function runInit(preset?: PresetId, isMonorepo?: boolean): Promise<InitRes
   rmSync(tmpDir, { force: true, recursive: true });
 
   return { configContent, pkg };
+}
+
+// tsconfig.json を任意で置いた一時dirでinitを実行し、戻り値と書き戻された tsconfig.json を読み取る
+async function runInitWithTsconfig(tsconfigSource?: string): Promise<TsconfigInitResult> {
+  const tmpDir = mkdtempSync(path.join(tmpdir(), "nozo-eslint-init-"));
+  writeFileSync(
+    path.join(tmpDir, "package.json"),
+    `${JSON.stringify({ name: "fixture", version: "1.0.0" }, null, 2)}\n`,
+  );
+
+  const tsconfigPath = path.join(tmpDir, "tsconfig.json");
+
+  if (tsconfigSource !== undefined) {
+    writeFileSync(tsconfigPath, tsconfigSource);
+  }
+
+  const { tsconfigInclude } = await init({ cwd: tmpDir });
+  const tsconfig = existsSync(tsconfigPath) ? readFileSync(tsconfigPath, "utf8") : null;
+
+  rmSync(tmpDir, { force: true, recursive: true });
+
+  return { outcome: tsconfigInclude, tsconfig };
 }
 
 test("init adds @nozomiishii/eslint-config to devDependencies", async () => {
@@ -104,9 +131,7 @@ test("the node starter does not reference nextjs", async () => {
 test("init with monorepo writes tsconfigRootDir", async () => {
   const { configContent } = await runInit("node", true);
 
-  expect(configContent).toContain(
-    "node({ typescript: { tsconfigRootDir: import.meta.dirname } })",
-  );
+  expect(configContent).toContain("node({ typescript: { tsconfigRootDir: import.meta.dirname } })");
 });
 
 // 単一 repo (既定) は tsconfigRootDir を入れない
@@ -114,4 +139,95 @@ test("init without monorepo omits tsconfigRootDir", async () => {
   const { configContent } = await runInit("node");
 
   expect(configContent).not.toContain("tsconfigRootDir");
+});
+
+// preset は .storybook を lint するため、tsconfig の include にも glob を足す
+test("init adds the storybook glob to the tsconfig include", async () => {
+  const { tsconfig } = await runInitWithTsconfig(`{\n  "include": ["src"]\n}\n`);
+
+  expect(tsconfig).toContain('".storybook/**/*"');
+});
+
+test("init reports added when it writes the storybook glob", async () => {
+  const { outcome } = await runInitWithTsconfig(`{\n  "include": ["src"]\n}\n`);
+
+  expect(outcome).toBe("added");
+});
+
+// 1行で書かれた include は1行のまま保つ
+test("init keeps a single-line include on one line", async () => {
+  const { tsconfig } = await runInitWithTsconfig(`{ "include": ["src"] }\n`);
+
+  expect(tsconfig).toBe(`{ "include": ["src", ".storybook/**/*"] }\n`);
+});
+
+// 複数行で書かれた include は既存要素のインデントに合わせる
+test("init matches the indentation of a multi-line include", async () => {
+  const { tsconfig } = await runInitWithTsconfig(`{\n  "include": [\n    "src"\n  ]\n}\n`);
+
+  expect(tsconfig).toBe(`{\n  "include": [\n    "src",\n    ".storybook/**/*"\n  ]\n}\n`);
+});
+
+// 既に glob があれば tsconfig.json は書き換えない
+test("init leaves the tsconfig untouched when the storybook glob is present", async () => {
+  const source = `{\n  "include": ["src", ".storybook/**/*"]\n}\n`;
+
+  const { tsconfig } = await runInitWithTsconfig(source);
+
+  expect(tsconfig).toBe(source);
+});
+
+test("init reports unchanged when the storybook glob is present", async () => {
+  const { outcome } = await runInitWithTsconfig(`{\n  "include": [".storybook/**/*"]\n}\n`);
+
+  expect(outcome).toBe("unchanged");
+});
+
+// コメント付き tsconfig.json のコメントを消さない
+test("init preserves comments in the tsconfig", async () => {
+  const { tsconfig } = await runInitWithTsconfig(`{\n  // src only\n  "include": ["src"]\n}\n`);
+
+  expect(tsconfig).toContain("// src only");
+});
+
+// コメント付きでも glob は足せる
+test("init adds the storybook glob to a tsconfig with comments", async () => {
+  const { tsconfig } = await runInitWithTsconfig(`{\n  // src only\n  "include": ["src"]\n}\n`);
+
+  expect(tsconfig).toContain('".storybook/**/*"');
+});
+
+// tsconfig.json が無いプロジェクトには作らない
+test("init does not create a tsconfig.json", async () => {
+  const { tsconfig } = await runInitWithTsconfig();
+
+  expect(tsconfig).toBeNull();
+});
+
+test("init reports missing when the project has no tsconfig.json", async () => {
+  const { outcome } = await runInitWithTsconfig();
+
+  expect(outcome).toBe("missing");
+});
+
+// include の無い tsconfig は既定の **/* を壊さないよう触らない
+test("init leaves a tsconfig without include untouched", async () => {
+  const source = `{\n  "compilerOptions": { "strict": true }\n}\n`;
+
+  const { tsconfig } = await runInitWithTsconfig(source);
+
+  expect(tsconfig).toBe(source);
+});
+
+test("init reports no-include when the tsconfig has no include array", async () => {
+  const { outcome } = await runInitWithTsconfig(`{\n  "compilerOptions": {}\n}\n`);
+
+  expect(outcome).toBe("no-include");
+});
+
+// 壊れた tsconfig.json でも init 全体は失敗させない
+test("init reports invalid when the tsconfig cannot be parsed", async () => {
+  const { outcome } = await runInitWithTsconfig(`{ "include": [`);
+
+  expect(outcome).toBe("invalid");
 });

--- a/packages/eslint-config/src/init/index.ts
+++ b/packages/eslint-config/src/init/index.ts
@@ -1,4 +1,5 @@
 /** Scaffold ESLint config into the consumer project. */
+import { type AST, getStaticJSONValue, parseJSON } from "jsonc-eslint-parser";
 import { existsSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
@@ -6,7 +7,11 @@ import { fileURLToPath } from "node:url";
 
 export type InitOptions = { cwd: string; monorepo?: boolean; preset?: PresetId };
 
+export type InitResult = { tsconfigInclude: TsconfigIncludeOutcome };
+
 export type PresetId = "nextjs" | "node";
+
+export type TsconfigIncludeOutcome = "added" | "invalid" | "missing" | "no-include" | "unchanged";
 
 type PackageJson = {
   devDependencies?: Record<string, string>;
@@ -16,11 +21,41 @@ type PackageJson = {
   version: string;
 };
 
+/**
+ * TypeScript はディレクトリ名を展開するときドット始まりを拾わないため、
+ * `.storybook` ではなく glob で書かないと projectService の対象にならない。
+ */
+const STORYBOOK_INCLUDE = ".storybook/**/*";
+
+/** tsconfig.json をどう扱ったかを CLI に伝える文言。nozo と nozo-eslint-init で共有する。 */
+export const tsconfigIncludeReports = {
+  added: {
+    level: "info",
+    message: `tsconfig.json: added "${STORYBOOK_INCLUDE}" to include`,
+  },
+  invalid: {
+    level: "warn",
+    message: `tsconfig.json could not be parsed; add "${STORYBOOK_INCLUDE}" to include by hand`,
+  },
+  missing: {
+    level: "info",
+    message: `No tsconfig.json found; skipped the "${STORYBOOK_INCLUDE}" include`,
+  },
+  "no-include": {
+    level: "warn",
+    message: `tsconfig.json has no include array; add "${STORYBOOK_INCLUDE}" to it by hand`,
+  },
+  unchanged: {
+    level: "info",
+    message: `tsconfig.json: include already covers "${STORYBOOK_INCLUDE}"`,
+  },
+} as const satisfies Record<TsconfigIncludeOutcome, { level: "info" | "warn"; message: string }>;
+
 export async function init({
   cwd,
   monorepo = false,
   preset = "nextjs",
-}: InitOptions): Promise<void> {
+}: InitOptions): Promise<InitResult> {
   const root = packageRoot();
 
   const selfPkg = JSON.parse(
@@ -29,10 +64,7 @@ export async function init({
     peerDependencies: { eslint: string; typescript: string };
   };
 
-  const starterRaw = await readFile(
-    path.join(root, "starters", `${preset}.ts`),
-    "utf8",
-  );
+  const starterRaw = await readFile(path.join(root, "starters", `${preset}.ts`), "utf8");
 
   // monorepo の per-package config は tsconfigRootDir を明示する。
   const starter = monorepo
@@ -54,13 +86,88 @@ export async function init({
 
   target.scripts = {
     ...target.scripts,
-    "eslint": "eslint --max-warnings=0 --cache",
-    "lint": "pnpm eslint",
+    eslint: "eslint --max-warnings=0 --cache",
+    lint: "pnpm eslint",
     "lint:fix": "pnpm eslint --fix",
   };
 
   await writeFile(targetPath, `${JSON.stringify(target, null, 2)}\n`);
   await writeFile(path.resolve(cwd, "eslint.config.ts"), starter);
+
+  return { tsconfigInclude: await ensureStorybookInclude(cwd) };
+}
+
+/**
+ * preset は `.storybook` を lint するため、tsconfig.json の include にも glob を足す。
+ * include が無い tsconfig は既定の `**\/*` を壊さないよう触らない。
+ */
+async function ensureStorybookInclude(cwd: string): Promise<TsconfigIncludeOutcome> {
+  const tsconfigPath = path.resolve(cwd, "tsconfig.json");
+
+  if (!existsSync(tsconfigPath)) {
+    return "missing";
+  }
+
+  const source = await readFile(tsconfigPath, "utf8");
+  let include: AST.JSONArrayExpression | null;
+
+  try {
+    include = findIncludeArray(source);
+  } catch {
+    return "invalid";
+  }
+
+  if (include === null) {
+    return "no-include";
+  }
+
+  if (getStaticJSONValue(include).includes(STORYBOOK_INCLUDE)) {
+    return "unchanged";
+  }
+
+  await writeFile(tsconfigPath, insertInclude(source, include));
+
+  return "added";
+}
+
+/** tsconfig.json の include 配列を返す。include が無い、または配列でないときは null。 */
+function findIncludeArray(source: string): AST.JSONArrayExpression | null {
+  const root = parseJSON(source, { jsonSyntax: "jsonc" }).body[0].expression;
+
+  if (root.type !== "JSONObjectExpression") {
+    return null;
+  }
+
+  const include = root.properties.find(
+    (property) => property.key.type === "JSONLiteral" && property.key.value === "include",
+  );
+
+  return include?.value.type === "JSONArrayExpression" ? include.value : null;
+}
+
+/** offset がある行の字下げ。 */
+function indentOf(source: string, offset: number): string {
+  const lineStart = source.lastIndexOf("\n", offset) + 1;
+
+  return /^[\t ]*/.exec(source.slice(lineStart, offset))?.[0] ?? "";
+}
+
+/** コメントや書式を保つため、JSON を組み直さずテキストへ直接差し込む。 */
+function insertInclude(source: string, include: AST.JSONArrayExpression): string {
+  const entry = JSON.stringify(STORYBOOK_INCLUDE);
+  const last = include.elements.at(-1);
+
+  if (last === undefined || last === null) {
+    const afterBracket = include.range[0] + 1;
+
+    return `${source.slice(0, afterBracket)}${entry}${source.slice(afterBracket)}`;
+  }
+
+  const end = last.range[1];
+  const isMultiline = source.slice(include.range[0], end).includes("\n");
+  const separator = isMultiline ? `,\n${indentOf(source, last.range[0])}` : ", ";
+
+  return `${source.slice(0, end)}${separator}${entry}${source.slice(end)}`;
 }
 
 /**

--- a/packages/nozo/src/commands/init.test.ts
+++ b/packages/nozo/src/commands/init.test.ts
@@ -33,8 +33,15 @@ test("happy path: every tool's install script completes without throwing", async
   expect.hasAssertions();
 
   for (const id of toolIds) {
-    await expect(tools[id].run({ cwd })).resolves.toBeUndefined();
+    await expect(tools[id].run({ cwd })).resolves.not.toThrow();
   }
+});
+
+// eslint は tsconfig.json をどう扱ったかを返し、init コマンドはそれをログに出す。
+test("the eslint tool reports how it handled tsconfig.json", async ({ cwd }) => {
+  await expect(tools.eslint.run({ cwd })).resolves.toStrictEqual({
+    tsconfigInclude: "missing",
+  });
 });
 
 // lockfile も packageManager フィールドも無いとき、nozo を起動したランナーを使う。
@@ -51,9 +58,7 @@ test("falls back to the launching runner when the project has no config", async 
 test("throws when neither project config nor runner is available", async ({ cwd }) => {
   stubUserAgent();
 
-  await expect(resolvePackageManager(cwd)).rejects.toThrow(
-    "Could not determine a package manager",
-  );
+  await expect(resolvePackageManager(cwd)).rejects.toThrow("Could not determine a package manager");
 });
 
 // プロジェクトの lockfile はランナーより優先される。

--- a/packages/nozo/src/commands/init.ts
+++ b/packages/nozo/src/commands/init.ts
@@ -1,6 +1,11 @@
 import * as p from "@clack/prompts";
 import { init as initCommitlint } from "@nozomiishii/commitlint-config/init";
-import { init as initEslint, type PresetId } from "@nozomiishii/eslint-config/init";
+import {
+  init as initEslint,
+  type InitResult,
+  type PresetId,
+  tsconfigIncludeReports,
+} from "@nozomiishii/eslint-config/init";
 import { init as initLefthook } from "@nozomiishii/lefthook-config/init";
 import { init as initPostinstall } from "@nozomiishii/postinstall/init";
 import { init as initPrettier } from "@nozomiishii/prettier-config/init";
@@ -20,11 +25,12 @@ type Tool = {
 
 type ToolConfig = { monorepo: boolean; preset: PresetId };
 
+// 報告することがある init だけ結果を返す
 type ToolInit = (options: {
   cwd: string;
   monorepo?: boolean;
   preset?: PresetId;
-}) => Promise<void>;
+}) => Promise<InitResult> | Promise<void>;
 
 export const tools = {
   commitlint: {
@@ -177,8 +183,14 @@ export default defineCommand({
 
       try {
         const config = configs[id];
-        await tool.run(config === undefined ? { cwd } : { cwd, ...config });
+        const result = await tool.run(config === undefined ? { cwd } : { cwd, ...config });
         spinner.stop(`${tool.label}: ok`);
+
+        // tsconfig.json に触れたツールは、何をしたかを spinner の後に伝える
+        if (result !== undefined) {
+          const report = tsconfigIncludeReports[result.tsconfigInclude];
+          p.log[report.level](report.message);
+        }
       } catch (error) {
         spinner.stop(`${tool.label}: failed`);
         p.cancel(error instanceof Error ? error.message : String(error));


### PR DESCRIPTION
## 背景

nextjs preset は `storybook()` を含み `.storybook/main.ts` を lint する。一方 `rules/typescript.ts` の `projectService: true` は tsconfig の対象外ファイルで parse error になるため、Storybook を使うプロジェクトは初回 lint が必ず落ちていた。

```
0:0  error  Parsing error: .../.storybook/main.ts was not found by the project service.
            Consider either including it in the tsconfig.json or including it in allowDefaultProject
```

エラーの案内どおり `include` に `.storybook` と書いても直らない。TypeScript がディレクトリ名をワイルドカード展開するとき、ドット始まりのディレクトリを拾わないため。`tsc --listFilesOnly` での実測:

| include | `.storybook/main.ts` | `.storybook/preview.tsx` |
| --- | --- | --- |
| 指定なし (既定の `**/*`) | ✗ | ✗ |
| `["src", ".storybook"]` | ✗ | ✗ |
| `["src", ".storybook/**/*.ts"]` | ✓ | ✗ |
| `["src", ".storybook/**/*"]` | ✓ | ✓ |

TanStack Start preset の [#2647](https://github.com/nozomiishii/configs/pull/2647) の敵対的レビューで見つかった。nextjs preset にも同じ穴があったため、無関係な変更を混ぜず別 PR として切り出している。

## 変更

`init()` が `tsconfig.json` の `include` 配列に `.storybook/**/*` を足す。

- 追加パターンは `.storybook/**/*`。`**/*.ts` だと React プロジェクトでよくある `.storybook/preview.tsx` が漏れるため、拡張子を絞らない
- `.storybook` の存在では分岐しない。init は Storybook 導入前に走るのが普通で、存在チェックにすると後から Storybook を入れた人が同じ穴を踏む。存在しないパスを include に書いても TypeScript は警告しない (他の include が空でなければ `No inputs were found` にはならない)
- `include` が無い `tsconfig.json` は触らない。`include` を新設すると既定の `**/*` や `files` 指定との関係を壊すため、CLI が警告を出して手動対応に委ねる

コメント付き `tsconfig.json` を壊さないよう、`JSON.parse` + 再シリアライズではなく `jsonc-eslint-parser` の range を使ってテキストに直接差し込む。1行で書かれた `include` は1行のまま、複数行なら既存要素のインデントに合わせる。

## CLI の出力

`init()` は扱った結果を返し、`nozo init` は `p.log.info` / `p.log.warn` に、`nozo-eslint-init` は stdout に同じ文言を出す。文言は `tsconfigIncludeReports` の 1 箇所で持つ。

```
✓ @nozomiishii/eslint-config installed
tsconfig.json: added ".storybook/**/*" to include
```

| 状態 | 出力 | level |
| --- | --- | --- |
| 追加した | `tsconfig.json: added ".storybook/**/*" to include` | info |
| 既に入っている | `tsconfig.json: include already covers ".storybook/**/*"` | info |
| tsconfig.json が無い | `No tsconfig.json found; skipped the ".storybook/**/*" include` | info |
| include が無い | `tsconfig.json has no include array; add ".storybook/**/*" to it by hand` | warn |
| パースできない | `tsconfig.json could not be parsed; add ".storybook/**/*" to include by hand` | warn |

## 確認

- `packages/eslint-config`: lint / tsc / test (25 passed、うち 13 が今回追加)
- `packages/nozo`: lint / tsc / test (5 passed)
- 一時プロジェクトで `init()` を実行し、コメント付き tsconfig にコメントを残したまま追記されること、`tsc --listFilesOnly` が `.storybook/main.ts` と `.storybook/preview.tsx` を拾うこと、2回目の実行が `unchanged` を返して書き換えないことを確認
