### PR TITLE
feat: enforce test.for over test.each in vitest rules

### DIFF
--- a/packages/eslint-config/rules/vitest.ts
+++ b/packages/eslint-config/rules/vitest.ts
@@ -19,8 +19,7 @@ export function vitest() {
         ...eslintPluginVitest.configs.all.rules,
 
         /**
-         * パラメータ化テストは Test Context を受け取れる .for に寄せる。
-         * 未指定のキーは検査されないため、4 つすべてに選好を与える。
+         * パラメータ化テストは Test Context を受け取れる .for を使う。
          *
          * @see https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/consistent-each-for.md
          */

--- a/packages/eslint-config/rules/vitest.ts
+++ b/packages/eslint-config/rules/vitest.ts
@@ -19,6 +19,17 @@ export function vitest() {
         ...eslintPluginVitest.configs.all.rules,
 
         /**
+         * パラメータ化テストは Test Context を受け取れる .for に寄せる。
+         * 未指定のキーは検査されないため、4 つすべてに選好を与える。
+         *
+         * @see https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/consistent-each-for.md
+         */
+        "vitest/consistent-each-for": [
+          "error",
+          { describe: "for", it: "for", suite: "for", test: "for" },
+        ],
+
+        /**
          * テストファイル名は .test.{ts,tsx} に統一する。
          * .spec.* も識別対象に含めた上で、ファイル名規則違反としてエラーにする。
          *


### PR DESCRIPTION
## 概要

パラメータ化テストの書き方を `test.for` / `describe.for` に寄せ、`vitest/consistent-each-for` で lint 強制する。

Vitest 公式の [Parameterized tests](https://vitest.dev/guide/learn/writing-tests.html#parameterized-tests) は新規コードで `test.for` を推奨している。`test.for` は Test Context (fixtures / per-test の expect / ユーティリティ) を受け取れ、配列引数を spread せず 1 つの値として渡す。`test.each` は Jest 互換のために残っているだけ。

## 変更

`rules/vitest.ts` に `vitest/consistent-each-for` の override を 1 件追加した。

このルールは `configs.all` 経由で既に `warn` として読み込まれていたが、`defaultOptions` が `[{}]` で選好が未指定のため何も報告していなかった。選好を与えるだけで有効になる。

- severity は `error`。`meta.fixable` が無く Auto Fix できないため、`packages/eslint-config/CLAUDE.md` の「Auto Fix できる rule は `warn`、できない rule は `error`」に従う。
- `describe` / `it` / `suite` / `test` の 4 つすべてを指定した。このルールにデフォルト値は無く、未指定のキーはそのキーだけ検査対象から外れる。`suite` は `describe` のエイリアスだが ESLint は識別子名で分岐するため、別キーとして埋める必要がある。

## 動作確認

| ケース | 結果 |
| --- | --- |
| `test.each` / `describe.each` / `it.each` / `suite.each` | error |
| `test.for` / `describe.for` | 素通り |
| 手書き `for` ループ | `vitest/prefer-each` の warning のみ |

`vitest/prefer-each` とは対象ノードが別 (`ForStatement` 系 vs `MemberExpression`) で、同じ箇所に両方が出ることはない。

`.each` は main に 1 件も無いため既存テストへの影響は無い。全パッケージの lint / test が通ることを確認した。

## 補足

- `packages/commitlint-config/src/rules/commit-message-ascii-only/index.test.ts` は #2747 でレビュー中のため触っていない。マージ後に別 PR で `.for` へ書き換える。
- `vitest/prefer-each` のメッセージは `Prefer using it.each rather than a manual loop` と `.each` を勧めており、このルールと案内が食い違う。手書きループを直す際に `.each` を経由して二度指摘される形になるが、upstream の固定文言でオプションが無いため今回は手を入れていない。
