### PR TITLE
feat!: enforce commit message policy before push

### DIFF
--- a/packages/commitlint-config/README.ja.md
+++ b/packages/commitlint-config/README.ja.md
@@ -28,7 +28,7 @@ pnpx nozo init
 
 - `type-enum`: `feat` / `fix` / `chore` / `revert` のみ許可。
 - `scope-empty`: デフォルトで scope 禁止。`feat: subject` は通り、`feat(api): subject` は弾かれる。
-- `commit-message-ascii-only`: body / footer / notes は ASCII のみ（コミットメッセージは英語で書く）。
+- `commit-message-ascii-only`: header / body / footer / notes は ASCII のみ（コミットメッセージは英語で書く）。
 - `breaking-change-requires-bang`: 破壊的変更は header の `!` で宣言する。`BREAKING CHANGE:` footer 単独（header に `!` なし）は弾かれる。GitHub の squash commit では footer が畳まれて見えないため。
 
 ### consumer 側で scope を許可する

--- a/packages/commitlint-config/README.md
+++ b/packages/commitlint-config/README.md
@@ -29,7 +29,7 @@ and writes a `commitlint.config.ts` that re-exports the shared config.
 
 - `type-enum`: only `feat` / `fix` / `chore` / `revert` are allowed.
 - `scope-empty`: scope must be empty by default. `feat: subject` passes; `feat(api): subject` is rejected.
-- `commit-message-ascii-only`: body / footer / notes must be ASCII (write commit messages in English).
+- `commit-message-ascii-only`: header / body / footer / notes must be ASCII (write commit messages in English).
 - `breaking-change-requires-bang`: declare breaking changes with `!` in the header. A `BREAKING CHANGE:` footer alone (no `!` in the header) is rejected, since GitHub collapses the footer in squash commits.
 
 ### Allowing scope in a consumer

--- a/packages/commitlint-config/src/rules/commit-message-ascii-only/index.test.ts
+++ b/packages/commitlint-config/src/rules/commit-message-ascii-only/index.test.ts
@@ -5,24 +5,33 @@ import { commitMessageAsciiOnly } from ".";
 const { name, rule } = commitMessageAsciiOnly;
 
 // rule callback を直接呼び、parser を介さず純粋ロジックを単体検証する。
