### PR TITLE
chore: add main image to oxfmt-config README

### DIFF
--- a/packages/oxfmt-config/README.ja.md
+++ b/packages/oxfmt-config/README.ja.md
@@ -4,6 +4,13 @@
 
 共通の [oxfmt](https://oxc.rs/docs/guide/usage/formatter) 設定。
 
+<!-- Main Image -->
+<br>
+<div align="center">
+  <img src="https://media.giphy.com/media/UdnRoDDuL5Ws8/giphy.gif" alt="Coding" width="480" />
+</div>
+<br>
+
 ## インストール
 
 [`nozo`](../nozo) CLI を使う:

--- a/packages/oxfmt-config/README.md
+++ b/packages/oxfmt-config/README.md
@@ -4,6 +4,13 @@ English | [日本語](./README.ja.md)
 
 Shared [oxfmt](https://oxc.rs/docs/guide/usage/formatter) config.
 
+<!-- Main Image -->
+<br>
+<div align="center">
+  <img src="https://media.giphy.com/media/UdnRoDDuL5Ws8/giphy.gif" alt="Coding" width="480" />
+</div>
+<br>
+
 ## Install
 
 Use the [`nozo`](../nozo) CLI:


### PR DESCRIPTION
## Summary
- `oxfmt-config` の日本語 README に Main Image を追加
- 英語 README も同内容で同期

## Test plan
- [ ] GitHub 上で両 README のプレビューで画像が表示されること
- [ ] 言語切替リンクが壊れていないこと