### PR TITLE
feat: add @tanstack/eslint-plugin-query to tanstack-start preset

### DIFF
--- a/packages/eslint-config/README.ja.md
+++ b/packages/eslint-config/README.ja.md
@@ -27,7 +27,7 @@ pnpx nozo init
 preset は次から選ぶ:
 
 - `nextjs`: React / Next.js / Tailwind / Storybook 込みの web アプリ向け
-- `tanstack-start`: React / TanStack Start (Vite) / Tailwind / Storybook 込みの web アプリ向け
+- `tanstack-start`: React / TanStack Start (Vite) / TanStack Query / Tailwind / Storybook 込みの web アプリ向け
 - `node`: CLI / ライブラリ向け（web 系を除いた Node.js 構成）
 
 ## preset

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -29,7 +29,7 @@ writes an `eslint.config.ts` that composes the preset you pick.
 Pick from these presets:
 
 - `nextjs`: web apps, with React / Next.js / Tailwind / Storybook
-- `tanstack-start`: web apps, with React / TanStack Start (Vite) / Tailwind / Storybook
+- `tanstack-start`: web apps, with React / TanStack Start (Vite) / TanStack Query / Tailwind / Storybook
 - `node`: CLI / library projects (Node.js setup without the web layers)
 
 ## Presets

--- a/packages/eslint-config/docs/tanstack-start.md
+++ b/packages/eslint-config/docs/tanstack-start.md
@@ -12,6 +12,15 @@ shell は SSR ビルドで prerender されて root route の loader がサー�
 `route-param-names` は TanStack Router の import があるファイルだけを見るが、
 `create-route-property-order` は callee の名前しか見ないので、別 package の `createRoute` にも当たる。
 
