### PR TITLE
fix: add jiti dependency

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -85,6 +85,7 @@
     "eslint-plugin-unicorn": "72.0.0",
     "eslint-typegen": "2.3.1",
     "globals": "17.8.0",
+    "jiti": "2.7.0",
     "jsonc-eslint-parser": "3.1.0",
     "tailwindcss": "4.3.3",
     "typescript-eslint": "8.65.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,9 @@ importers:
       globals:
         specifier: 17.8.0
         version: 17.8.0
+      jiti:
+        specifier: 2.7.0
+        version: 2.7.0
       jsonc-eslint-parser:
         specifier: 3.1.0
         version: 3.1.0


### PR DESCRIPTION
## 概要

- `jiti` を `@nozomiishii/eslint-config` の直接依存に追加
- `eslint.config.ts` の読み込みを `@eslint/config-inspector` などの推移依存に頼らない構成に変更

## 検証

- `pnpm install --frozen-lockfile`
- `pnpm --dir packages/eslint-config lint`
- `pnpm --dir packages/eslint-config check:ts`
- `pnpm --dir packages/eslint-config test`