### PR TITLE
chore: simplify tsconfig comments and move details to docs

### DIFF
--- a/packages/tsconfig/README.ja.md
+++ b/packages/tsconfig/README.ja.md
@@ -30,6 +30,8 @@ pnpm add -D @nozomiishii/tsconfig
 - [`@nozomiishii/tsconfig/tsconfig.nextjs.json`](./src/tsconfig.nextjs.json) — Next.js 向け (`jsx` + Next.js plugin など)。
 - [`@nozomiishii/tsconfig/tsconfig.tanstack-start.json`](./src/tsconfig.tanstack-start.json) — Vite を使う TanStack Start 向け (`react-jsx` + DOM + Vite client types)。
 
+各オプションの選定理由は [docs/プリセットの選定理由.md](./docs/プリセットの選定理由.md) を参照。
+
 extends したあとに `include` / `exclude` / `baseUrl` などプロジェクト固有設定を足す:
 
 ```json

--- a/packages/tsconfig/README.md
+++ b/packages/tsconfig/README.md
@@ -30,6 +30,8 @@ Pick the variant for your setup. Each file is a working `tsconfig` you can `exte
 - [`@nozomiishii/tsconfig/tsconfig.nextjs.json`](./src/tsconfig.nextjs.json) — for Next.js (`jsx` + Next.js plugin, etc.).
 - [`@nozomiishii/tsconfig/tsconfig.tanstack-start.json`](./src/tsconfig.tanstack-start.json) — for TanStack Start with Vite (`react-jsx` + DOM + Vite client types).
 
