### PR TITLE
chore: update op:// refs for renamed 1Password vault

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,8 +47,8 @@ jobs:
           version: "2.38.1"
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          APP_ID: op://github-app/nozomiishii-release/username
-          APP_PRIVATE_KEY: op://github-app/nozomiishii-release/credential
+          APP_ID: op://nozomiishii-release/github-app/username
+          APP_PRIVATE_KEY: op://nozomiishii-release/github-app/credential
 
       - name: Generate GitHub App token
         id: app-token
@@ -99,8 +99,8 @@ jobs:
           version: "2.38.1"
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          APP_ID: op://github-app/nozomiishii-release/username
-          APP_PRIVATE_KEY: op://github-app/nozomiishii-release/credential
+          APP_ID: op://nozomiishii-release/github-app/username
+          APP_PRIVATE_KEY: op://nozomiishii-release/github-app/credential
 
       - name: Generate GitHub App token
         id: app-token


### PR DESCRIPTION
## 概要

1Password の vault / item をリネームしたため、release workflow の secret 参照を更新する。

- vault: `github-app` → `nozomiishii-release` (GitHub App 名に合わせる)
- item: `nozomiishii-release` → `github-app`
- 参照: `op://github-app/nozomiishii-release/…` → `op://nozomiishii-release/github-app/…`

## 背景

- vault 名は中身ではなく配り先で付ける方針に伴うリネーム。経緯は nozomiishii/Brooklyn#141 と Brooklyn の docs/release.md「1Password vault」節を参照
- service account の vault アクセス権は vault オブジェクト (UUID) に紐づくため、リネームで権限は維持される。`OP_SERVICE_ACCOUNT_TOKEN` の差し替えは不要
- vault は**リネーム済み**のため、この PR がマージされるまで release workflow は secret 解決に失敗する。早めのマージを推奨

## 検証

マージ後の初回リリース実行で「Load secrets」step が成功することを確認する。事前にローカルで以下でも確認できる:

```bash
OP_SERVICE_ACCOUNT_TOKEN=<token> op read "op://nozomiishii-release/github-app/username"
```
