### PR TITLE
chore: guard against non-pnpm installs via devEngines

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,14 +40,14 @@
     "npkill": "0.12.2",
     "oxfmt": "0.63.0"
   },
-  "engines": {
-    "node": "24.19.0"
-  },
-  "packageManager": "pnpm@11.21.0",
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
       "onFail": "error"
     }
-  }
+  },
+  "engines": {
+    "node": "24.19.0"
+  },
+  "packageManager": "pnpm@11.21.0"
 }

--- a/package.json
+++ b/package.json
@@ -43,5 +43,11 @@
   "engines": {
     "node": "24.19.0"
   },
-  "packageManager": "pnpm@11.21.0"
+  "packageManager": "pnpm@11.21.0",
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "onFail": "error"
+    }
+  }
 }


### PR DESCRIPTION
## 概要

pnpm プロジェクトで誤って npm install を実行する事故を防ぐため、package.json に `devEngines.packageManager` を追加する。全 repo への横断適用 (broadcast)。

## 背景

dotfiles の corepack 廃止に伴う移行 (https://github.com/nozomiishii/dotfiles/pull/1561)。corepack の shim が担っていた誤パッケージマネージャーガードを、package.json の宣言に置き換える。

- pnpm 公式が corepack 非推奨を明言し、pnpm 12 (Rust ネイティブ) は corepack で起動できない
- corepack は Node 25 から同梱されなくなる
- 宣言による方式は corepack を有効化していないマシン・CI・他人の環境でも同じく効く

## 変更内容

```json
"devEngines": {
  "packageManager": { "name": "pnpm", "onFail": "error" }
}
```

npm 10.9 以降と pnpm 11 以降が install 前に評価し、不一致なら EBADDEVENGINES で停止する。既存の `packageManager` フィールドは pnpm 自身と yarn classic が読むため、両方を残すことで止められる範囲が広がる。

## 検証

`npm install` が EBADDEVENGINES で停止し、`pnpm install` が正常完了することを確認済み。
