### PR TITLE
chore: replace init test fixtures with helpers

### DIFF
--- a/packages/commitlint-config/src/init/index.test.ts
+++ b/packages/commitlint-config/src/init/index.test.ts
@@ -1,42 +1,46 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { test as baseTest, expect } from "vitest";
-
-import { init } from "./index.js";
+import { expect, test } from "vitest";
+import { init } from ".";
 
 type InitResult = {
   configContent: string;
   pkg: { devDependencies?: Record<string, string> };
 };
 
-const test = baseTest.extend<{ initResult: InitResult }>({
-  initResult: async ({ task: _ }, provide) => {
-    const tmpDir = mkdtempSync(path.join(tmpdir(), "nozo-commitlint-init-"));
-    writeFileSync(
-      path.join(tmpDir, "package.json"),
-      `${JSON.stringify({ name: "fixture", version: "1.0.0" }, null, 2)}\n`,
-    );
+// 一時dirでinitを実行し、生成された package.json と commitlint.config.ts を読み取る。
+async function runInit(): Promise<InitResult> {
+  const tmpDir = mkdtempSync(path.join(tmpdir(), "nozo-commitlint-init-"));
+  writeFileSync(
+    path.join(tmpDir, "package.json"),
+    `${JSON.stringify({ name: "fixture", version: "1.0.0" }, null, 2)}\n`,
+  );
 
+  try {
     await init({ cwd: tmpDir });
 
     const pkg = JSON.parse(
-      readFileSync(path.join(tmpDir, "package.json"), "utf8"),
+      readFileSync(path.join(tmpDir, "package.json"), "utf-8"),
     ) as InitResult["pkg"];
-    const configContent = readFileSync(path.join(tmpDir, "commitlint.config.ts"), "utf8");
+    const configContent = readFileSync(path.join(tmpDir, "commitlint.config.ts"), "utf-8");
 
-    await provide({ configContent, pkg });
-
+    return { configContent, pkg };
+  } finally {
     rmSync(tmpDir, { force: true, recursive: true });
-  },
+  }
+}
+
+// init は @nozomiishii/commitlint-config を devDependencies に追加する。
+test("init adds @nozomiishii/commitlint-config to devDependencies", async () => {
+  const { pkg } = await runInit();
+
+  expect(pkg.devDependencies?.["@nozomiishii/commitlint-config"]).toMatch(/^\d+\.\d+\.\d+$/);
 });
 
-test("init adds @nozomiishii/commitlint-config to devDependencies", ({ initResult }) => {
-  expect(initResult.pkg.devDependencies?.["@nozomiishii/commitlint-config"]).toMatch(
-    /^\d+\.\d+\.\d+$/,
-  );
-});
+// init は commitlint.config.ts を生成する。
+test("init generates commitlint.config.ts", async () => {
+  const { configContent } = await runInit();
 
-test("init generates commitlint.config.ts", ({ initResult }) => {
-  expect(initResult.configContent.length).toBeGreaterThan(0);
+  expect(configContent.length).toBeGreaterThan(0);
 });

--- a/packages/lefthook-config/src/init/index.test.ts
+++ b/packages/lefthook-config/src/init/index.test.ts
@@ -1,46 +1,53 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { test as baseTest, expect } from "vitest";
-
-import { init } from "./index.js";
+import { expect, test } from "vitest";
+import { init } from ".";
 
 type InitResult = {
   pkg: { devDependencies?: Record<string, string> };
   yamlContent: string;
 };
 
-const test = baseTest.extend<{ initResult: InitResult }>({
-  initResult: async ({ task: _ }, provide) => {
-    const tmpDir = mkdtempSync(path.join(tmpdir(), "nozo-lefthook-init-"));
-    writeFileSync(
-      path.join(tmpDir, "package.json"),
-      `${JSON.stringify({ name: "fixture", version: "1.0.0" }, null, 2)}\n`,
-    );
+// 一時dirでinitを実行し、生成された package.json と lefthook.yaml を読み取る。
+async function runInit(): Promise<InitResult> {
+  const tmpDir = mkdtempSync(path.join(tmpdir(), "nozo-lefthook-init-"));
+  writeFileSync(
+    path.join(tmpDir, "package.json"),
+    `${JSON.stringify({ name: "fixture", version: "1.0.0" }, null, 2)}\n`,
+  );
 
+  try {
     await init({ cwd: tmpDir });
 
     const pkg = JSON.parse(
-      readFileSync(path.join(tmpDir, "package.json"), "utf8"),
+      readFileSync(path.join(tmpDir, "package.json"), "utf-8"),
     ) as InitResult["pkg"];
-    const yamlContent = readFileSync(path.join(tmpDir, "lefthook.yaml"), "utf8");
+    const yamlContent = readFileSync(path.join(tmpDir, "lefthook.yaml"), "utf-8");
 
-    await provide({ pkg, yamlContent });
-
+    return { pkg, yamlContent };
+  } finally {
     rmSync(tmpDir, { force: true, recursive: true });
-  },
+  }
+}
+
+// init は @nozomiishii/lefthook-config を devDependencies に追加する。
+test("init adds @nozomiishii/lefthook-config to devDependencies", async () => {
+  const { pkg } = await runInit();
+
+  expect(pkg.devDependencies?.["@nozomiishii/lefthook-config"]).toMatch(/^\d+\.\d+\.\d+$/);
 });
 
-test("init adds @nozomiishii/lefthook-config to devDependencies", ({ initResult }) => {
-  expect(initResult.pkg.devDependencies?.["@nozomiishii/lefthook-config"]).toMatch(
-    /^\d+\.\d+\.\d+$/,
-  );
+// init は lefthook を devDependencies に追加する。
+test("init adds lefthook to devDependencies", async () => {
+  const { pkg } = await runInit();
+
+  expect(pkg.devDependencies?.lefthook).toMatch(/^\d+\.\d+\.\d+$/);
 });
 
-test("init adds lefthook to devDependencies", ({ initResult }) => {
-  expect(initResult.pkg.devDependencies?.lefthook).toMatch(/^\d+\.\d+\.\d+$/);
-});
+// init は lefthook.yaml を生成する。
+test("init generates lefthook.yaml", async () => {
+  const { yamlContent } = await runInit();
 
-test("init generates lefthook.yaml", ({ initResult }) => {
-  expect(initResult.yamlContent.length).toBeGreaterThan(0);
+  expect(yamlContent.length).toBeGreaterThan(0);
 });

--- a/packages/nozo/src/commands/init.test.ts
+++ b/packages/nozo/src/commands/init.test.ts
@@ -1,8 +1,23 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { test as baseTest, expect, onTestFinished, vi } from "vitest";
+import { expect, onTestFinished, test, vi } from "vitest";
 import { resolvePackageManager, toolIds, tools } from "./init";
+
+// 一時dirに最小構成の package.json を作り、テスト終了時に削除する。
+function createTestProject(): string {
+  const tmpDir = mkdtempSync(path.join(tmpdir(), "nozo-init-"));
+  writeFileSync(
+    path.join(tmpDir, "package.json"),
+    `${JSON.stringify({ name: "fixture", version: "1.0.0" }, null, 2)}\n`,
+  );
+
+  onTestFinished(() => {
+    rmSync(tmpDir, { force: true, recursive: true });
+  });
+
+  return tmpDir;
+}
 
 // npm_config_user_agent を一時的に差し替え、テスト終了時に元へ戻す。value 省略でランナー無しを再現する。
 // process.env 直接操作は n/no-process-env で禁止のため vi.stubEnv を使う。
@@ -13,24 +28,12 @@ function stubUserAgent(value?: string) {
   });
 }
 
-const test = baseTest.extend<{ cwd: string }>({
-  cwd: async ({ task: _ }, provide) => {
-    const tmpDir = mkdtempSync(path.join(tmpdir(), "nozo-init-"));
-    writeFileSync(
-      path.join(tmpDir, "package.json"),
-      `${JSON.stringify({ name: "fixture", version: "1.0.0" }, null, 2)}\n`,
-    );
-
-    await provide(tmpDir);
-
-    rmSync(tmpDir, { force: true, recursive: true });
-  },
-});
-
 // 全ツールの install スクリプトが throw せずに完走することだけを確認する。
 // 各ツールの生成物・package.json 内容の検証は各 config パッケージ側の責務。
-test("happy path: every tool's install script completes without throwing", async ({ cwd }) => {
+test("happy path: every tool's install script completes without throwing", async () => {
   expect.hasAssertions();
+
+  const cwd = createTestProject();
 
   for (const id of toolIds) {
     await expect(tools[id].run({ cwd })).resolves.toBeUndefined();
@@ -38,7 +41,8 @@ test("happy path: every tool's install script completes without throwing", async
 });
 
 // lockfile も packageManager フィールドも無いとき、nozo を起動したランナーを使う。
-test("falls back to the launching runner when the project has no config", async ({ cwd }) => {
+test("falls back to the launching runner when the project has no config", async () => {
+  const cwd = createTestProject();
   stubUserAgent("bun/1.3.11 npm/? node/v24 darwin arm64");
 
   await expect(resolvePackageManager(cwd)).resolves.toStrictEqual({
@@ -48,16 +52,16 @@ test("falls back to the launching runner when the project has no config", async 
 });
 
 // 設定もランナーも無いときは throw する。
-test("throws when neither project config nor runner is available", async ({ cwd }) => {
+test("throws when neither project config nor runner is available", async () => {
+  const cwd = createTestProject();
   stubUserAgent();
 
-  await expect(resolvePackageManager(cwd)).rejects.toThrow(
-    "Could not determine a package manager",
-  );
+  await expect(resolvePackageManager(cwd)).rejects.toThrow("Could not determine a package manager");
 });
 
 // プロジェクトの lockfile はランナーより優先される。
-test("prefers project config over the launching runner", async ({ cwd }) => {
+test("prefers project config over the launching runner", async () => {
+  const cwd = createTestProject();
   writeFileSync(path.join(cwd, "pnpm-lock.yaml"), "");
   stubUserAgent("bun/1.3.11 npm/? node/v24 darwin arm64");
 

--- a/packages/postinstall/src/init/index.test.ts
+++ b/packages/postinstall/src/init/index.test.ts
@@ -1,9 +1,8 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { test as baseTest, expect } from "vitest";
-
-import { init } from "./index.js";
+import { expect, test } from "vitest";
+import { init } from ".";
 
 type InitResult = {
   pkg: {
@@ -12,30 +11,37 @@ type InitResult = {
   };
 };
 
-const test = baseTest.extend<{ initResult: InitResult }>({
-  initResult: async ({ task: _ }, provide) => {
-    const tmpDir = mkdtempSync(path.join(tmpdir(), "nozo-postinstall-init-"));
-    writeFileSync(
-      path.join(tmpDir, "package.json"),
-      `${JSON.stringify({ name: "fixture", version: "1.0.0" }, null, 2)}\n`,
-    );
+// 一時dirでinitを実行し、生成された package.json を読み取る。
+async function runInit(): Promise<InitResult> {
+  const tmpDir = mkdtempSync(path.join(tmpdir(), "nozo-postinstall-init-"));
+  writeFileSync(
+    path.join(tmpDir, "package.json"),
+    `${JSON.stringify({ name: "fixture", version: "1.0.0" }, null, 2)}\n`,
+  );
 
+  try {
     await init({ cwd: tmpDir });
 
     const pkg = JSON.parse(
-      readFileSync(path.join(tmpDir, "package.json"), "utf8"),
+      readFileSync(path.join(tmpDir, "package.json"), "utf-8"),
     ) as InitResult["pkg"];
 
-    await provide({ pkg });
-
+    return { pkg };
+  } finally {
     rmSync(tmpDir, { force: true, recursive: true });
-  },
+  }
+}
+
+// init は @nozomiishii/postinstall を devDependencies に追加する。
+test("init adds @nozomiishii/postinstall to devDependencies", async () => {
+  const { pkg } = await runInit();
+
+  expect(pkg.devDependencies?.["@nozomiishii/postinstall"]).toMatch(/^\d+\.\d+\.\d+$/);
 });
 
-test("init adds @nozomiishii/postinstall to devDependencies", ({ initResult }) => {
-  expect(initResult.pkg.devDependencies?.["@nozomiishii/postinstall"]).toMatch(/^\d+\.\d+\.\d+$/);
-});
+// init は postinstall script を追加する。
+test("init adds postinstall script", async () => {
+  const { pkg } = await runInit();
 
-test("init adds postinstall script", ({ initResult }) => {
-  expect(initResult.pkg.scripts?.postinstall).toBe("postinstall");
+  expect(pkg.scripts?.postinstall).toBe("postinstall");
 });

--- a/packages/prettier-config/src/init/index.test.ts
+++ b/packages/prettier-config/src/init/index.test.ts
@@ -1,9 +1,8 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { test as baseTest, expect } from "vitest";
-
-import { init } from "./index.js";
+import { expect, test } from "vitest";
+import { init } from ".";
 
 type InitResult = {
   configContent: string;
@@ -14,53 +13,73 @@ type InitResult = {
   };
 };
 
-const test = baseTest.extend<{ initResult: InitResult }>({
-  initResult: async ({ task: _ }, provide) => {
-    const tmpDir = mkdtempSync(path.join(tmpdir(), "nozo-prettier-init-"));
-    writeFileSync(
-      path.join(tmpDir, "package.json"),
-      `${JSON.stringify({ name: "fixture", version: "1.0.0" }, null, 2)}\n`,
-    );
+// 一時dirでinitを実行し、生成された package.json と prettier.config.ts を読み取る。
+async function runInit(): Promise<InitResult> {
+  const tmpDir = mkdtempSync(path.join(tmpdir(), "nozo-prettier-init-"));
+  writeFileSync(
+    path.join(tmpDir, "package.json"),
+    `${JSON.stringify({ name: "fixture", version: "1.0.0" }, null, 2)}\n`,
+  );
 
+  try {
     await init({ cwd: tmpDir });
 
     const pkg = JSON.parse(
-      readFileSync(path.join(tmpDir, "package.json"), "utf8"),
+      readFileSync(path.join(tmpDir, "package.json"), "utf-8"),
     ) as InitResult["pkg"];
-    const configContent = readFileSync(path.join(tmpDir, "prettier.config.ts"), "utf8");
+    const configContent = readFileSync(path.join(tmpDir, "prettier.config.ts"), "utf-8");
 
-    await provide({ configContent, pkg });
-
+    return { configContent, pkg };
+  } finally {
     rmSync(tmpDir, { force: true, recursive: true });
-  },
+  }
+}
+
+// init は type:module を設定する。
+test("init sets type:module", async () => {
+  const { pkg } = await runInit();
+
+  expect(pkg.type).toBe("module");
 });
 
-test("init sets type:module", ({ initResult }) => {
-  expect(initResult.pkg.type).toBe("module");
+// init は @nozomiishii/prettier-config を devDependencies に追加する。
+test("init adds @nozomiishii/prettier-config to devDependencies", async () => {
+  const { pkg } = await runInit();
+
+  expect(pkg.devDependencies?.["@nozomiishii/prettier-config"]).toMatch(/^\d+\.\d+\.\d+$/);
 });
 
-test("init adds @nozomiishii/prettier-config to devDependencies", ({ initResult }) => {
-  expect(initResult.pkg.devDependencies?.["@nozomiishii/prettier-config"]).toMatch(
-    /^\d+\.\d+\.\d+$/,
-  );
+// init は prettier を devDependencies に追加する。
+test("init adds prettier to devDependencies", async () => {
+  const { pkg } = await runInit();
+
+  expect(pkg.devDependencies?.prettier).toMatch(/^\d+\.\d+\.\d+$/);
 });
 
-test("init adds prettier to devDependencies", ({ initResult }) => {
-  expect(initResult.pkg.devDependencies?.prettier).toMatch(/^\d+\.\d+\.\d+$/);
+// init は format script を追加する。
+test("init adds format script", async () => {
+  const { pkg } = await runInit();
+
+  expect(pkg.scripts?.format).toBe("pnpm prettier . --check");
 });
 
-test("init adds format script", ({ initResult }) => {
-  expect(initResult.pkg.scripts?.format).toBe("pnpm prettier . --check");
+// init は format:fix script を追加する。
+test("init adds format:fix script", async () => {
+  const { pkg } = await runInit();
+
+  expect(pkg.scripts?.["format:fix"]).toBe("pnpm prettier . --write");
 });
 
-test("init adds format:fix script", ({ initResult }) => {
-  expect(initResult.pkg.scripts?.["format:fix"]).toBe("pnpm prettier . --write");
+// init は prettier script を追加する。
+test("init adds prettier script", async () => {
+  const { pkg } = await runInit();
+
+  expect(pkg.scripts?.prettier).toBe("prettier --ignore-unknown --cache");
 });
 
-test("init adds prettier script", ({ initResult }) => {
-  expect(initResult.pkg.scripts?.prettier).toBe("prettier --ignore-unknown --cache");
-});
+// init は prettier.config.ts を生成する。
+test("init generates prettier.config.ts", async () => {
+  const { configContent } = await runInit();
 
-test("init generates prettier.config.ts", ({ initResult }) => {
-  expect(initResult.configContent.length).toBeGreaterThan(0);
+  expect(configContent.length).toBeGreaterThan(0);
 });


### PR DESCRIPTION
## 概要

- init / command テストの `baseTest.extend` fixture を素のヘルパー関数へ置き換える
- 一時ディレクトリを各テストから明示的に作成し、確実に削除する
- 対象ファイルのテストコメントと lint 違反を整える

## 検証

- `pnpm --filter @nozomiishii/prettier-config --filter @nozomiishii/postinstall --filter @nozomiishii/commitlint-config --filter @nozomiishii/lefthook-config --filter nozo test`
- `pnpm --filter @nozomiishii/prettier-config --filter @nozomiishii/postinstall --filter @nozomiishii/commitlint-config --filter @nozomiishii/lefthook-config --filter nozo tsc`
- ESLint
- Prettier

Closes #2346