### PR TITLE
fix: require lefthook for installed hooks

### DIFF
--- a/packages/lefthook-config/recommended.yaml
+++ b/packages/lefthook-config/recommended.yaml
@@ -9,6 +9,7 @@
 # Run the command to test:
 #   pnpx lefthook run [-v,--verbose] <hook-name>
 
+# インストール済みの Git hook で lefthook が見つからない場合は失敗させる。
 assert_lefthook_installed: true
 
 extends:

--- a/packages/lefthook-config/recommended.yaml
+++ b/packages/lefthook-config/recommended.yaml
@@ -9,7 +9,7 @@
 # Run the command to test:
 #   pnpx lefthook run [-v,--verbose] <hook-name>
 
-# インストール済みの Git hook で lefthook が見つからない場合は失敗させる。
+# lefthook が見つからない場合は Git hook を失敗させ、検証なしのコミットを防ぐ。
 assert_lefthook_installed: true
 
 extends:

--- a/packages/lefthook-config/recommended.yaml
+++ b/packages/lefthook-config/recommended.yaml
@@ -9,6 +9,8 @@
 # Run the command to test:
 #   pnpx lefthook run [-v,--verbose] <hook-name>
 
+assert_lefthook_installed: true
+
 extends:
   - node_modules/@nozomiishii/lefthook-config/hooks/commit-msg/commitlint.yaml
   - node_modules/@nozomiishii/lefthook-config/hooks/post-merge/update-node-modules.yaml


### PR DESCRIPTION
## 概要

`packages/lefthook-config/recommended.yaml` に `assert_lefthook_installed: true` を追加します。

## 背景

lefthook が生成した Git hook は、実行時に lefthook バイナリを見つけられない場合、既定ではメッセージを表示するだけで終了ステータス 0 になります。新しい worktree や fresh clone で依存関係が未インストールだと、commit-msg の commitlint が実行されないままコミットが通る可能性があります。

さらに lefthook 1.8.0 以降は存在しない `extends` 先を黙って無視するため、設定の欠落を `lefthook validate` でも検出できません。

## 変更内容

各リポジトリが `extends` する共通プリセットに `assert_lefthook_installed: true` を設定します。これにより、設定を読み込んで生成された Git hook は lefthook バイナリが見つからない場合に exit 1 となり、検証を省略してコミットを通さなくなります。

`--no-verify` と `LEFTHOOK=0` による明示的なバイパスは引き続き利用できます。一度も `lefthook install` が実行されておらず Git hook 自体がない fresh clone は対象外です。

## 検証

- `pnpm lint`
- `pnpm tsc`
- `pnpm test`
- `pnpm exec lefthook validate`
- `pnpm exec lefthook dump` で `assert_lefthook_installed: true` が merged config に含まれることを確認