### PR TITLE
chore: remove unused lint-docs pre-commit hook

### DIFF
--- a/packages/lefthook-config/hooks/pre-commit/docs.yaml
+++ b/packages/lefthook-config/hooks/pre-commit/docs.yaml
@@ -1,8 +1,0 @@
-pre-commit:
-  jobs:
-    - name: lint-docs
-      run: |
-        if git diff --cached --diff-filter=d --name-only | grep -q '^docs/superpowers/specs/'; then
-          echo "docs/superpowers/specs/ へのコミットは禁止。設計は GitHub issue にまとめる" >&2
-          exit 1
-        fi

--- a/packages/lefthook-config/recommended.yaml
+++ b/packages/lefthook-config/recommended.yaml
@@ -17,7 +17,6 @@ extends:
   - node_modules/@nozomiishii/lefthook-config/hooks/post-merge/update-node-modules.yaml
   - node_modules/@nozomiishii/lefthook-config/hooks/post-merge/cleanup-worktrees-and-branches.yaml
   - node_modules/@nozomiishii/lefthook-config/hooks/pre-commit/yaml.yaml
-  - node_modules/@nozomiishii/lefthook-config/hooks/pre-commit/docs.yaml
 
 commit-msg:
   parallel: true


### PR DESCRIPTION
## 背景

`docs/superpowers/specs/` へのコミットを禁止していた `lint-docs` は使わなくなった。

## 変更

- `hooks/pre-commit/docs.yaml` を削除
- `recommended.yaml` の `extends` から該当行を削除

## 検証

- プリセットの extends から `docs.yaml` が消えていること