### PR TITLE
fix: run postinstall tests sequentially

### DIFF
--- a/packages/postinstall/vitest.config.ts
+++ b/packages/postinstall/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    fileParallelism: false,
+  },
+});


### PR DESCRIPTION
## 概要

- `packages/postinstall/vitest.config.ts` を追加
- Vitest の `fileParallelism` を `false` に設定

## 背景

[release PR #2657 のテストジョブ](https://github.com/nozomiishii/configs/actions/runs/30624522108/job/91136705150?pr=2657) では、`tests/build.test.ts` と `src/init/index.test.ts` が `ubuntu-slim` 上で並列実行されました。ビルドとのリソース競合により init テストが既定の5秒を超え、タイムアウトしていました。

テストタイムアウトを延長せず、postinstall パッケージのテストファイルを直列実行して競合を避けます。

## 影響

postinstall パッケージのテスト実行順だけが変わります。プロダクションコードへの影響はありません。

## 検証

- `pnpm test`
- `pnpm tsc`
- `pnpm lint`
- `pnpm prettier --check packages/postinstall/vitest.config.ts`
- `git diff --check`