### PR TITLE
chore: use pnpm exec for markdownlint in CI

### DIFF
--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -48,7 +48,7 @@ jobs:
         uses: ./.github/actions/setup-node
 
       - name: lint
-        run: npx -y markdownlint-cli2 "**/*.md"
+        run: pnpm exec markdownlint-cli2 "**/*.md"
 
   required:
     # name 変更時は infra 側の required_status_checks も更新する


### PR DESCRIPTION
## Summary

- `.github/workflows/markdown.yaml` の lint ステップを `npx -y` から `pnpm exec` に変更

## 背景

[#2731](https://github.com/nozomiishii/configs/pull/2731) で root `package.json` に `devEngines.packageManager` (pnpm / `onFail: error`) を追加した結果、npm 由来の `npx` が拒否されるようになった。

```
npm error EBADDEVENGINES Invalid name "pnpm" does not match "npm" for "packageManager"
npm error EBADDEVENGINES   current: { name: 'npm', version: '11.17.0' }
npm error EBADDEVENGINES   required: { name: 'pnpm', onFail: 'error' }
```

このため `**/*.md` を変更する全 PR で Markdown lint が失敗している ([#2706](https://github.com/nozomiishii/configs/pull/2706) の CI 失敗もこれが原因)。

CI 全体で `npx` を使っていたのはこの 1 箇所のみ (`github-pages.yaml` の `pnpx` は pnpm 由来なので影響なし)。

## 変更内容

`.github/actions/setup-node` が既に `pnpm install --frozen-lockfile` を実行済みで、`markdownlint-cli2@0.23.2` は root の devDependencies にある。そのため `pnpm exec` でそのまま呼べる。

副次的な利点として、`npx -y` の「毎回最新を取得」から lockfile 固定版に変わり、ローカルの `fix:md` スクリプトと同じバージョンで動くようになる。CI だけ勝手にルールが変わる事故を防げる。

## Testing

worktree で実行して確認:

```
pnpm exec markdownlint-cli2 "**/*.md"
markdownlint-cli2 v0.23.2 (markdownlint v0.41.1)
Linting: 40 files
Summary: 0 issues in 0 files
```