-// `commit-message-ascii-only` の検査範囲が body / footer / notes 全体に拡張されたことを保証する。
+// `commit-message-ascii-only` の検査範囲が header / body / footer / notes 全体であることを保証する。
 describe("commit-message-ascii-only (unit)", () => {
-  // body、footer、notes が空のコミットを許可する。
-  test("allows an empty commit body, footer, and notes", () => {
-    const [valid] = rule({ body: null, footer: null, notes: [] });
+  // header、body、footer、notes が空のコミットを許可する。
+  test("allows an empty commit header, body, footer, and notes", () => {
+    const [valid] = rule({ body: null, footer: null, header: null, notes: [] });
 
     expect(valid).toBe(true);
   });
 
-  // body、footer、notes がすべて ASCII のコミットを許可する。
-  test("allows ASCII body, footer, and notes", () => {
+  // header、body、footer、notes がすべて ASCII のコミットを許可する。
+  test("allows ASCII header, body, footer, and notes", () => {
     const [valid] = rule({
       body: "English body line.",
       footer: "Refs #123",
+      header: "chore: add validation",
       notes: [{ text: "english breaking note", title: "BREAKING CHANGE" }],
     });
 
     expect(valid).toBe(true);
+  });
+
+  // non-ASCII の header を固定メッセージ付きで拒否する。
+  test("rejects a non-ASCII header with the fixed message", () => {
+    const [valid, message] = rule({ header: "chore: 日本語" });
+
+    expect(valid).toBe(false);
+    expect(message).toMatch(/ASCII characters only/);
   });
 
   // non-ASCII の body を固定メッセージ付きで拒否する。
@@ -77,6 +86,14 @@ describe("commit-message-ascii-only (unit)", () => {
 describe("commit-message-ascii-only (integration via @commitlint/lint)", () => {
   const rules = { [name]: [2, "always"] } as const;
   const opts = { plugins: { local: { rules: { [name]: rule } } } } as const;
+
+  // non-ASCII の header を検出する。
+  test("rejects a non-ASCII header", async () => {
+    const result = await lint("chore: 日本語", rules, opts);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.name === name)).toBe(true);
+  });
 
   // issue 参照より後ろにある non-ASCII text を検出する。
   test("detects non-ASCII text after an issue reference", async () => {

--- a/packages/commitlint-config/src/rules/commit-message-ascii-only/index.ts
+++ b/packages/commitlint-config/src/rules/commit-message-ascii-only/index.ts
@@ -1,16 +1,16 @@
 import type { RuleConfigTuple } from "@commitlint/types";
 import type { CommitBase } from "conventional-commits-parser";
 
-type Parsed = Partial<Pick<CommitBase, "body" | "footer" | "notes">>;
+type Parsed = Partial<Pick<CommitBase, "body" | "footer" | "header" | "notes">>;
 
-// Header 以外 (body + footer + BREAKING CHANGE notes) を ASCII のみに制限する。
+// header、body、footer、BREAKING CHANGE notes を ASCII のみに制限する。
 // body のみを検査すると、本文 1 行目に `#issue-number` が含まれる場合に
 // conventional-commits-parser がその行から footer 開始と判定し、
 // body が空文字列となって ASCII チェックが素通りする問題があるため、
 // footer / notes も検査対象に含める。
-const rule = ({ body, footer, notes }: Parsed): readonly [boolean, string?] => {
+const rule = ({ body, footer, header, notes }: Parsed): readonly [boolean, string?] => {
   const noteText = (notes ?? []).flatMap((n) => [n.title, n.text]).join("\n");
-  const text = [body, footer, noteText].filter(Boolean).join("\n");
+  const text = [header, body, footer, noteText].filter(Boolean).join("\n");
 
   if (!text) {
     return [true];
@@ -20,7 +20,7 @@ const rule = ({ body, footer, notes }: Parsed): readonly [boolean, string?] => {
 
   return [
     isValid,
-    "commit message body / footer / notes must contain ASCII characters only (write in English)",
+    "commit message header / body / footer / notes must contain ASCII characters only (write in English)",
   ];
 };
 

--- a/packages/lefthook-config/README.ja.md
+++ b/packages/lefthook-config/README.ja.md
@@ -56,6 +56,7 @@ extends:
 ## 利用可能なフラグメント
 
 - `hooks/commit-msg/commitlint.yaml` — `nozo-commitlint`（`@nozomiishii/commitlint-config` が提供）を実行
+- `hooks/pre-push/commitlint.yaml` — push 前に今回送るすべての commit を再検査（remote の既存履歴は除外）
 - `hooks/post-merge/update-node-modules.yaml` — pnpm > bun > npm > yarn
 - `hooks/post-merge/cleanup-worktrees-and-branches.yaml` — このパッケージが提供する `nozo-git-harvest` shim 経由で [`git-harvest`](https://github.com/nozomiishii/git-harvest) を実行
 - `hooks/pre-commit/yaml.yaml` — ステージしたファイルが `.yml` 拡張子だった場合にコミットを失敗させる（`.yaml` を強制）

--- a/packages/lefthook-config/README.md
+++ b/packages/lefthook-config/README.md
@@ -65,6 +65,7 @@ extends:
 ## Available fragments
 
 - `hooks/commit-msg/commitlint.yaml` — runs `nozo-commitlint` (provided by `@nozomiishii/commitlint-config`)
+- `hooks/pre-push/commitlint.yaml` — rechecks every outgoing commit before push; existing remote history is excluded
 - `hooks/post-merge/update-node-modules.yaml` — pnpm > bun > npm > yarn
 - `hooks/post-merge/cleanup-worktrees-and-branches.yaml` — runs [`git-harvest`](https://github.com/nozomiishii/git-harvest) via the `nozo-git-harvest` shim shipped by this package
 - `hooks/pre-commit/yaml.yaml` — fails the commit when staged files use the `.yml` extension (enforces `.yaml`)

--- a/packages/lefthook-config/hooks/pre-push/commitlint.yaml
+++ b/packages/lefthook-config/hooks/pre-push/commitlint.yaml
@@ -1,0 +1,5 @@
+pre-push:
+  jobs:
+    - name: commitlint
+      run: node node_modules/@nozomiishii/lefthook-config/dist/pre-push.js "{1}"
+      use_stdin: true

--- a/packages/lefthook-config/recommended.yaml
+++ b/packages/lefthook-config/recommended.yaml
@@ -14,6 +14,7 @@ assert_lefthook_installed: true
 
 extends:
   - node_modules/@nozomiishii/lefthook-config/hooks/commit-msg/commitlint.yaml
+  - node_modules/@nozomiishii/lefthook-config/hooks/pre-push/commitlint.yaml
   - node_modules/@nozomiishii/lefthook-config/hooks/post-merge/update-node-modules.yaml
   - node_modules/@nozomiishii/lefthook-config/hooks/post-merge/cleanup-worktrees-and-branches.yaml
   - node_modules/@nozomiishii/lefthook-config/hooks/pre-commit/yaml.yaml
@@ -26,4 +27,7 @@ post-merge:
   parallel: true
 
 pre-commit:
+  parallel: true
+
+pre-push:
   parallel: true

--- a/packages/lefthook-config/src/pre-push/index.test.ts
+++ b/packages/lefthook-config/src/pre-push/index.test.ts
@@ -1,0 +1,147 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, test, vi } from "vitest";
+import type { PrePushDependencies } from ".";
+import { isPrePushInputValid } from ".";
+
+const zeroOid = "0".repeat(40);
+const localOid = "1".repeat(40);
+const remoteOid = "2".repeat(40);
+const outgoingOid = "3".repeat(40);
+
+function createDependencies() {
+  return {
+    isCommit: vi.fn<PrePushDependencies["isCommit"]>(() => true),
+    lint: vi.fn<PrePushDependencies["lint"]>(() => true),
+    listCommits: vi.fn<PrePushDependencies["listCommits"]>(() => []),
+    readMessage: vi.fn<PrePushDependencies["readMessage"]>(() => "chore: add validation"),
+  };
+}
+
+// pre-push の stdin を解析し、今回 push する commit だけを lint する。
+describe("isPrePushInputValid", () => {
+  // 新規 ref では remote 上に既にある履歴を除外する。
+  test("rejects an invalid commit on a new ref", () => {
+    const dependencies = createDependencies();
+    dependencies.listCommits.mockReturnValue([outgoingOid]);
+    dependencies.readMessage.mockReturnValue("chore: 日本語");
+    dependencies.lint.mockReturnValue(false);
+
+    const isValid = isPrePushInputValid(
+      `refs/heads/topic ${localOid} refs/heads/topic ${zeroOid}\n`,
+      "origin",
+      dependencies,
+    );
+
+    expect(isValid).toBe(false);
+    expect(dependencies.listCommits).toHaveBeenCalledWith(localOid, undefined, "origin");
+    expect(dependencies.lint).toHaveBeenCalledWith("chore: 日本語");
+  });
+
+  // 既存 ref では remote oid より後ろの commit だけを検査する。
+  test("allows valid commits on an existing ref", () => {
+    const dependencies = createDependencies();
+    dependencies.listCommits.mockReturnValue([outgoingOid]);
+
+    const isValid = isPrePushInputValid(
+      `refs/heads/topic ${localOid} refs/heads/topic ${remoteOid}\n`,
+      "origin",
+      dependencies,
+    );
+
+    expect(isValid).toBe(true);
+    expect(dependencies.listCommits).toHaveBeenCalledWith(localOid, remoteOid, "origin");
+    expect(dependencies.lint).toHaveBeenCalledWith("chore: add validation");
+  });
+
+  // remote oid がローカルにない場合は remote tracking refs を基準にする。
+  test("falls back to remote refs when the remote oid is unavailable", () => {
+    const dependencies = createDependencies();
+    dependencies.isCommit.mockImplementation((oid) => oid !== remoteOid);
+
+    const isValid = isPrePushInputValid(
+      `refs/heads/topic ${localOid} refs/heads/topic ${remoteOid}\n`,
+      "origin",
+      dependencies,
+    );
+
+    expect(isValid).toBe(true);
+    expect(dependencies.listCommits).toHaveBeenCalledWith(localOid, undefined, "origin");
+  });
+
+  // ref 削除では commit message の検査対象がない。
+  test("skips ref deletions", () => {
+    const dependencies = createDependencies();
+
+    const isValid = isPrePushInputValid(
+      `refs/heads/topic ${zeroOid} refs/heads/topic ${remoteOid}\n`,
+      "origin",
+      dependencies,
+    );
+
+    expect(isValid).toBe(true);
+    expect(dependencies.isCommit).not.toHaveBeenCalled();
+    expect(dependencies.lint).not.toHaveBeenCalled();
+  });
+
+  // 同じ commit を複数 ref で push しても一度だけ検査する。
+  test("deduplicates commits across ref updates", () => {
+    const dependencies = createDependencies();
+    dependencies.listCommits.mockReturnValue([outgoingOid]);
+    const input = [
+      `refs/heads/topic ${localOid} refs/heads/topic ${zeroOid}`,
+      `refs/tags/topic ${localOid} refs/tags/topic ${zeroOid}`,
+    ].join("\n");
+
+    const isValid = isPrePushInputValid(`${input}\n`, "origin", dependencies);
+
+    expect(isValid).toBe(true);
+    expect(dependencies.lint).toHaveBeenCalledTimes(1);
+  });
+
+  // commit を指さない ref は検査対象外にする。
+  test("skips refs that do not resolve to commits", () => {
+    const dependencies = createDependencies();
+    dependencies.isCommit.mockReturnValue(false);
+
+    const isValid = isPrePushInputValid(
+      `refs/tags/blob ${localOid} refs/tags/blob ${zeroOid}\n`,
+      "origin",
+      dependencies,
+    );
+
+    expect(isValid).toBe(true);
+    expect(dependencies.listCommits).not.toHaveBeenCalled();
+    expect(dependencies.lint).not.toHaveBeenCalled();
+  });
+
+  // remote 上の既存履歴だけなら検査対象を空にする。
+  test("does not relint commits that are already on the remote", () => {
+    const dependencies = createDependencies();
+    dependencies.listCommits.mockReturnValue([]);
+
+    const isValid = isPrePushInputValid(
+      `refs/heads/topic ${localOid} refs/heads/topic ${zeroOid}\n`,
+      "origin",
+      dependencies,
+    );
+
+    expect(isValid).toBe(true);
+    expect(dependencies.lint).not.toHaveBeenCalled();
+  });
+});
+
+// recommended preset が stdin 対応の pre-push fragment を必ず読み込む。
+test("wires commitlint into the recommended pre-push hook", () => {
+  const recommended = readFileSync(new URL("../../recommended.yaml", import.meta.url), "utf-8");
+  const fragment = readFileSync(
+    new URL("../../hooks/pre-push/commitlint.yaml", import.meta.url),
+    "utf-8",
+  );
+
+  expect(recommended).toContain(
+    "node_modules/@nozomiishii/lefthook-config/hooks/pre-push/commitlint.yaml",
+  );
+  expect(recommended).toMatch(/pre-push:\n\s+parallel: true/);
+  expect(fragment).toContain("use_stdin: true");
+  expect(fragment).toContain('node node_modules/@nozomiishii/lefthook-config/dist/pre-push.js "{1}"');
+});

--- a/packages/lefthook-config/src/pre-push/index.ts
+++ b/packages/lefthook-config/src/pre-push/index.ts
@@ -1,0 +1,148 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+export type PrePushDependencies = Readonly<{
+  isCommit: (oid: string) => boolean;
+  lint: (message: string) => boolean;
+  listCommits: (localOid: string, remoteOid: string | undefined, remoteName: string) => string[];
+  readMessage: (oid: string) => string;
+}>;
+
+type RefUpdate = Readonly<{
+  localOid: string;
+  remoteOid: string;
+}>;
+
+export function isPrePushInputValid(
+  input: string,
+  remoteName: string,
+  dependencies: PrePushDependencies,
+): boolean {
+  if (!remoteName) {
+    throw new Error("pre-push remote name is required");
+  }
+
+  const linted = new Set<string>();
+
+  for (const { localOid, remoteOid } of parseRefUpdates(input)) {
+    if (isZeroOid(localOid) || !dependencies.isCommit(localOid)) {
+      continue;
+    }
+
+    const excludedOid =
+      !isZeroOid(remoteOid) && dependencies.isCommit(remoteOid) ? remoteOid : undefined;
+    const commits = dependencies.listCommits(localOid, excludedOid, remoteName);
+
+    if (commits.some((commit) => !isCommitValid(commit, linted, dependencies))) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function gitOutput(args: string[]): string {
+  const result = spawnSync("git", args, { encoding: "utf-8" });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || `git ${args.join(" ")} failed`);
+  }
+
+  return result.stdout;
+}
+
+function isCommitValid(
+  commit: string,
+  linted: Set<string>,
+  dependencies: PrePushDependencies,
+): boolean {
+  if (linted.has(commit)) {
+    return true;
+  }
+
+  linted.add(commit);
+
+  return dependencies.lint(dependencies.readMessage(commit));
+}
+
+function isZeroOid(oid: string): boolean {
+  return /^0+$/u.test(oid);
+}
+
+function parseRefUpdates(input: string): RefUpdate[] {
+  if (!input.trim()) {
+    return [];
+  }
+
+  return input
+    .trim()
+    .split(/\r?\n/u)
+    .map((line) => {
+      const fields = line.trim().split(/\s+/u);
+      const localOid = fields[1];
+      const remoteOid = fields[3];
+
+      if (localOid === undefined || remoteOid === undefined || fields.length !== 4) {
+        throw new Error(`invalid pre-push input: ${line}`);
+      }
+
+      return { localOid, remoteOid };
+    });
+}
+
+const defaultDependencies: PrePushDependencies = {
+  isCommit: (oid) => {
+    const result = spawnSync("git", ["cat-file", "-e", oid + "^{commit}"], { stdio: "ignore" });
+
+    if (result.error) {
+      throw result.error;
+    }
+
+    return result.status === 0;
+  },
+  lint: (message) => {
+    const executable = process.platform === "win32" ? "nozo-commitlint.cmd" : "nozo-commitlint";
+    const command = path.join(process.cwd(), "node_modules", ".bin", executable);
+    const result = spawnSync(command, ["--verbose"], {
+      input: message,
+      stdio: ["pipe", "inherit", "inherit"],
+    });
+
+    if (result.error) {
+      throw result.error;
+    }
+
+    return result.status === 0;
+  },
+  listCommits: (localOid, remoteOid, remoteName) => {
+    const exclusion = remoteOid ?? `--remotes=${remoteName}`;
+    const output = gitOutput(["rev-list", "--reverse", localOid, "--not", exclusion]).trim();
+
+    return output ? output.split(/\r?\n/u) : [];
+  },
+  readMessage: (oid) => gitOutput(["show", "--quiet", "--format=%B", oid]),
+};
+
+export function runPrePushCli(remoteName = process.argv[2]): number {
+  try {
+    const input = readFileSync(0, "utf-8");
+
+    return isPrePushInputValid(input, remoteName ?? "", defaultDependencies) ? 0 : 1;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`pre-push commitlint failed: ${message}\n`);
+
+    return 1;
+  }
+}
+
+const entrypoint = process.argv[1];
+
+if (entrypoint !== undefined && import.meta.url === new URL(entrypoint, "file:").href) {
+  process.exitCode = runPrePushCli();
+}

--- a/packages/lefthook-config/tsdown.config.ts
+++ b/packages/lefthook-config/tsdown.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     cli: "src/cli.ts",
     "init/bin": "src/init/bin.ts",
     "init/index": "src/init/index.ts",
+    "pre-push": "src/pre-push/index.ts",
   },
   format: ["esm"],
   outExtensions: () => ({ js: ".js" }),


### PR DESCRIPTION
## 概要

コミットメッセージの規約違反を、Claude Code / Codex 固有の agent hook に依存せず、共有 commitlint と Lefthook で決定論的に防ぎます。

## 原因

- `commit-message-ascii-only` が body / footer / notes だけを検査し、header を対象外にしていた
- 共有 Lefthook preset に pre-push の commit 再検査がなく、commit-msg hook を通らなかった commit を push 前に止められなかった

## 変更

- commitlint の ASCII 検査対象を header / body / footer / notes 全体へ拡張
- 共有 Lefthook preset に pre-push commitlint を追加
- 新規 branch では remote 到達済みの履歴を除外し、今回 push する commit だけを検査
- 複数 ref、ref 削除、非 commit ref、remote oid がローカルにない場合を処理
- README を更新

## 破壊的変更

これまで許可されていた non-ASCII header を拒否し、recommended preset 利用者には pre-push 検証が追加されます。

## 検証

- `pnpm --filter @nozomiishii/commitlint-config test`
- `pnpm --filter @nozomiishii/commitlint-config tsc`
- `pnpm --filter @nozomiishii/commitlint-config lint`
- `pnpm --filter @nozomiishii/lefthook-config test`
- `pnpm --filter @nozomiishii/lefthook-config tsc`
- `pnpm --filter @nozomiishii/lefthook-config lint`
- 両 package の build / pack
- valid / non-ASCII commit を使った pre-push 実動作確認
- 初回 push 時に pre-push commitlint と repository lint が成功