### PR TITLE
feat!: check the header in commit-message-ascii-only

### DIFF
--- a/packages/commitlint-config/README.ja.md
+++ b/packages/commitlint-config/README.ja.md
@@ -28,7 +28,7 @@ pnpx nozo init
 
 - `type-enum`: `feat` / `fix` / `chore` / `revert` のみ許可。
 - `scope-empty`: デフォルトで scope 禁止。`feat: subject` は通り、`feat(api): subject` は弾かれる。
-- `commit-message-ascii-only`: body / footer / notes は ASCII のみ（コミットメッセージは英語で書く）。
+- `commit-message-ascii-only`: header / body / footer / notes すべて ASCII のみ（コミットメッセージは英語で書く）。
 - `breaking-change-requires-bang`: 破壊的変更は header の `!` で宣言する。`BREAKING CHANGE:` footer 単独（header に `!` なし）は弾かれる。GitHub の squash commit では footer が畳まれて見えないため。
 
 ### consumer 側で scope を許可する

--- a/packages/commitlint-config/README.md
+++ b/packages/commitlint-config/README.md
@@ -29,7 +29,7 @@ and writes a `commitlint.config.ts` that re-exports the shared config.
 
 - `type-enum`: only `feat` / `fix` / `chore` / `revert` are allowed.
 - `scope-empty`: scope must be empty by default. `feat: subject` passes; `feat(api): subject` is rejected.
-- `commit-message-ascii-only`: body / footer / notes must be ASCII (write commit messages in English).
+- `commit-message-ascii-only`: header / body / footer / notes must all be ASCII (write commit messages in English).
 - `breaking-change-requires-bang`: declare breaking changes with `!` in the header. A `BREAKING CHANGE:` footer alone (no `!` in the header) is rejected, since GitHub collapses the footer in squash commits.
 
 ### Allowing scope in a consumer

--- a/packages/commitlint-config/src/rules/commit-message-ascii-only/index.test.ts
+++ b/packages/commitlint-config/src/rules/commit-message-ascii-only/index.test.ts
@@ -4,54 +4,51 @@ import { commitMessageAsciiOnly } from ".";
 
 const { name, rule } = commitMessageAsciiOnly;
 
