### PR TITLE
chore: remove redundant Prettier defaults

### DIFF
--- a/packages/prettier-config/src/index.ts
+++ b/packages/prettier-config/src/index.ts
@@ -3,36 +3,9 @@ import packagejsonPlugin from "prettier-plugin-packagejson";
 
 /**
  * Prettier options
- * {@link https://prettier.io/docs/en/options.html}
+ * {@link https://prettier.io/docs/options}
  */
 export default {
-  // Prettier default アロー関数の引数が 1 つでも括弧を付ける
-  arrowParens: "always",
-
-  // Prettier default 複数行の HTML/JSX で閉じ > を次行に置く (旧 jsxBracketSameLine と同等)
-  bracketSameLine: false,
-
-  // Prettier default オブジェクトリテラルの { 直後と } 直前にスペース ({ a } 形式)
-  bracketSpacing: true,
-
-  // Prettier default template literal 等の埋め込み言語も format
-  embeddedLanguageFormatting: "auto",
-
-  // Prettier default 改行コードは LF
-  endOfLine: "lf",
-
-  // Prettier default CSS の display 値で HTML 内空白の扱いを判定
-  htmlWhitespaceSensitivity: "css",
-
-  // Prettier default format したファイルに pragma を自動挿入しない
-  insertPragma: false,
-
-  // Prettier default JSX 属性はダブルクォート (HTML 慣習)
-  jsxSingleQuote: false,
-
-  // Prettier default 複数行に分かれたオブジェクトの改行スタイルを保つ
-  objectWrap: "preserve",
-
   overrides: [
     {
       // prettier の format を実行したくないものを指定
@@ -76,34 +49,4 @@ export default {
 
   // 1 行あたりの文字数。default 80。型注釈言語コミュニティの収束点として 100 を採用 (Rust / Google Java / Apple swift-format / Linux kernel 2020 で 80 deprecate / OXC oxfmt 2025)。
   printWidth: 100,
-
-  // Prettier default Markdown の改行・折り返しを元の状態のまま保つ
-  proseWrap: "preserve",
-
-  // Prettier default 必要なときだけプロパティ名をクオート
-  quoteProps: "as-needed",
-
-  // Prettier default pragma が無くても全ファイルを format
-  requirePragma: false,
-
-  // Prettier default 文末にセミコロンを付ける
-  semi: true,
-
-  // Prettier default HTML/JSX 属性を 1 行ずつにしない
-  singleAttributePerLine: false,
-
-  // Prettier default ダブルクォートを使う (apostrophe を含む string と混在しにくく、Prettier の escape 最少優先 logic とも整合)
-  singleQuote: false,
-
-  // Prettier default タブ幅は 2 スペース
-  tabWidth: 2,
-
-  // Prettier default 関数引数や型パラメータも含め可能な限り末尾カンマを付ける
-  trailingComma: "all",
-
-  // Prettier default インデントを space で出力
-  useTabs: false,
-
-  // Prettier default Vue SFC の <script>/<style> 内をインデントしない
-  vueIndentScriptAndStyle: false,
 } satisfies Config;


### PR DESCRIPTION
## 概要

Prettier 3.9.6 のデフォルトと同じトップレベル設定を削除しました。
共有設定固有の printWidth、plugins、overrides だけを残しています。
設定コメントの Options リンクは現在の公式 URL に更新しました。

## 確認

- pnpm --filter @nozomiishii/prettier-config test
- pnpm --filter @nozomiishii/prettier-config tsc
- pnpm --filter @nozomiishii/prettier-config build
- pnpm exec prettier --check packages/prettier-config/src/index.ts
- pre-push lint