### PR TITLE
chore: pin the next release to 2.3.0

### DIFF
--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -5,6 +5,8 @@
 
   "always-update": true,
 
+  "release-as": "2.3.0",
+
   "group-pull-request-title-pattern": "chore: release ${version}",
 
   "changelog-sections": [


### PR DESCRIPTION
`commit-message-ascii-only` に header 判定を足した変更を `feat!` で入れてしまい、release-please が 3.0.0 を計算している。破壊的変更ではなく機能追加として出したいので、次のリリースを 2.3.0 に固定する。

`linked-versions` で 11 パッケージが同じ版を共有しているため、この 1 件のために全パッケージが 3.0.0 に上がる状態になっていた。

## 効果

マージすると release-please が [#2735](https://github.com/nozomiishii/configs/pull/2735) を `chore: release 2.3.0` として再生成する。

## 後始末

`release-as` は残すと次回以降も 2.3.0 に固定されてしまうため、リリース後に削除する PR を別に出す。CHANGELOG に入る `⚠ BREAKING CHANGES` の見出しもそこで消す。

main の履歴を書き換える案も検討したが、ruleset の `non_fast_forward` に阻まれた。ruleset は infra の IaC 管理で、一時的に緩める操作は避けた。