+The reasoning behind each option is documented in [docs/プリセットの選定理由.md](./docs/プリセットの選定理由.md) (Japanese).
+
 After extending, add your own `include` / `exclude` / `baseUrl`:
 
 ```json

--- a/packages/tsconfig/docs/プリセットの選定理由.md
+++ b/packages/tsconfig/docs/プリセットの選定理由.md
@@ -1,0 +1,40 @@
+# プリセットの選定理由
+
+`src/` の各プリセットの「なぜこの値にしたか」を残す。設定が何をするかの一行説明は各 JSON のコメントに書き、ここには理由と参照リンクだけを書く。
+
+## 前提
+
+- このプリセットは TypeScript 6+ 前提。TS 6.0 でデフォルト true になった `strict` と `noUncheckedSideEffectImports` は指定しない
+- `strict` を明示していた理由は `exactOptionalPropertyTypes` の警告バグ [microsoft/TypeScript#63232](https://github.com/microsoft/TypeScript/issues/63232) だったが、6.0.3 での修正を再現テストで確認して外した。[TS 6.0 のデフォルト変更一覧](https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/)
+- `noUncheckedSideEffectImports` により副作用 import の解決失敗はエラーになる。CSS などのアセットを import する project は `declare module "*.css";` のアンビエント宣言を追加する。[noUncheckedSideEffectImports](https://www.typescriptlang.org/tsconfig/#noUncheckedSideEffectImports)
+- tsc は typecheck 専用 (`noEmit: true`) にして、emit はバンドラー (tsdown / tsup / esbuild など) に任せる。tsc で emit する構成は `tsconfig.tsc.json` と `tsconfig.lib.json` だけが `noEmit: false` で明示する
+
+## tsconfig.json (base)
+
+- `skipLibCheck: true` — false だと node_modules の .d.ts まで全部チェックしてパフォーマンスが悪い。[解説動画](https://www.youtube.com/watch?v=zu-EgnbmcLY)
+- `target: ES2025` — ES2025 で Iterator helpers / Set methods / `Promise.try` などの型が使える。Node 22 LTS / Node 24 / 主要モダンブラウザは 2026 年時点でネイティブサポート済み。Node バージョンとの対応は [Node Target Mapping](https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping)
+- `module: "preserve"` — imports / exports を変換せず保持し、`moduleResolution: "bundler"` を暗黙指定する (TS 5.4+)。tsc 以外が transpile する現状の標準構成に合う。tsc で transpile する場合は `tsconfig.tsc.json` が `NodeNext` に上書きする。[module: preserve](https://www.typescriptlang.org/tsconfig/module.html#preserve)
+- `moduleDetection: "force"` — 全ファイルがモジュール扱いになり、ファイルがスコープの単位になるので別ファイルで同名の変数を定義できる。[解説](https://www.totaltypescript.com/cannot-redeclare-block-scoped-variable)
+- `isolatedModules: true` — tsc 以外のトランスパイラはファイル単位でしか変換できないため、その前提で書けているかを検査させる
+- `verbatimModuleSyntax: true` — import type / export type の明示で可読性が上がり、トランスパイル後に不要な import が残らない
+- `erasableSyntaxOnly: true` — enum / runtime namespace / parameter properties をエラー化し、Node 23.6+ の type-stripping や tsgo でも実行できる構文に制限する (TS 5.8+)。`verbatimModuleSyntax: true` と方針が揃う。[TS 5.8 announcement](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8/)
+- `noUncheckedIndexedAccess: true` / `exactOptionalPropertyTypes: true` — strict に含まれない追加の strict 系。インデックスアクセスと optional property の `undefined` を厳密に扱う
+
+## tsconfig.tsc.json
+
+tsc で transpile する構成。base の `module: "preserve"` を `NodeNext` に上書きし、`noEmit: false` で emit を有効化する。
+
+## tsconfig.lib.json
+
+- `isolatedDeclarations: true` — tsdown / tsup / rolldown-plugin-dts などが .d.ts を並列生成できるようになる。代わりに全 export へ明示的な型注釈が必要。[isolatedDeclarations](https://www.typescriptlang.org/tsconfig/isolatedDeclarations.html)
+
+## tsconfig.nextjs.json
+
+- `jsx: "preserve"` — Next.js は .jsx のまま受け取って自前で変換するため
+- `lib: ["dom", "ESNext"]` — `dom.iterable` は TypeScript 6.0 で `dom` にマージ予定のため指定しない。[比較 gist](https://gist.github.com/privatenumber/3d2e80da28f84ee30b77d53e1693378f)
+
+## tsconfig.tanstack-start.json
+
+- `module` / `moduleResolution` / `target` — [公式の build-from-scratch 手順](https://tanstack.com/start/latest/docs/framework/react/build-from-scratch)の案内どおりの値
+- `verbatimModuleSyntax: false` — server module が client bundle に残る可能性があるため、公式が無効を案内している
+- `types: ["vite/client"]` — asset import / `import.meta.env` / `import.meta.hot` の型を足す。[Vite client types](https://vite.dev/guide/features.html#client-types)

--- a/packages/tsconfig/src/tsconfig.json
+++ b/packages/tsconfig/src/tsconfig.json
@@ -1,5 +1,6 @@
 {
-  // https://www.typescriptlang.org/tsconfig
+  // 各オプションの選定理由: https://github.com/nozomiishii/configs/blob/main/packages/tsconfig/docs/プリセットの選定理由.md
+  // リファレンス: https://www.typescriptlang.org/tsconfig
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "@nozomiishii/tsconfig",
 
@@ -7,79 +8,56 @@
     // ----------------------------------------------------------------
     // Base Option
     // ----------------------------------------------------------------
-    // ESModuleの互換。CommonJSで定義されてるモジュールを変換してESModuleでも利用できるようにするか。
+    // CommonJSモジュールをESModuleとしてimportできるようにする
     "esModuleInterop": true,
 
-    // .d.tsファイルの型までtype checkするか
-    // falseだと全てのnode_modulesまでチェックするからパフォーマンスよくない
-    // https://www.youtube.com/watch?v=zu-EgnbmcLY
+    // .d.tsの型チェックを省略してパフォーマンスを確保する
     "skipLibCheck": true,
 
-    // どのJavaScriptのバージョンに変換するか
-    // 使うnodeバージョンによって変更する
-    // 対応表 https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping
-    // ES2025でIterator helpers / Set methods / Promise.try等の型が利用可能
-    // Node 22 LTS / Node 24 / 主要モダンブラウザは2026年時点でES2025をネイティブサポート
+    // Node 22+と主要モダンブラウザがネイティブサポートするESバージョン
     "target": "ES2025",
 
-    // バンドラー / トランスパイラ前提のmoduleモード (TS 5.4+)
-    // ECMAScript imports/exportsを変換せず保持し、moduleResolution: "bundler" を暗黙的に指定する
-    // tsupなどでtsc以外がtranspileするのが標準的な現状に最適
-    // tscでtranspileする場合はconsumer側で `module: "NodeNext"` 等に上書きする
-    // https://www.typescriptlang.org/tsconfig/module.html#preserve
+    // バンドラー前提のmoduleモード (moduleResolution: "bundler" を暗黙指定)
     "module": "preserve",
 
-    // tsc は typecheck 専用にして emit はバンドラー (tsdown / tsup / esbuild 等) に任せる
-    // tsc で emit する構成 (tsconfig.tsc.json / tsconfig.lib.json) 側で `noEmit: false` を明示する
+    // tscはtypecheck専用にしてemitはバンドラーに任せる
     "noEmit": true,
 
-    // .jsファイルのインポートを許可するか
+    // .jsファイルのインポートを許可する
     "allowJs": true,
 
-    // .jsonファイルのインポートを許可するか
+    // .jsonファイルのインポートを許可する
     "resolveJsonModule": true,
 
-    // forceにすることで全てのファイルをモジュールとして扱う
-    // ファイルがスコープの単位になるので別ファイルで同一名の変数定義が可能
-    // https://www.totaltypescript.com/cannot-redeclare-block-scoped-variable
+    // 全ファイルをモジュールとして扱う
     "moduleDetection": "force",
 
-    // ファイル内で何かをエクスポートするか、少なくとも1つの外部モジュールをインポートしているか確認する
-    // TSC以外のトランスパイラに配慮するためのもの
+    // tsc以外のトランスパイラでも変換できるファイル単位の書き方を強制する
     "isolatedModules": true,
 
-    // ファイルパスの大文字小文字を区別するか
+    // ファイルパスの大文字小文字を区別する
     "forceConsistentCasingInFileNames": true,
 
-    // import typeやexport typeすることを強制
-    // 可読性向上とトランスパイル時に不必要なimportが残ってしまうのを減らせる
+    // import type / export type の明示を強制する
     "verbatimModuleSyntax": true,
 
-    // `noUncheckedSideEffectImports` はTypeScript 6.0からデフォルトtrueのため指定しない (このプリセットはTS 6+前提)
-    // 副作用importの解決失敗がエラー化されるので、CSS等は `declare module "*.css";` のアンビエント宣言を追加する
-    // https://www.typescriptlang.org/tsconfig/#noUncheckedSideEffectImports
+    // noUncheckedSideEffectImports はTypeScript 6.0からデフォルトtrueのため指定しない (このプリセットはTS 6+前提)
 
-    // Node 23.6+ の type-stripping や `tsgo` などでも実行可能なTypeScript構文に制限 (TS 5.8+)
-    // enum / runtime namespace / parameter properties をエラー化
-    // 既に `verbatimModuleSyntax: true` を採用しているため整合性が高い
-    // https://devblogs.microsoft.com/typescript/announcing-typescript-5-8/
+    // 型を消すだけで実行可能なTypeScript構文に制限する (enum等をエラー化)
     "erasableSyntaxOnly": true,
 
     // ----------------------------------------------------------------
     // Strictness
     // ----------------------------------------------------------------
-    // `strict` は TypeScript 6.0からデフォルトtrueのため指定しない (このプリセットはTS 6+前提)
-    // 明示維持の理由だった`exactOptionalPropertyTypes`の警告バグ
-    // (microsoft/TypeScript#63232) は6.0.3で修正済みを確認
-    // https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/
+    // strict はTypeScript 6.0からデフォルトtrueのため指定しない (このプリセットはTS 6+前提)
 
     // 配列やオブジェクトへのインデックスアクセスを型安全にする
     "noUncheckedIndexedAccess": true,
 
-    // x?: T と x?: T | undefined が区別される
+    // x?: T と x?: T | undefined を区別する
     "exactOptionalPropertyTypes": true,
 
-    // overrideする場合は明示する
+    // overrideする場合は明示を強制する
     "noImplicitOverride": true,
 
     // ----------------------------------------------------------------

--- a/packages/tsconfig/src/tsconfig.lib.json
+++ b/packages/tsconfig/src/tsconfig.lib.json
@@ -1,4 +1,5 @@
 {
+  // 各オプションの選定理由: https://github.com/nozomiishii/configs/blob/main/packages/tsconfig/docs/プリセットの選定理由.md
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "@nozomiishii/tsconfig/tsconfig.lib.json",
   "extends": "./tsconfig.json",
@@ -7,14 +8,13 @@
     // ----------------------------------------------------------------
     // Library Declaration emit
     // ----------------------------------------------------------------
+    // baseはtypecheck専用のためemitを明示的に有効化する
     "noEmit": false,
 
-    // .d.ts ファイルを生成する
+    // .d.tsファイルを生成する
     "declaration": true,
 
-    // tsc 以外のツール (tsdown / tsup / rolldown-plugin-dts 等) で
-    // .d.ts を並列生成可能にする。全ての export に明示的な型注釈を要求する
-    // https://www.typescriptlang.org/tsconfig/isolatedDeclarations.html
+    // tsc以外のツールで.d.tsを並列生成できるようにする
     "isolatedDeclarations": true,
 
     // ----------------------------------------------------------------

--- a/packages/tsconfig/src/tsconfig.nextjs.json
+++ b/packages/tsconfig/src/tsconfig.nextjs.json
@@ -1,4 +1,5 @@
 {
+  // 各オプションの選定理由: https://github.com/nozomiishii/configs/blob/main/packages/tsconfig/docs/プリセットの選定理由.md
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "@nozomiishii/tsconfig/tsconfig.nextjs.json",
   "extends": "./tsconfig.json",
@@ -7,24 +8,23 @@
     // ----------------------------------------------------------------
     // Transpiling
     // ----------------------------------------------------------------
-    // tsconfig.tsbuildinfoを生成して差分コンパイルにより時間短縮するか
+    // tsbuildinfoによる差分コンパイルで時間短縮する
     "incremental": true,
 
+    // Next.js公式が案内するmodule設定
     "moduleResolution": "Bundler",
     "module": "ESNext",
 
     // ----------------------------------------------------------------
     // JSX
     // ----------------------------------------------------------------
-    // tsxファイルの変換方法。preserveは.jsファイルに変換せずにそのまま.jsxを出力する
-    // Nextjs使う場合はpreserveのままが良い
+    // .jsxのまま出力してNext.js側で変換させる
     "jsx": "preserve",
 
     // ----------------------------------------------------------------
     // Libs
     // ----------------------------------------------------------------
-    // TypeScript 6.0で`dom.iterable`は`dom`にマージ予定のため指定しない
-    // https://gist.github.com/privatenumber/3d2e80da28f84ee30b77d53e1693378f
+    // dom.iterable はTypeScript 6.0で dom にマージ予定のため指定しない
     "lib": ["dom", "ESNext"],
 
     // ----------------------------------------------------------------

--- a/packages/tsconfig/src/tsconfig.tanstack-start.json
+++ b/packages/tsconfig/src/tsconfig.tanstack-start.json
@@ -1,4 +1,5 @@
 {
+  // 各オプションの選定理由: https://github.com/nozomiishii/configs/blob/main/packages/tsconfig/docs/プリセットの選定理由.md
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "@nozomiishii/tsconfig/tsconfig.tanstack-start.json",
   "extends": "./tsconfig.json",
@@ -7,14 +8,12 @@
     // ----------------------------------------------------------------
     // Transpiling
     // ----------------------------------------------------------------
-    // TanStack Start が公式に案内する Vite 向けの module 設定
-    // https://tanstack.com/start/latest/docs/framework/react/build-from-scratch
+    // TanStack Start公式が案内するVite向けのmodule設定
     "moduleResolution": "Bundler",
     "module": "ESNext",
     "target": "ES2022",
 
-    // TanStack Start では server module が client bundle に残る可能性があるため無効にする
-    // https://tanstack.com/start/latest/docs/framework/react/build-from-scratch
+    // server moduleがclient bundleに残る可能性があるため無効にする
     "verbatimModuleSyntax": false,
 
     // ----------------------------------------------------------------
@@ -31,7 +30,6 @@
     // Types
     // ----------------------------------------------------------------
     // asset import / import.meta.env / import.meta.hot の型を追加する
-    // https://vite.dev/guide/features.html#client-types
     "types": ["vite/client"]
   }
 }

--- a/packages/tsconfig/src/tsconfig.tsc.json
+++ b/packages/tsconfig/src/tsconfig.tsc.json
@@ -1,4 +1,5 @@
 {
+  // 各オプションの選定理由: https://github.com/nozomiishii/configs/blob/main/packages/tsconfig/docs/プリセットの選定理由.md
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "@nozomiishii/tsconfig/tsconfig.tsc.json",
   "extends": "./tsconfig.json",
@@ -7,10 +8,11 @@
     // ----------------------------------------------------------------
     // Transpiling
     // ----------------------------------------------------------------
-    // tsc で transpile する場合 (base の `module: "preserve"` を上書き)
+    // tscでtranspileするためbaseの module: "preserve" を上書きする
     "moduleResolution": "NodeNext",
     "module": "NodeNext",
 
+    // baseはtypecheck専用のためemitを明示的に有効化する
     "noEmit": false,
     "outDir": "../dist",
     "sourceMap": true


### PR DESCRIPTION
## 概要

`packages/tsconfig/src/` の各プリセットに書かれていた長いコメントを、各設定項目の上に 1 行だけ残す形に整理する。選定理由・トレードオフ・参照リンクの詳細は `packages/tsconfig/docs/` に移す。

## 変更内容

- `packages/tsconfig/docs/プリセットの選定理由.md` を新規作成し、各オプションの「なぜこの値にしたか」と参照リンクを集約
- 全 5 プリセット (`tsconfig.json` / `tsconfig.tsc.json` / `tsconfig.lib.json` / `tsconfig.nextjs.json` / `tsconfig.tanstack-start.json`) のコメントを 1 行化し、ファイル先頭に docs へのリンクを追加
- README (en / ja) の Usage に docs へのリンクを追加

docs の置き場は `packages/eslint-config/docs/` の既存慣習に合わせてパッケージ配下にしている。

## 検証

- `pnpm -r run tsc` / `check:ts`: 全パッケージ成功
- `pnpm --filter @nozomiishii/tsconfig lint`: 成功
- markdownlint (新規 docs + README): 0 issues