-// rule callback を直接呼び、parser を介さず検査対象フィールドを網羅する。
-// 非 ASCII のサンプルは日本語で揃え、ケース間で変わるのはフィールドだけにする。
-describe("commit-message-ascii-only (unit)", () => {
-  test.each([
-    { label: "no field is present", parsed: {}, valid: true },
-    {
-      label: "every field is ASCII",
-      parsed: {
-        body: "English body line.",
-        footer: "Refs #123",
-        header: "feat: add something",
-        notes: [{ text: "english breaking note", title: "BREAKING CHANGE" }],
-      },
-      valid: true,
-    },
-    {
-      label: "the header subject is Japanese",
-      parsed: { header: "chore: 日本語のタイトル" },
-      valid: false,
-    },
-    // scope を許可した consumer でも header 全体が検査対象になる。
-    {
-      label: "the header scope is Japanese",
-      parsed: { header: "feat(日本語): subject" },
-      valid: false,
-    },
-    { label: "the body is Japanese", parsed: { body: "日本語の本文。" }, valid: false },
-    // parser が body 1 行目の `#nnn` 以降を footer へ振り分けると、日本語は footer 側に流れる。
-    {
-      label: "the footer is Japanese",
-      parsed: { footer: "Issue #2126 のような本文。" },
-      valid: false,
-    },
-    {
-      label: "a note text is Japanese",
-      parsed: { notes: [{ text: "互換性破壊の説明", title: "BREAKING CHANGE" }] },
-      valid: false,
-    },
-    // title は実用上 "BREAKING CHANGE" 固定だが、検査対象に含める契約を固定する。
-    {
-      label: "a note title is Japanese",
-      parsed: { notes: [{ text: "english", title: "破壊的変更" }] },
-      valid: false,
-    },
-  ])("returns $valid when $label", ({ parsed, valid }) => {
-    const [actual] = rule(parsed);
+// 検査対象のフィールド。
+const fields = [
+  { build: (text: string) => ({ body: text }), name: "body" },
+  { build: (text: string) => ({ footer: text }), name: "footer" },
+  { build: (text: string) => ({ header: text }), name: "header" },
+  { build: (text: string) => ({ notes: [{ text, title: "BREAKING CHANGE" }] }), name: "note text" },
+  { build: (text: string) => ({ notes: [{ text: "english", title: text }] }), name: "note title" },
+];
+
+// 文字種。
+const samples = [
+  { name: "accented latin", text: "café latte", valid: false },
+  { name: "ascii", text: "plain english text", valid: true },
+  { name: "emoji", text: "ship it 🚀", valid: false },
+  { name: "japanese", text: "日本語のテキスト", valid: false },
+];
+
+// フィールドと文字種の 2 軸。どのフィールドに入っても判定が変わらないことを固定する。
+describe.each(fields)("commit-message-ascii-only ($name)", ({ build }) => {
+  test.each(samples)("$name", ({ text, valid }) => {
+    const [actual] = rule(build(text));
 
     expect(actual).toBe(valid);
+  });
+});
+
+// 2 軸に乗らない、rule 単体の契約。
+describe("commit-message-ascii-only (contract)", () => {
+  // 空のコミットを許可する。
+  test("allows a commit with no field at all", () => {
+    const [valid] = rule({});
+
+    expect(valid).toBe(true);
+  });
+
+  // 全フィールドが同時に埋まっていても、ASCII なら許可する。
+  test("allows ASCII in every field at once", () => {
+    const [valid] = rule({
+      body: "English body line.",
+      footer: "Refs #123",
+      header: "feat: add something",
+      notes: [{ text: "english breaking note", title: "BREAKING CHANGE" }],
+    });
+
+    expect(valid).toBe(true);
   });
 
   // 違反時のメッセージで、対象がコミットメッセージ全体だと分かるようにする。
@@ -62,39 +59,37 @@ describe("commit-message-ascii-only (unit)", () => {
   });
 });
 
-// 実 parser を通した end-to-end 検証。文字種ごとの合否と、parser のフィールド振り分けを確認する。
-describe("commit-message-ascii-only (integration via @commitlint/lint)", () => {
+// 実 parser がどのフィールドへ振り分けても判定が効くことを確認する。文字種は上の 2 軸が持つ。
+describe("commit-message-ascii-only (parser routing via @commitlint/lint)", () => {
   const rules = { [name]: [2, "always"] } as const;
   const opts = { plugins: { local: { rules: { [name]: rule } } } } as const;
 
-  test.each([
-    { label: "an ASCII subject", message: "chore: ok subject", valid: true },
+  const routings = [
+    { message: "chore: 日本語のタイトル", name: "the subject lands in the header", valid: false },
     {
-      label: "a revert subject wrapped in double quotes",
       message: 'revert: "feat: add something"',
+      name: "a quoted revert subject stays in the header",
       valid: true,
     },
     {
-      label: "an English body carrying an issue reference and a breaking note",
-      message: [
-        "feat(scope): subject",
-        "",
-        "English body. Refs #2126.",
-        "",
-        "BREAKING CHANGE: english note",
-      ].join("\n"),
+      message: ["feat: subject", "", "English body. Refs #2126."].join("\n"),
+      name: "an English body stays in the body",
       valid: true,
     },
-    { label: "a Japanese subject", message: "chore: 日本語のタイトル", valid: false },
-    { label: "an emoji in the subject", message: "chore: emoji 🚀", valid: false },
-    { label: "accented latin in the subject", message: "chore: café latte", valid: false },
     {
       // 本文 1 行目の `#nnn` を parser が footer 開始と判定し、body が空文字列になる経路。
-      label: "Japanese placed after an issue reference in the body",
-      message: ["feat(scope): subject", "", "Issue #2126 のような本文。日本語混入。"].join("\n"),
+      message: ["feat: subject", "", "Issue #2126 のような本文。日本語混入。"].join("\n"),
+      name: "text after an issue reference lands in the footer",
       valid: false,
     },
-  ])("returns $valid for $label", async ({ message, valid }) => {
+    {
+      message: ["feat!: subject", "", "BREAKING CHANGE: 日本語のノート"].join("\n"),
+      name: "a breaking change note lands in the notes",
+      valid: false,
+    },
+  ];
+
+  test.each(routings)("$name", async ({ message, valid }) => {
     const result = await lint(message, rules, opts);
 
     expect(result.errors.map((e) => e.name)).toStrictEqual(valid ? [] : [name]);

--- a/packages/commitlint-config/src/rules/commit-message-ascii-only/index.test.ts
+++ b/packages/commitlint-config/src/rules/commit-message-ascii-only/index.test.ts
@@ -4,6 +4,9 @@ import { commitMessageAsciiOnly } from ".";
 
 const { name, rule } = commitMessageAsciiOnly;
 
+const rules = { [name]: [2, "always"] } as const;
+const opts = { plugins: { local: { rules: { [name]: rule } } } } as const;
+
 // 検査対象のフィールド。
 const fields = [
   { build: (text: string) => ({ body: text }), name: "body" },
@@ -13,34 +16,30 @@ const fields = [
   { build: (text: string) => ({ notes: [{ text: "english", title: text }] }), name: "note title" },
 ];
 
-// 文字種。
-const samples = [
-  { name: "accented latin", text: "café latte", valid: false },
-  { name: "ascii", text: "plain english text", valid: true },
-  { name: "emoji", text: "ship it 🚀", valid: false },
-  { name: "japanese", text: "日本語のテキスト", valid: false },
+// 弾かれる文字種。
+const nonAsciiSamples = [
+  { name: "accented latin", text: "café latte" },
+  { name: "emoji", text: "ship it 🚀" },
+  { name: "japanese", text: "日本語のテキスト" },
 ];
 
-// フィールドと文字種の 2 軸。どのフィールドに入っても判定が変わらないことを固定する。
-describe.each(fields)("commit-message-ascii-only ($name)", ({ build }) => {
-  test.each(samples)("$name", ({ text, valid }) => {
-    const [actual] = rule(build(text));
+describe("commit-message-ascii-only (allows ASCII)", () => {
+  // ASCII はどのフィールドに入っても通る。
+  test.each(fields)("$name", ({ build }) => {
+    const [valid] = rule(build("plain english text"));
 
-    expect(actual).toBe(valid);
+    expect(valid).toBe(true);
   });
-});
 
-// 2 軸に乗らない、rule 単体の契約。
-describe("commit-message-ascii-only (contract)", () => {
-  // 空のコミットを許可する。
-  test("allows a commit with no field at all", () => {
+  // フィールドが 1 つも無いコミットを通す。
+  test("no field at all", () => {
     const [valid] = rule({});
 
     expect(valid).toBe(true);
   });
 
-  // 全フィールドが同時に埋まっていても、ASCII なら許可する。
-  test("allows ASCII in every field at once", () => {
+  // 全フィールドが同時に埋まっていても通す。
+  test("every field at once", () => {
     const [valid] = rule({
       body: "English body line.",
       footer: "Refs #123",
@@ -50,8 +49,19 @@ describe("commit-message-ascii-only (contract)", () => {
 
     expect(valid).toBe(true);
   });
+});
 
-  // 違反時のメッセージで、対象がコミットメッセージ全体だと分かるようにする。
+describe("commit-message-ascii-only (rejects non-ASCII)", () => {
+  // 非 ASCII はどのフィールドに入っても弾かれる。
+  describe.each(fields)("$name", ({ build }) => {
+    test.each(nonAsciiSamples)("$name", ({ text }) => {
+      const [valid] = rule(build(text));
+
+      expect(valid).toBe(false);
+    });
+  });
+
+  // 対象がコミットメッセージ全体だと分かるメッセージを返す。
   test("reports that the whole commit message must be ASCII", () => {
     const [, message] = rule({ header: "chore: 日本語のタイトル" });
 
@@ -59,39 +69,40 @@ describe("commit-message-ascii-only (contract)", () => {
   });
 });
 
-// 実 parser がどのフィールドへ振り分けても判定が効くことを確認する。文字種は上の 2 軸が持つ。
-describe("commit-message-ascii-only (parser routing via @commitlint/lint)", () => {
-  const rules = { [name]: [2, "always"] } as const;
-  const opts = { plugins: { local: { rules: { [name]: rule } } } } as const;
-
-  const routings = [
-    { message: "chore: 日本語のタイトル", name: "the subject lands in the header", valid: false },
+describe("commit-message-ascii-only (parser routing, allows ASCII)", () => {
+  // 実 parser がどのフィールドへ振り分けても、ASCII なら通る。
+  test.each([
     {
       message: 'revert: "feat: add something"',
       name: "a quoted revert subject stays in the header",
-      valid: true,
     },
     {
       message: ["feat: subject", "", "English body. Refs #2126."].join("\n"),
       name: "an English body stays in the body",
-      valid: true,
     },
+  ])("$name", async ({ message }) => {
+    const result = await lint(message, rules, opts);
+
+    expect(result.errors.map((e) => e.name)).toStrictEqual([]);
+  });
+});
+
+describe("commit-message-ascii-only (parser routing, rejects non-ASCII)", () => {
+  // 実 parser がどのフィールドへ振り分けても、非 ASCII は弾かれる。
+  test.each([
+    { message: "chore: 日本語のタイトル", name: "the subject lands in the header" },
     {
       // 本文 1 行目の `#nnn` を parser が footer 開始と判定し、body が空文字列になる経路。
       message: ["feat: subject", "", "Issue #2126 のような本文。日本語混入。"].join("\n"),
       name: "text after an issue reference lands in the footer",
-      valid: false,
     },
     {
       message: ["feat!: subject", "", "BREAKING CHANGE: 日本語のノート"].join("\n"),
       name: "a breaking change note lands in the notes",
-      valid: false,
     },
-  ];
-
-  test.each(routings)("$name", async ({ message, valid }) => {
+  ])("$name", async ({ message }) => {
     const result = await lint(message, rules, opts);
 
-    expect(result.errors.map((e) => e.name)).toStrictEqual(valid ? [] : [name]);
+    expect(result.errors.map((e) => e.name)).toStrictEqual([name]);
   });
 });

--- a/packages/commitlint-config/src/rules/commit-message-ascii-only/index.test.ts
+++ b/packages/commitlint-config/src/rules/commit-message-ascii-only/index.test.ts
@@ -25,7 +25,7 @@ const nonAsciiSamples = [
 
 describe("commit-message-ascii-only (allows ASCII)", () => {
   // ASCII はどのフィールドに入っても通る。
-  test.each(fields)("$name", ({ build }) => {
+  test.for(fields)("$name", ({ build }) => {
     const [valid] = rule(build("plain english text"));
 
     expect(valid).toBe(true);
@@ -53,8 +53,8 @@ describe("commit-message-ascii-only (allows ASCII)", () => {
 
 describe("commit-message-ascii-only (rejects non-ASCII)", () => {
   // 非 ASCII はどのフィールドに入っても弾かれる。
-  describe.each(fields)("$name", ({ build }) => {
-    test.each(nonAsciiSamples)("$name", ({ text }) => {
+  describe.for(fields)("$name", ({ build }) => {
+    test.for(nonAsciiSamples)("$name", ({ text }) => {
       const [valid] = rule(build(text));
 
       expect(valid).toBe(false);
@@ -71,7 +71,7 @@ describe("commit-message-ascii-only (rejects non-ASCII)", () => {
 
 describe("commit-message-ascii-only (parser routing, allows ASCII)", () => {
   // 実 parser がどのフィールドへ振り分けても、ASCII なら通る。
-  test.each([
+  test.for([
     {
       message: 'revert: "feat: add something"',
       name: "a quoted revert subject stays in the header",
@@ -89,7 +89,7 @@ describe("commit-message-ascii-only (parser routing, allows ASCII)", () => {
 
 describe("commit-message-ascii-only (parser routing, rejects non-ASCII)", () => {
   // 実 parser がどのフィールドへ振り分けても、非 ASCII は弾かれる。
-  test.each([
+  test.for([
     { message: "chore: 日本語のタイトル", name: "the subject lands in the header" },
     {
       // 本文 1 行目の `#nnn` を parser が footer 開始と判定し、body が空文字列になる経路。

--- a/packages/commitlint-config/src/rules/commit-message-ascii-only/index.test.ts
+++ b/packages/commitlint-config/src/rules/commit-message-ascii-only/index.test.ts
@@ -4,174 +4,99 @@ import { commitMessageAsciiOnly } from ".";
 
 const { name, rule } = commitMessageAsciiOnly;
 
-// rule callback を直接呼び、parser を介さず純粋ロジックを単体検証する。
-// `commit-message-ascii-only` の検査範囲が header / body / footer / notes 全体に及ぶことを保証する。
+// rule callback を直接呼び、parser を介さず検査対象フィールドを網羅する。
+// 非 ASCII のサンプルは日本語で揃え、ケース間で変わるのはフィールドだけにする。
 describe("commit-message-ascii-only (unit)", () => {
-  // header、body、footer、notes が空のコミットを許可する。
-  test("allows an empty header, body, footer, and notes", () => {
-    const [valid] = rule({ body: null, footer: null, header: null, notes: [] });
+  test.each([
+    { label: "no field is present", parsed: {}, valid: true },
+    {
+      label: "every field is ASCII",
+      parsed: {
+        body: "English body line.",
+        footer: "Refs #123",
+        header: "feat: add something",
+        notes: [{ text: "english breaking note", title: "BREAKING CHANGE" }],
+      },
+      valid: true,
+    },
+    {
+      label: "the header subject is Japanese",
+      parsed: { header: "chore: 日本語のタイトル" },
+      valid: false,
+    },
+    // scope を許可した consumer でも header 全体が検査対象になる。
+    {
+      label: "the header scope is Japanese",
+      parsed: { header: "feat(日本語): subject" },
+      valid: false,
+    },
+    { label: "the body is Japanese", parsed: { body: "日本語の本文。" }, valid: false },
+    // parser が body 1 行目の `#nnn` 以降を footer へ振り分けると、日本語は footer 側に流れる。
+    {
+      label: "the footer is Japanese",
+      parsed: { footer: "Issue #2126 のような本文。" },
+      valid: false,
+    },
+    {
+      label: "a note text is Japanese",
+      parsed: { notes: [{ text: "互換性破壊の説明", title: "BREAKING CHANGE" }] },
+      valid: false,
+    },
+    // title は実用上 "BREAKING CHANGE" 固定だが、検査対象に含める契約を固定する。
+    {
+      label: "a note title is Japanese",
+      parsed: { notes: [{ text: "english", title: "破壊的変更" }] },
+      valid: false,
+    },
+  ])("returns $valid when $label", ({ parsed, valid }) => {
+    const [actual] = rule(parsed);
 
-    expect(valid).toBe(true);
+    expect(actual).toBe(valid);
   });
 
-  // header、body、footer、notes がすべて ASCII のコミットを許可する。
-  test("allows an ASCII header, body, footer, and notes", () => {
-    const [valid] = rule({
-      body: "English body line.",
-      footer: "Refs #123",
-      header: "feat: add something",
-      notes: [{ text: "english breaking note", title: "BREAKING CHANGE" }],
-    });
+  // 違反時のメッセージで、対象がコミットメッセージ全体だと分かるようにする。
+  test("reports that the whole commit message must be ASCII", () => {
+    const [, message] = rule({ header: "chore: 日本語のタイトル" });
 
-    expect(valid).toBe(true);
-  });
-
-  // non-ASCII の body を固定メッセージ付きで拒否する。
-  test("rejects a non-ASCII body with the fixed message", () => {
-    const [valid, message] = rule({ body: "日本語の本文。", footer: null, notes: [] });
-
-    expect(valid).toBe(false);
-    expect(message).toMatch(/ASCII characters only/);
-  });
-
-  // non-ASCII の footer を拒否する。
-  test("rejects a non-ASCII footer", () => {
-    // parser が body 1 行目の `#nnn` を検出して以降を footer に振り分けたときに、
-    // body は空文字列となり footer 側に日本語が流れ込む状況を再現。
-    const [valid] = rule({
-      body: "",
-      footer: "Issue #2126 のような本文。日本語混入。",
-      notes: [],
-    });
-
-    expect(valid).toBe(false);
-  });
-
-  // breaking change note 内の non-ASCII text を拒否する。
-  test("rejects non-ASCII text in breaking change notes", () => {
-    const [valid] = rule({
-      body: "English body.",
-      footer: null,
-      notes: [{ text: "互換性破壊の説明", title: "BREAKING CHANGE" }],
-    });
-
-    expect(valid).toBe(false);
-  });
-
-  // non-ASCII の note title を拒否する。
-  test("rejects a non-ASCII note title", () => {
-    // ルール実装は title と text を両方検査対象に含めている契約。
-    // 実用上 title はほぼ "BREAKING CHANGE" 固定だが、契約をテストで固定する。
-    const [valid] = rule({
-      body: "English body.",
-      footer: null,
-      notes: [{ text: "english", title: "破壊的変更" }],
-    });
-
-    expect(valid).toBe(false);
-  });
-
-  // non-ASCII の header を固定メッセージ付きで拒否する。
-  test("rejects a non-ASCII header with the fixed message", () => {
-    const [valid, message] = rule({ body: null, footer: null, header: "chore: 日本語のタイトル" });
-
-    expect(valid).toBe(false);
-    expect(message).toMatch(/ASCII characters only/);
-  });
-
-  // header 内の emoji を拒否する。
-  test("rejects an emoji in the header", () => {
-    // emoji は surrogate pair のため、byte 長と code unit 長の比較で検出できることを固定する。
-    const [valid] = rule({ body: null, footer: null, header: "chore: emoji 🚀" });
-
-    expect(valid).toBe(false);
-  });
-
-  // header 内の accented latin を拒否する。
-  test("rejects accented latin characters in the header", () => {
-    const [valid] = rule({ body: null, footer: null, header: "chore: café latte" });
-
-    expect(valid).toBe(false);
-  });
-
-  // scope 内の non-ASCII を拒否する。
-  test("rejects a non-ASCII scope", () => {
-    // scope を許可した consumer でも header 全体が検査対象であることを固定する。
-    const [valid] = rule({ body: null, footer: null, header: "feat(日本語): subject" });
-
-    expect(valid).toBe(false);
+    expect(message).toBe("commit message must contain ASCII characters only (write in English)");
   });
 });
 
-// `@commitlint/lint` を介した end-to-end 検証。
-// PR #2145 で問題になった「body 1 行目の `#nnn` で parser が footer に振り分ける」挙動を
-// 実 parser で踏ませ、ルールが期待通り検出するかを確認する。
+// 実 parser を通した end-to-end 検証。文字種ごとの合否と、parser のフィールド振り分けを確認する。
 describe("commit-message-ascii-only (integration via @commitlint/lint)", () => {
   const rules = { [name]: [2, "always"] } as const;
   const opts = { plugins: { local: { rules: { [name]: rule } } } } as const;
 
-  // issue 参照より後ろにある non-ASCII text を検出する。
-  test("detects non-ASCII text after an issue reference", async () => {
-    const message = ["feat(scope): subject", "", "Issue #2126 のような本文。日本語混入。"].join(
-      "\n",
-    );
-
+  test.each([
+    { label: "an ASCII subject", message: "chore: ok subject", valid: true },
+    {
+      label: "a revert subject wrapped in double quotes",
+      message: 'revert: "feat: add something"',
+      valid: true,
+    },
+    {
+      label: "an English body carrying an issue reference and a breaking note",
+      message: [
+        "feat(scope): subject",
+        "",
+        "English body. Refs #2126.",
+        "",
+        "BREAKING CHANGE: english note",
+      ].join("\n"),
+      valid: true,
+    },
+    { label: "a Japanese subject", message: "chore: 日本語のタイトル", valid: false },
+    { label: "an emoji in the subject", message: "chore: emoji 🚀", valid: false },
+    { label: "accented latin in the subject", message: "chore: café latte", valid: false },
+    {
+      // 本文 1 行目の `#nnn` を parser が footer 開始と判定し、body が空文字列になる経路。
+      label: "Japanese placed after an issue reference in the body",
+      message: ["feat(scope): subject", "", "Issue #2126 のような本文。日本語混入。"].join("\n"),
+      valid: false,
+    },
+  ])("returns $valid for $label", async ({ message, valid }) => {
     const result = await lint(message, rules, opts);
 
-    expect(result.valid).toBe(false);
-    expect(result.errors.some((e) => e.name === name)).toBe(true);
-  });
-
-  // 英語だけのコミットを許可する。
-  test("allows an English-only commit", async () => {
-    const message = [
-      "feat(scope): subject",
-      "",
-      "English body. Refs #2126.",
-      "",
-      "BREAKING CHANGE: english note",
-    ].join("\n");
-
-    const result = await lint(message, rules, opts);
-
-    expect(result.valid).toBe(true);
-  });
-
-  // 日本語 subject のみのコミットを拒否する。
-  test("rejects a Japanese subject", async () => {
-    const result = await lint("chore: 日本語のタイトル", rules, opts);
-
-    expect(result.valid).toBe(false);
-    expect(result.errors.some((e) => e.name === name)).toBe(true);
-  });
-
-  // emoji を含む subject のみのコミットを拒否する。
-  test("rejects a subject containing an emoji", async () => {
-    const result = await lint("chore: emoji 🚀", rules, opts);
-
-    expect(result.valid).toBe(false);
-    expect(result.errors.some((e) => e.name === name)).toBe(true);
-  });
-
-  // accented latin を含む subject のみのコミットを拒否する。
-  test("rejects a subject containing accented latin characters", async () => {
-    const result = await lint("chore: café latte", rules, opts);
-
-    expect(result.valid).toBe(false);
-    expect(result.errors.some((e) => e.name === name)).toBe(true);
-  });
-
-  // ASCII のみの subject を許可する。
-  test("allows an ASCII-only subject", async () => {
-    const result = await lint("chore: ok subject", rules, opts);
-
-    expect(result.valid).toBe(true);
-  });
-
-  // revert コミットの引用付き subject を許可する。
-  test("allows a revert subject wrapped in double quotes", async () => {
-    const result = await lint('revert: "feat: add something"', rules, opts);
-
-    expect(result.valid).toBe(true);
+    expect(result.errors.map((e) => e.name)).toStrictEqual(valid ? [] : [name]);
   });
 });

--- a/packages/commitlint-config/src/rules/commit-message-ascii-only/index.test.ts
+++ b/packages/commitlint-config/src/rules/commit-message-ascii-only/index.test.ts
@@ -5,20 +5,21 @@ import { commitMessageAsciiOnly } from ".";
 const { name, rule } = commitMessageAsciiOnly;
 
 // rule callback を直接呼び、parser を介さず純粋ロジックを単体検証する。
-// `commit-message-ascii-only` の検査範囲が body / footer / notes 全体に拡張されたことを保証する。
+// `commit-message-ascii-only` の検査範囲が header / body / footer / notes 全体に及ぶことを保証する。
 describe("commit-message-ascii-only (unit)", () => {
-  // body、footer、notes が空のコミットを許可する。
-  test("allows an empty commit body, footer, and notes", () => {
-    const [valid] = rule({ body: null, footer: null, notes: [] });
+  // header、body、footer、notes が空のコミットを許可する。
+  test("allows an empty header, body, footer, and notes", () => {
+    const [valid] = rule({ body: null, footer: null, header: null, notes: [] });
 
     expect(valid).toBe(true);
   });
 
-  // body、footer、notes がすべて ASCII のコミットを許可する。
-  test("allows ASCII body, footer, and notes", () => {
+  // header、body、footer、notes がすべて ASCII のコミットを許可する。
+  test("allows an ASCII header, body, footer, and notes", () => {
     const [valid] = rule({
       body: "English body line.",
       footer: "Refs #123",
+      header: "feat: add something",
       notes: [{ text: "english breaking note", title: "BREAKING CHANGE" }],
     });
 
@@ -69,6 +70,37 @@ describe("commit-message-ascii-only (unit)", () => {
 
     expect(valid).toBe(false);
   });
+
+  // non-ASCII の header を固定メッセージ付きで拒否する。
+  test("rejects a non-ASCII header with the fixed message", () => {
+    const [valid, message] = rule({ body: null, footer: null, header: "chore: 日本語のタイトル" });
+
+    expect(valid).toBe(false);
+    expect(message).toMatch(/ASCII characters only/);
+  });
+
+  // header 内の emoji を拒否する。
+  test("rejects an emoji in the header", () => {
+    // emoji は surrogate pair のため、byte 長と code unit 長の比較で検出できることを固定する。
+    const [valid] = rule({ body: null, footer: null, header: "chore: emoji 🚀" });
+
+    expect(valid).toBe(false);
+  });
+
+  // header 内の accented latin を拒否する。
+  test("rejects accented latin characters in the header", () => {
+    const [valid] = rule({ body: null, footer: null, header: "chore: café latte" });
+
+    expect(valid).toBe(false);
+  });
+
+  // scope 内の non-ASCII を拒否する。
+  test("rejects a non-ASCII scope", () => {
+    // scope を許可した consumer でも header 全体が検査対象であることを固定する。
+    const [valid] = rule({ body: null, footer: null, header: "feat(日本語): subject" });
+
+    expect(valid).toBe(false);
+  });
 });
 
 // `@commitlint/lint` を介した end-to-end 検証。
@@ -101,6 +133,44 @@ describe("commit-message-ascii-only (integration via @commitlint/lint)", () => {
     ].join("\n");
 
     const result = await lint(message, rules, opts);
+
+    expect(result.valid).toBe(true);
+  });
+
+  // 日本語 subject のみのコミットを拒否する。
+  test("rejects a Japanese subject", async () => {
+    const result = await lint("chore: 日本語のタイトル", rules, opts);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.name === name)).toBe(true);
+  });
+
+  // emoji を含む subject のみのコミットを拒否する。
+  test("rejects a subject containing an emoji", async () => {
+    const result = await lint("chore: emoji 🚀", rules, opts);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.name === name)).toBe(true);
+  });
+
+  // accented latin を含む subject のみのコミットを拒否する。
+  test("rejects a subject containing accented latin characters", async () => {
+    const result = await lint("chore: café latte", rules, opts);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.name === name)).toBe(true);
+  });
+
+  // ASCII のみの subject を許可する。
+  test("allows an ASCII-only subject", async () => {
+    const result = await lint("chore: ok subject", rules, opts);
+
+    expect(result.valid).toBe(true);
+  });
+
+  // revert コミットの引用付き subject を許可する。
+  test("allows a revert subject wrapped in double quotes", async () => {
+    const result = await lint('revert: "feat: add something"', rules, opts);
 
     expect(result.valid).toBe(true);
   });

--- a/packages/commitlint-config/src/rules/commit-message-ascii-only/index.ts
+++ b/packages/commitlint-config/src/rules/commit-message-ascii-only/index.ts
@@ -1,16 +1,17 @@
 import type { RuleConfigTuple } from "@commitlint/types";
 import type { CommitBase } from "conventional-commits-parser";
 
-type Parsed = Partial<Pick<CommitBase, "body" | "footer" | "notes">>;
+type Parsed = Partial<Pick<CommitBase, "body" | "footer" | "header" | "notes">>;
 
-// Header 以外 (body + footer + BREAKING CHANGE notes) を ASCII のみに制限する。
+// commit message 全体 (header + body + footer + BREAKING CHANGE notes) を ASCII のみに制限する。
+// header を含めるのは、PR タイトル検証を commitlint に一本化するため。
 // body のみを検査すると、本文 1 行目に `#issue-number` が含まれる場合に
 // conventional-commits-parser がその行から footer 開始と判定し、
 // body が空文字列となって ASCII チェックが素通りする問題があるため、
 // footer / notes も検査対象に含める。
-const rule = ({ body, footer, notes }: Parsed): readonly [boolean, string?] => {
+const rule = ({ body, footer, header, notes }: Parsed): readonly [boolean, string?] => {
   const noteText = (notes ?? []).flatMap((n) => [n.title, n.text]).join("\n");
-  const text = [body, footer, noteText].filter(Boolean).join("\n");
+  const text = [header, body, footer, noteText].filter(Boolean).join("\n");
 
   if (!text) {
     return [true];
@@ -18,10 +19,7 @@ const rule = ({ body, footer, notes }: Parsed): readonly [boolean, string?] => {
 
   const isValid = Buffer.byteLength(text, "utf-8") === text.length;
 
-  return [
-    isValid,
-    "commit message body / footer / notes must contain ASCII characters only (write in English)",
-  ];
+  return [isValid, "commit message must contain ASCII characters only (write in English)"];
 };
 
 const severity: RuleConfigTuple<void> = [2, "always"];

--- a/packages/commitlint-config/src/rules/commit-message-ascii-only/index.ts
+++ b/packages/commitlint-config/src/rules/commit-message-ascii-only/index.ts
@@ -1,8 +1,6 @@
 import type { RuleConfigTuple } from "@commitlint/types";
 import type { CommitBase } from "conventional-commits-parser";
 
-// CommitBase の残り 4 つを検査対象に入れないのは、commitlint の parser では merge / revert が
-// 常に null で、mentions / references は header・body・footer からの派生値のため。
 type Parsed = Partial<Pick<CommitBase, "body" | "footer" | "header" | "notes">>;
 
 // commit message 全体 (header + body + footer + BREAKING CHANGE notes) を ASCII のみに制限する。

--- a/packages/commitlint-config/src/rules/commit-message-ascii-only/index.ts
+++ b/packages/commitlint-config/src/rules/commit-message-ascii-only/index.ts
@@ -1,6 +1,8 @@
 import type { RuleConfigTuple } from "@commitlint/types";
 import type { CommitBase } from "conventional-commits-parser";
 
+// CommitBase の残り 4 つを検査対象に入れないのは、commitlint の parser では merge / revert が
+// 常に null で、mentions / references は header・body・footer からの派生値のため。
 type Parsed = Partial<Pick<CommitBase, "body" | "footer" | "header" | "notes">>;
 
 // commit message 全体 (header + body + footer + BREAKING CHANGE notes) を ASCII のみに制限する。


### PR DESCRIPTION
`commit-message-ascii-only` の判定対象に header を足した。これまでは body / footer / notes だけを見ていたため、日本語や emoji の subject が素通りしていた。PR タイトル検証を workflows 側の amannn/action-semantic-pull-request から commitlint に寄せるための前提。

## 判定の変化

| タイトル | 現行 CI | 変更前 | 変更後 |
| --- | --- | --- | --- |
| `chore: 日本語のタイトル` | FAIL | PASS | FAIL |
| `chore: emoji 🚀` | FAIL | PASS | FAIL |
| `chore: café latte` | FAIL | PASS | FAIL |
| `chore: ok subject` | PASS | PASS | PASS |
| `revert: "feat: add something"` | PASS | PASS | PASS |

ルール名は据え置き、エラーメッセージだけ対象範囲に合わせて `commit message must contain ASCII characters only (write in English)` にした。

## breaking change

consumer 側で日本語 subject のコミットが弾かれる。直近 200 コミットに日本語 subject が残っているのは dotfiles と brain の 1 件ずつ。

`chore: a` は現行 CI では FAIL、commitlint では PASS のまま。この差は今回埋めない。

dotfiles 側でも同じ切り替えを進めている[^dotfiles-pr]。

[^dotfiles-pr]: https://github.com/nozomiishii/dotfiles/pull/1602
