### PR TITLE
fix: ignore generated route trees in Prettier

### DIFF
--- a/packages/prettier-config/README.ja.md
+++ b/packages/prettier-config/README.ja.md
@@ -23,6 +23,7 @@ pnpx nozo init
 ```
 
 これで `@nozomiishii/prettier-config` / `prettier` が pin で `devDependencies` に追加され、`"type": "module"` が設定され、`format` / `format:fix` / `prettier` の scripts が追加され、shared config を re-export する `prettier.config.ts` が生成される。
+`**/routeTree.gen.ts` は `.prettierignore` に追記される。
 
 ## 同梱プラグイン
 
@@ -30,23 +31,32 @@ pnpx nozo init
 
 ## ポリシー
 
-### ファイル除外: `.prettierignore` ではなく `requirePragma` を使う
+### ファイル除外
 
-format 対象外にしたいファイル (`pnpm-lock.yaml` / `submodules/**` /
-`next-env.d.ts` / `**/routeTree.gen.ts` / `*.md` / `*.mdx` /
-`**/.claude/settings.json`) は、このパッケージの `overrides` で
-`requirePragma: true` を指定して除外している。`.prettierignore` ファイルは作らない。
+[shareable config](https://prettier.io/docs/sharing-configurations/) は通常の
+Prettier設定だけを提供する仕組みであり、ファイルのignore状態は設定できない。
+[Prettier公式のignore手順](https://prettier.io/docs/ignore/)に従い、initはconsumer
+rootの`.prettierignore`へ`**/routeTree.gen.ts`を追記する。既存の内容は保持する。
+[TanStack Routerも生成されたroute treeをformatterから除外するよう案内している](https://tanstack.com/router/latest/docs/framework/react/installation/with-router-cli#ignoring-the-generated-route-tree-file)。
+これによりCLIとeditorの両方が生成されたroute treeを対象外として扱い、
+`prettier --file-info src/routeTree.gen.ts`は`ignored: true`を返す。
+
+既存projectでは`pnpx nozo init`を再実行するか、`.prettierignore`へ
+`**/routeTree.gen.ts`を手動で追加する。`--ignore-path`を指定している場合、
+[既定のignore file探索を置き換える](https://prettier.io/docs/cli#--ignore-path)ため、
+指定を外すか`.gitignore`と`.prettierignore`の両方を渡す。
+
+`pnpm-lock.yaml` / `submodules/**` / `next-env.d.ts` / `*.md` / `*.mdx` /
+`**/.claude/settings.json`はshared configの`overrides`で`requirePragma: true`を
+指定し、pragmaが無い限りformatしない。未移行projectを保護するため、
+`**/routeTree.gen.ts`にも同じoverrideを互換用として残す。
 
 `**/.claude/settings.json` は `parser: jsonc` も要る。Claude Code が多行配列で
 書き戻すうえ、`json` parser は `requirePragma` を無視するため (`jsonc` は尊重する)。
 
-`.prettierignore` を導入すると `.gitignore` と二重管理になり、片方だけ
-更新する事故を起こしやすい。Prettier 3.x は `.gitignore` を自動で尊重
-するため、ほとんどの ignore は `.gitignore` だけで足りる。
-
-同じ理由から、Prettier 3.6 で追加された `checkIgnorePragma`
+Prettier 3.6 で追加された `checkIgnorePragma`
 (`@noformat` / `@noprettier`) は採用しない。opt-out の入り口を増やす
-だけで、`.prettierignore` 問題そのものは解決しないため。
+必要がないため。
 
 ### experimental option は採用しない
 

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -26,6 +26,7 @@ This adds `@nozomiishii/prettier-config` and `prettier` to your
 `devDependencies` (pinned), sets `"type": "module"`, adds `format` /
 `format:fix` / `prettier` scripts, and writes a `prettier.config.ts` that
 re-exports the shared config.
+It also adds `**/routeTree.gen.ts` to `.prettierignore`.
 
 ## Included Plugins
 
@@ -33,24 +34,35 @@ re-exports the shared config.
 
 ## Policy
 
-### File exclusion: `requirePragma` over `.prettierignore`
+### File exclusion
 
-Files that should never be formatted (`pnpm-lock.yaml`, `submodules/**`,
-`next-env.d.ts`, `**/routeTree.gen.ts`, `*.md`, `*.mdx`,
-`**/.claude/settings.json`) are excluded via `requirePragma: true` overrides in
-this config rather than a `.prettierignore` file.
+A [shareable config](https://prettier.io/docs/sharing-configurations/) only
+provides regular Prettier options and cannot set a file's ignore status.
+Following [Prettier's official ignore mechanism](https://prettier.io/docs/ignore/),
+the init command appends `**/routeTree.gen.ts` to the consumer root's
+`.prettierignore` without replacing existing content. This follows
+[TanStack Router's guidance to exclude its generated route tree](https://tanstack.com/router/latest/docs/framework/react/installation/with-router-cli#ignoring-the-generated-route-tree-file).
+The CLI and editors exclude the file, and
+`prettier --file-info src/routeTree.gen.ts` returns `ignored: true`.
+
+For an existing project, rerun `pnpx nozo init` or add
+`**/routeTree.gen.ts` to `.prettierignore` manually. If the project passes
+`--ignore-path`, it [replaces the default ignore file lookup](https://prettier.io/docs/cli#--ignore-path).
+Remove the option or pass both `.gitignore` and `.prettierignore`.
+
+`pnpm-lock.yaml`, `submodules/**`, `next-env.d.ts`, `*.md`, `*.mdx`, and
+`**/.claude/settings.json` use `requirePragma: true` overrides in the shared
+config, so they are not formatted without a pragma. The same override remains
+for `**/routeTree.gen.ts` as a compatibility fallback for projects that have
+not migrated yet.
 
 `**/.claude/settings.json` also needs `parser: jsonc`: Claude Code writes it
 with multi-line arrays, and the `json` parser ignores `requirePragma` while
 `jsonc` honors it.
 
-A `.prettierignore` would duplicate patterns already in `.gitignore` and
-invite drift between the two. Prettier 3.x already honors `.gitignore`
-automatically, so most ignore needs are covered without a dedicated file.
-
-For the same reason, the Prettier 3.6 `checkIgnorePragma` option
-(`@noformat` / `@noprettier`) is **not** adopted: it adds another opt-out
-surface without removing the `.prettierignore` problem.
+The Prettier 3.6 `checkIgnorePragma` option
+(`@noformat` / `@noprettier`) is not adopted: it adds another opt-out surface
+without a need for one.
 
 ### Experimental options
 

--- a/packages/prettier-config/src/init/index.test.ts
+++ b/packages/prettier-config/src/init/index.test.ts
@@ -1,11 +1,22 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { expect, test } from "vitest";
 import { init } from ".";
 
 type InitResult = {
   configContent: string;
+  fileInfo: { ignored: boolean; inferredParser: null | string };
+  ignoreContent: string;
   pkg: {
     devDependencies?: Record<string, string>;
     scripts?: Record<string, string>;
@@ -14,22 +25,46 @@ type InitResult = {
 };
 
 // 一時dirでinitを実行し、生成された package.json と prettier.config.ts を読み取る。
-async function runInit(): Promise<InitResult> {
+async function runInit(prettierIgnore?: string): Promise<InitResult> {
   const tmpDir = mkdtempSync(path.join(tmpdir(), "nozo-prettier-init-"));
   writeFileSync(
     path.join(tmpDir, "package.json"),
     `${JSON.stringify({ name: "fixture", version: "1.0.0" }, null, 2)}\n`,
   );
 
+  if (prettierIgnore !== undefined) {
+    writeFileSync(path.join(tmpDir, ".prettierignore"), prettierIgnore);
+  }
+
   try {
     await init({ cwd: tmpDir });
+
+    const routeTreeRelativePath = "src/routeTree.gen.ts";
+    const routeTreePath = path.join(tmpDir, routeTreeRelativePath);
+    mkdirSync(path.dirname(routeTreePath));
+    writeFileSync(routeTreePath, "export const routeTree = {}\n");
+    const scopePath = path.join(tmpDir, "node_modules", "@nozomiishii");
+    mkdirSync(scopePath, { recursive: true });
+    symlinkSync(
+      fileURLToPath(new URL("../..", import.meta.url)),
+      path.join(scopePath, "prettier-config"),
+      "dir",
+    );
 
     const pkg = JSON.parse(
       readFileSync(path.join(tmpDir, "package.json"), "utf-8"),
     ) as InitResult["pkg"];
     const configContent = readFileSync(path.join(tmpDir, "prettier.config.ts"), "utf-8");
+    const ignoreContent = readFileSync(path.join(tmpDir, ".prettierignore"), "utf-8");
+    const prettierBin = fileURLToPath(import.meta.resolve("prettier/bin/prettier.cjs"));
+    const fileInfo = JSON.parse(
+      execFileSync(process.execPath, [prettierBin, "--file-info", routeTreeRelativePath], {
+        cwd: tmpDir,
+        encoding: "utf-8",
+      }),
+    ) as InitResult["fileInfo"];
 
-    return { configContent, pkg };
+    return { configContent, fileInfo, ignoreContent, pkg };
   } finally {
     rmSync(tmpDir, { force: true, recursive: true });
   }
@@ -82,4 +117,32 @@ test("init generates prettier.config.ts", async () => {
   const { configContent } = await runInit();
 
   expect(configContent.length).toBeGreaterThan(0);
+});
+
+// Prettier configにはignore設定が無いため、標準のignore fileへ生成物を追加する。
+test("init adds the generated TanStack Router route tree to .prettierignore", async () => {
+  const { ignoreContent } = await runInit();
+
+  expect(ignoreContent).toBe("**/routeTree.gen.ts\n");
+});
+
+// 既存のignore patternを壊さず、改行が無いファイルにも追記する。
+test("init preserves existing .prettierignore patterns", async () => {
+  const { ignoreContent } = await runInit("dist");
+
+  expect(ignoreContent).toBe("dist\n**/routeTree.gen.ts\n");
+});
+
+// 再実行しても既存のpatternを重複させない。
+test("init does not duplicate the route tree ignore pattern", async () => {
+  const { ignoreContent } = await runInit("**/routeTree.gen.ts\n");
+
+  expect(ignoreContent).toBe("**/routeTree.gen.ts\n");
+});
+
+// consumerと同じPrettier CLIのfile-infoで、設定上のskipではなく実際のignoreを確認する。
+test("prettier --file-info reports routeTree.gen.ts as ignored", async () => {
+  const { fileInfo } = await runInit();
+
+  expect(fileInfo).toStrictEqual({ ignored: true, inferredParser: null });
 });

--- a/packages/prettier-config/src/init/index.ts
+++ b/packages/prettier-config/src/init/index.ts
@@ -8,6 +8,8 @@ import { fileURLToPath } from "node:url";
 
 export type InitOptions = { cwd: string };
 
+const routeTreeIgnorePattern = "**/routeTree.gen.ts";
+
 type PackageJson = {
   devDependencies?: Record<string, string>;
   name: string;
@@ -48,6 +50,20 @@ export async function init({ cwd }: InitOptions): Promise<void> {
 
   await writeFile(targetPath, `${JSON.stringify(target, null, 2)}\n`);
   await writeFile(path.resolve(cwd, "prettier.config.ts"), starter);
+  await addRouteTreeIgnore(cwd);
+}
+
+async function addRouteTreeIgnore(cwd: string): Promise<void> {
+  const ignorePath = path.resolve(cwd, ".prettierignore");
+  const current = existsSync(ignorePath) ? await readFile(ignorePath, "utf-8") : "";
+  const patterns = current.split(/\r?\n/u).map((line) => line.trim());
+
+  if (patterns.includes(routeTreeIgnorePattern)) {
+    return;
+  }
+
+  const separator = current.length === 0 || current.endsWith("\n") ? "" : "\n";
+  await writeFile(ignorePath, `${current}${separator}${routeTreeIgnorePattern}\n`);
 }
 
 /**


### PR DESCRIPTION
## 概要

- `@nozomiishii/prettier-config` のinitが、consumer rootの`.prettierignore`へ`**/routeTree.gen.ts`を追記するようにした
- 既存のignore内容を保持し、再実行しても同じpatternを重複させない
- 未移行の既存利用者を保護するため、現在の`requirePragma` overrideは互換用として残した
- 実際の`prettier --file-info src/routeTree.gen.ts`が`ignored: true`を返す回帰テストを追加した
- 日英READMEへ仕様と移行手順を追加した

## 背景

従来の`requirePragma` overrideは、pragmaの無い`routeTree.gen.ts`を書き換えないための保護にはなるものの、Prettier上のignore状態は変えない。`prettier --file-info`は`ignored: false`のままで、consumer側ではTanStack Router generatorとPrettierのquote・semicolon設定を揃える必要があった。

Prettierの[shareable config](https://prettier.io/docs/sharing-configurations/)は通常の設定オブジェクトを共有する仕組みであり、ignore用のconfig項目はない。[ファイル除外の公式手順](https://prettier.io/docs/ignore/)はproject rootの`.prettierignore`を使う。TanStack Routerも[生成されたroute treeをlinterとformatterから除外するよう案内している](https://tanstack.com/router/latest/docs/framework/react/installation/with-router-cli#ignoring-the-generated-route-tree-file)。

## 設計判断

検討した案:

- shareable configにignore設定を追加する: Prettierに該当するconfig項目がないため採用不可
- package内の共通ignore fileを`--ignore-path`で参照する: 全consumerのscript変更に加えてeditor側の設定も必要になり、CLIとeditorで挙動がずれるため不採用
- 既存initでconsumer rootの`.prettierignore`へ追記する: Prettier標準のCLIとeditorが同じfileを認識し、既存init経路も再利用できるため採用

`--ignore-path`は[既定のignore file探索を置き換える](https://prettier.io/docs/cli#--ignore-path)ため、明示指定しているconsumerには下記の追従が必要。

## consumer側の追従

package公開後、対象repoで次を行う。

- `@nozomiishii/prettier-config`または`nozo`を更新する
- `pnpx nozo init`でPrettierを再設定するか、`.prettierignore`へ`**/routeTree.gen.ts`を追加する
- Prettier scriptに`--ignore-path .gitignore`がある場合は削除する。残す場合は`--ignore-path=.gitignore --ignore-path=.prettierignore`の両方を渡す
- `prettier --file-info src/routeTree.gen.ts`が`ignored: true`になった後、回避策として追加したTanStack Routerの`quoteStyle: "double"`と`semicolons: true`を削除できる

## 検証

- `pnpm -r run build`
- `pnpm --filter @nozomiishii/prettier-config lint`
- `pnpm --filter @nozomiishii/prettier-config tsc`
- `pnpm --filter @nozomiishii/prettier-config test`
- `pnpm run format`
- `pnpm markdownlint-cli2 packages/prettier-config/README.md packages/prettier-config/README.ja.md`
- pre-push hookのworkspace全体lint
