### PR TITLE
fix: raise tanstack-start preset lib to ES2025

### DIFF
--- a/packages/tsconfig/docs/プリセットの選定理由.md
+++ b/packages/tsconfig/docs/プリセットの選定理由.md
@@ -35,6 +35,8 @@ tsc で transpile する構成。base の `module: "preserve"` を `NodeNext` �
 
 ## tsconfig.tanstack-start.json
 
-- `module` / `moduleResolution` / `target` — [公式の build-from-scratch 手順](https://tanstack.com/start/latest/docs/framework/react/build-from-scratch)の案内どおりの値
+- `module` / `moduleResolution` — [公式の build-from-scratch 手順](https://tanstack.com/start/latest/docs/framework/react/build-from-scratch)の案内どおりの値
+- `target` を指定しない — 公式が案内する `ES2022` は "at least" の最低要件で、base の `ES2025` が満たす。Vite は tsconfig の `target` を無視して `build.target` / `oxc.target` を使うため、値を上げても出力は変わらない。[Vite の TypeScript](https://vite.dev/guide/features.html#typescript)
+- `lib: ["DOM", "DOM.Iterable", "ES2025"]` — base の `ES2025` に DOM 系を足す。`ES2022` のままでは `Promise.withResolvers` など ES2023 以降の型が引けない
 - `verbatimModuleSyntax: false` — server module が client bundle に残る可能性があるため、公式が無効を案内している
 - `types: ["vite/client"]` — asset import / `import.meta.env` / `import.meta.hot` の型を足す。[Vite client types](https://vite.dev/guide/features.html#client-types)

--- a/packages/tsconfig/src/tsconfig.tanstack-start.json
+++ b/packages/tsconfig/src/tsconfig.tanstack-start.json
@@ -11,7 +11,9 @@
     // TanStack Start公式が案内するVite向けのmodule設定
     "moduleResolution": "Bundler",
     "module": "ESNext",
-    "target": "ES2022",
+
+    // target は公式が最低要件として案内するES2022をbaseのES2025が満たすため指定しない
+    // (Viteはtsconfigのtargetを無視してbuild.target / oxc.targetを使う)
 
     // server moduleがclient bundleに残る可能性があるため無効にする
     "verbatimModuleSyntax": false,
@@ -24,7 +26,7 @@
     // ----------------------------------------------------------------
     // Libs
     // ----------------------------------------------------------------
-    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "lib": ["DOM", "DOM.Iterable", "ES2025"],
 
     // ----------------------------------------------------------------
     // Types


### PR DESCRIPTION
## 概要

`tsconfig.tanstack-start.json` の `target` / `lib` が `ES2022` 固定で、base preset の `ES2025` より低い。そのため `Promise.withResolvers` など ES2023 以降の型が引けない。

実利用側（dance / language の `apps/web`）がこの API を使っており、preset をそのまま適用すると typecheck が落ちる状態だった。

## 変更内容

- `target: "ES2022"` の明示を削除し、base の `ES2025` を継承する
- `lib` を `["DOM", "DOM.Iterable", "ES2025"]` に更新
- docs の選定理由にそれぞれの根拠を追記

## 設計

TanStack Start 公式の [build-from-scratch](https://tanstack.com/start/latest/docs/framework/react/build-from-scratch) は "at least the following settings" として `target: "ES2022"` を案内している。これは最低要件であって固定値ではなく、base の `ES2025` が満たす。

Vite は tsconfig の `target` を無視して `build.target` / `oxc.target` を使うため（[Vite の TypeScript](https://vite.dev/guide/features.html#typescript)）、`target` を上げてもバンドル出力は変わらない。`target` に依存する唯一の実挙動である `useDefineForClassFields` のデフォルトも「ES2022 以上で true」なので、ES2022 と ES2025 で差は出ない。

`verbatimModuleSyntax: false` は公式が無効を案内しているため据え置く。

## 影響

利用側が受け取る型が増える方向の変更で、既存の設定を壊さない。

## 検証

- `pnpm --filter @nozomiishii/tsconfig lint`
- `pnpm prettier --check packages/tsconfig`
- `pnpm markdownlint-cli2 packages/tsconfig/docs/プリセットの選定理由.md`