+`@tanstack/eslint-plugin-query` は `flat/recommended-strict` を有効化する。どの rule も
+`@tanstack/` で始まり `-query` で終わる package からの import があるファイルだけを見るため、
+TanStack Query を使わない project に入れても何も報告しない。
+
+`recommended` との差は `prefer-query-options` の 1 つ。`queryKey` と `queryFn` を
+`queryOptions()` / `infiniteQueryOptions()` に閉じ込めさせる rule で、
+[同じ key に別の `queryFn` が紐づく事故](https://tanstack.com/query/latest/docs/eslint/prefer-query-options)
+を防ぐ。
+
 他プラグインの rule 調整は preset 側に置く。rule module は自分の plugin だけを扱い、
 横断的な調整は組み合わせる preset が持つ。上書き対象より後に置く必要があるため preset の末尾にまとまっている。
 
@@ -36,23 +45,27 @@ lint で直しても毎回消える。route 2 本のプロジェクトで 28 件
 
 ## perfectionist/sort-objects
 
-route 定義のオブジェクトを並べ替えの対象外にする。
+TanStack の property-order 系 rule が見るオブジェクトを並べ替えの対象外にする。対象は
+route 定義 (`createFileRoute` など) と、`useMutation` / `useInfiniteQuery` /
+`useSuspenseInfiniteQuery` / `infiniteQueryOptions`。
 
-route 定義のプロパティ順は型推論に効く。`context` が組み立てた値を `beforeLoad` が受け取り、
-それを `loader` が受け取る、という連鎖が順序で決まっている。`create-route-property-order` はその順を守らせる rule で、
-アルファベット順とは両立しない。
+これらのプロパティ順は型推論に効く。route 定義では `context` が組み立てた値を `beforeLoad` が受け取り、
+それを `loader` が受け取る。`useMutation` では `onMutate` が返した context を `onError` と `onSettled` が受け取る。
+`create-route-property-order` と `mutation-property-order` / `infinite-query-property-order` は
+その順を守らせる rule で、アルファベット順とは両立しない。
 
 ```tsx
 // TanStack が要求する順
-{ context: ..., beforeLoad: ... }
-// → perfectionist: Expected "beforeLoad" to come before "context"
+{ context: ..., beforeLoad: ... } // route 定義
+{ onMutate: ..., onError: ... } // useMutation
 
 // perfectionist が要求する順
 { beforeLoad: ..., context: ... }
-// → @tanstack/router: Invalid order of properties for `createFileRoute`
+{ onError: ..., onMutate: ... }
 ```
 
-どちらの順でも片方が怒り、両方 auto fix 可能なので `--fix` が往復する。型推論に効く側を優先した。
+どちらの順でも片方が怒り、両方 auto fix 可能なので `--fix` が往復し、
+ESLint が `ESLintCircularFixesWarning` を出す。型推論に効く側を優先した。
 
 除外は `useConfigurationIf.callingFunctionNamePattern` でオブジェクト単位に絞っている。
 route 定義は `src/router.tsx` など routes 配下以外にも書けるため、ファイル単位では切れない。
@@ -107,8 +120,6 @@ route ファイルは `export const Route` が構造上必須なので、この 
 `@tanstack/eslint-plugin-start` は入れていない。peer が `^8.57.0 || ^9.0.0` 止まりで eslint 10 に入らず、
 rule 2 つがどちらも RSC の `'use client'` 境界の検査で SPA mode には効かない。
 追跡は [#2646](https://github.com/nozomiishii/configs/issues/2646)。
-
-`@tanstack/eslint-plugin-query` も入れていない。react-query を使う構成が決まっていないため、使う時点で追加する。
 
 ## 既定値を変えている場合
 

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -61,6 +61,7 @@
     "@next/eslint-plugin-next": "16.2.12",
     "@stylistic/eslint-plugin": "5.10.0",
     "@swc-node/register": "1.12.1",
+    "@tanstack/eslint-plugin-query": "5.101.4",
     "@tanstack/eslint-plugin-router": "1.162.0",
     "@types/node": "24.13.3",
     "@vitest/eslint-plugin": "1.6.24",

--- a/packages/eslint-config/presets/tanstack-start.ts
+++ b/packages/eslint-config/presets/tanstack-start.ts
@@ -12,26 +12,33 @@ import {
   reactHooks,
   reactRefresh,
   storybook,
+  tanstackQuery,
   tanstackRouter,
 } from "../rules";
 import { name } from "../utils/name";
 import { base } from "./base";
 
 /**
- * route定義のオブジェクトを受け取る関数。
- * create-route-property-orderが並び順を見る対象と同じ。
+ * プロパティの並び順が型推論に効くオブジェクトを受け取る関数。
+ * TanStackのproperty-order系ruleが並び順を見る対象と同じ。
  *
  * @see https://github.com/TanStack/router/blob/main/packages/eslint-plugin-router/src/rules/create-route-property-order/constants.ts
+ * @see https://github.com/TanStack/query/blob/main/packages/eslint-plugin-query/src/rules/infinite-query-property-order/constants.ts
+ * @see https://github.com/TanStack/query/blob/main/packages/eslint-plugin-query/src/rules/mutation-property-order/constants.ts
  */
-const routeDefinitionFunctions = [
+const propertyOrderFunctions = [
   "createFileRoute",
   "createRootRoute",
   "createRootRouteWithContext",
   "createRoute",
+  "infiniteQueryOptions",
+  "useInfiniteQuery",
+  "useMutation",
+  "useSuspenseInfiniteQuery",
 ];
 
 /**
- * base の sort-objects 設定。上書きしても route 定義以外は元の挙動を保つため、
+ * base の sort-objects 設定。上書きしても対象のオブジェクト以外は元の挙動を保つため、
  * 値を書き写さず recommended-natural から取る。
  */
 const sortObjectsRule =
@@ -82,12 +89,13 @@ export function tanstackStart(options: Options = {}) {
     jsxA11yX(),
 
     tanstackRouter(),
+    tanstackQuery(),
     betterTailwindcss(options.betterTailwindcss),
 
     storybook(),
     playwright(),
 
-    // ここから下は TanStack Router の書き方に合わせた他 plugin の調整。
+    // ここから下は TanStack の書き方に合わせた他 plugin の調整。
     // 上書き対象より後に置く必要がある。
     {
       name: name("tanstack-start/only-throw-error"),
@@ -118,10 +126,10 @@ export function tanstackStart(options: Options = {}) {
       name: name("tanstack-start/sort-objects"),
       rules: {
         /**
-         * route定義のプロパティ順は型推論に効くため、create-route-property-orderが
-         * 決めた順を守る必要がある。baseのperfectionistがアルファベット順に直そうとして
-         * 競合し、どちらもauto fixできるので互いを打ち消し合う。
-         * route定義のオブジェクトだけ並べ替えの対象外にする。
+         * route定義とquery定義のプロパティ順は型推論に効くため、TanStackの
+         * property-order系ruleが決めた順を守る必要がある。baseのperfectionistが
+         * アルファベット順に直そうとして競合し、どちらもauto fixできるので
+         * 互いを打ち消し合う。該当のオブジェクトだけ並べ替えの対象外にする。
          *
          * @see https://perfectionist.dev/rules/sort-objects#useconfigurationif
          */
@@ -132,9 +140,7 @@ export function tanstackStart(options: Options = {}) {
             // 照合対象はcalleeのソース文字列。createFileRoute("/about")のように
             // 引数まで含むため、関数名の直後で切る。
             useConfigurationIf: {
-              callingFunctionNamePattern: routeDefinitionFunctions.map(
-                (fn) => String.raw`^${fn}\b`,
-              ),
+              callingFunctionNamePattern: propertyOrderFunctions.map((fn) => String.raw`^${fn}\b`),
             },
           },
           ...sortObjectsFallback,

--- a/packages/eslint-config/rules/index.ts
+++ b/packages/eslint-config/rules/index.ts
@@ -38,6 +38,8 @@ export { stylistic } from "./stylistic";
 
 export { betterTailwindcss } from "./tailwindcss";
 
+export { tanstackQuery } from "./tanstack-query";
+
 export { tanstackRouter } from "./tanstack-router";
 
 export { typescript } from "./typescript";

--- a/packages/eslint-config/rules/tanstack-query.ts
+++ b/packages/eslint-config/rules/tanstack-query.ts
@@ -1,0 +1,25 @@
+import tanstackQueryPlugin from "@tanstack/eslint-plugin-query";
+import { defineConfig } from "eslint/config";
+import { name } from "../utils/name";
+
+/**
+ * @returns `@tanstack/eslint-plugin-query`
+ *
+ * どのruleも`@tanstack/`で始まり`-query`で終わるpackageからのimportがある
+ * ファイルだけを見るため、queryを使わないprojectに入れても何も報告しない。
+ *
+ * recommendedではなくrecommended-strictを使う。差はprefer-query-optionsの1つで、
+ * queryKeyとqueryFnをqueryOptions()に閉じ込めさせる。
+ *
+ * @see https://tanstack.com/query/latest/docs/eslint/eslint-plugin-query
+ * @see https://github.com/TanStack/query/tree/main/packages/eslint-plugin-query
+ */
+export function tanstackQuery() {
+  return defineConfig(
+    // 要素が増えても落とさないよう配列のまま扱う。upstream の name は付け替える。
+    tanstackQueryPlugin.configs["flat/recommended-strict"].map((config) => ({
+      ...config,
+      name: name("tanstack-query"),
+    })),
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,9 @@ importers:
       '@swc-node/register':
         specifier: 1.12.1
         version: 1.12.1(@swc/core@1.15.46)(@swc/types@0.1.27)(supports-color@7.2.0)(typescript@6.0.3)
+      '@tanstack/eslint-plugin-query':
+        specifier: 5.101.4
+        version: 5.101.4(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
       '@tanstack/eslint-plugin-router':
         specifier: 1.162.0
         version: 1.162.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
@@ -1832,6 +1835,15 @@ packages:
 
   '@swc/types@0.1.27':
     resolution: {integrity: sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==}
+
+  '@tanstack/eslint-plugin-query@5.101.4':
+    resolution: {integrity: sha512-jqAZJWXGd5PthJYH9wmC2O5Ry5xAN2/7zxi9qcANQ+Xix8V5JkqNRjZ8Fh+rYzqzVYGiHqbrHekt+uh38OZVpw==}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: ^5.4.0 || ^6.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@tanstack/eslint-plugin-router@1.162.0':
     resolution: {integrity: sha512-0mv+5fOnWXeorh6zd3VyHVfpejIzc7+z68Ts0CQMDzMiwjM5rvea46fyl2m50zx5JFennsu7RO/QJAfnqkKJXw==}
@@ -5831,6 +5843,15 @@ snapshots:
   '@swc/types@0.1.27':
     dependencies:
       '@swc/counter': 0.1.3
+
+  '@tanstack/eslint-plugin-query@5.101.4(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@tanstack/eslint-plugin-router@1.162.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
     dependencies:


### PR DESCRIPTION
## 背景

`tanstackStart()` preset に TanStack Query 向けの lint が無い。preset 追加時 (#2647) は「react-query を使う構成が決まっていないため、使う時点で追加する」として見送っていた。

## 変更

`@tanstack/eslint-plugin-query` を `tanstackStart()` に入れた。

`rules/tanstack-query.ts` はプラグインの有効化だけを持ち、他プラグインの調整は preset 側に置く方針を `rules/tanstack-router.ts` から踏襲している。

### `flat/recommended-strict` を選んだ

`recommended` との差は `prefer-query-options` の 1 つで、`queryKey` と `queryFn` を `queryOptions()` / `infiniteQueryOptions()` に閉じ込めさせる。[同じ key に別の `queryFn` が紐づく事故](https://tanstack.com/query/latest/docs/eslint/prefer-query-options)を防ぐルール。

この repo の他の選択 (typescript は `strictTypeChecked`、storybook は `csf-strict`、vitest は `configs.all`) に合わせている。

有効になるルールは以下の 8 つ。severity は upstream の既定のまま。

| rule | severity | fixable |
| --- | --- | --- |
| `exhaustive-deps` | error | あり |
| `stable-query-client` | error | あり |
| `infinite-query-property-order` | error | あり |
| `mutation-property-order` | error | あり |
| `no-unstable-deps` | error | なし |
| `no-void-query-fn` | error | なし |
| `prefer-query-options` | error | なし |
| `no-rest-destructuring` | warn | なし |

どのルールも `@tanstack/` で始まり `-query` で終わる package からの import があるファイルだけを見る ([detect-react-query-imports.ts](https://github.com/TanStack/query/blob/main/packages/eslint-plugin-query/src/utils/detect-react-query-imports.ts))。TanStack Query を使わない project に入れても何も報告しない。

### `perfectionist/sort-objects` の除外を広げた

`create-route-property-order` と同じ衝突が query 側にもある。`mutation-property-order` は `onMutate` を `onError` より前に、`infinite-query-property-order` は `queryFn` を `getNextPageParam` より前に要求する。どちらもアルファベット順と逆で、両方 auto fix できるので `--fix` が往復する。

既存の除外リストに `useMutation` / `useInfiniteQuery` / `useSuspenseInfiniteQuery` / `infiniteQueryOptions` を足した。リスト名は route 定義だけではなくなったので `routeDefinitionFunctions` から `propertyOrderFunctions` に変えている。

対象関数はプラグインから取れないか調べたが、`createPropertyOrderRule()` のクロージャに閉じ込められていて公開 API には出てこない。`meta.schema` は `[]`、`defaultOptions` も `[]`、`create.toString()` は `applyDefault` のラッパーだけ。型も `index.d.ts` が `Plugin` / `plugin` / `default` しか再 export していない。constants ファイル自体は npm に同梱されているが `exports` に載っていないため、正攻法では読めない。リテラルのまま置いている。

## 採用しなかったもの

`@tanstack/eslint-plugin-start` は前回から変わらず入れていない。peer は `^8.57.0 || ^9.0.0` のままで eslint 10 に入らない。追跡は #2646。

TanStack 公式の ESLint プラグインは router / query / start の 3 つだけで、form / table / virtual / store / db / pacer 向けは npm に存在しない (いずれも 404)。

## 検証

`pnpm lint` / `check:ts` / `test` (15 件) が通っている。markdownlint と prettier も通した。

加えて fixture に preset を当てて確認した。

- `prefer-query-options` / `mutation-property-order` / `infinite-query-property-order` が発火する
- 除外を外した config で `--fix`: `ESLintCircularFixesWarning: Circular fixes detected` が出て順序が直らない
- 除外ありで `--fix`: TanStack が要求する順に収束し、警告なし
