### PR TITLE
chore: remove redundant typescript pin

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,12 +17,6 @@
       "matchDepNames": ["node"],
       "matchUpdateTypes": ["minor", "patch"],
       "enabled": false
-    },
-    {
-      "description": "Hold typescript below v7 until typescript-eslint supports TS7 (typescript-eslint/typescript-eslint#10940)",
-      "matchManagers": ["npm"],
-      "matchDepNames": ["typescript"],
-      "allowedVersions": "<7"
     }
   ]
 }


### PR DESCRIPTION
## 概要

- `.github/renovate.json` から TypeScript 7 を避ける個別の `allowedVersions` ルールを削除

## 背景

同じ制約を共有 Renovate preset 側へ移しました。

- https://github.com/nozomiishii/renovate/pull/814
- 上流追跡: https://github.com/typescript-eslint/typescript-eslint/issues/10940

共有 preset を継承しているため、個別ルールを残す必要がありません。

## 影響

共有 preset の PR が取り込まれた後も TypeScript は 6.x に制限され、設定の管理場所だけが一元化されます。

## 検証

- `pnpm format`
- `renovate-config-validator --strict .github/renovate.json`
- `git diff --check`
- pre-commit hook
- pre-push workspace lint