### PR TITLE
fix: isolate nozo init tests from ancestor package.json lookup

### DIFF
--- a/packages/nozo/src/commands/init.test.ts
+++ b/packages/nozo/src/commands/init.test.ts
@@ -1,22 +1,30 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { expect, onTestFinished, test, vi } from "vitest";
 import { defaultToolIds, resolvePackageManager, toolIds, tools } from "./init";
 
 // 一時dirに最小構成の package.json を作り、テスト終了時に削除する。
+// detect は上位ディレクトリを遡るため、親には別の packageManager を置いて探索終端が効いていることも押さえる。
 function createTestProject(): string {
-  const tmpDir = mkdtempSync(path.join(tmpdir(), "nozo-init-"));
+  const tmpRoot = mkdtempSync(path.join(tmpdir(), "nozo-init-"));
   writeFileSync(
-    path.join(tmpDir, "package.json"),
+    path.join(tmpRoot, "package.json"),
+    `${JSON.stringify({ name: "outside", packageManager: "npm@11.0.0" }, null, 2)}\n`,
+  );
+
+  const cwd = path.join(tmpRoot, "project");
+  mkdirSync(cwd);
+  writeFileSync(
+    path.join(cwd, "package.json"),
     `${JSON.stringify({ name: "fixture", version: "1.0.0" }, null, 2)}\n`,
   );
 
   onTestFinished(() => {
-    rmSync(tmpDir, { force: true, recursive: true });
+    rmSync(tmpRoot, { force: true, recursive: true });
   });
 
-  return tmpDir;
+  return cwd;
 }
 
 // npm_config_user_agent を一時的に差し替え、テスト終了時に元へ戻す。value 省略でランナー無しを再現する。
@@ -56,7 +64,7 @@ test("falls back to the launching runner when the project has no config", async 
   const cwd = createTestProject();
   stubUserAgent("bun/1.3.11 npm/? node/v24 darwin arm64");
 
-  await expect(resolvePackageManager(cwd)).resolves.toStrictEqual({
+  await expect(resolvePackageManager(cwd, cwd)).resolves.toStrictEqual({
     agent: "bun",
     source: "runner",
   });
@@ -67,7 +75,9 @@ test("throws when neither project config nor runner is available", async () => {
   const cwd = createTestProject();
   stubUserAgent();
 
-  await expect(resolvePackageManager(cwd)).rejects.toThrow("Could not determine a package manager");
+  await expect(resolvePackageManager(cwd, cwd)).rejects.toThrow(
+    "Could not determine a package manager",
+  );
 });
 
 // プロジェクトの lockfile はランナーより優先される。
@@ -76,7 +86,7 @@ test("prefers project config over the launching runner", async () => {
   writeFileSync(path.join(cwd, "pnpm-lock.yaml"), "");
   stubUserAgent("bun/1.3.11 npm/? node/v24 darwin arm64");
 
-  await expect(resolvePackageManager(cwd)).resolves.toStrictEqual({
+  await expect(resolvePackageManager(cwd, cwd)).resolves.toStrictEqual({
     agent: "pnpm",
     source: "project",
   });

--- a/packages/nozo/src/commands/init.ts
+++ b/packages/nozo/src/commands/init.ts
@@ -8,7 +8,7 @@ import { init as initPrettier } from "@nozomiishii/prettier-config/init";
 import { defineCommand } from "citty";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { type AgentName, detect, getUserAgent } from "package-manager-detector";
+import { type AgentName, detect, type DetectOptions, getUserAgent } from "package-manager-detector";
 
 const exec = promisify(execFile);
 
@@ -110,8 +110,10 @@ export const defaultToolIds = toolIds.filter((id) => id !== "prettier");
 
 export async function resolvePackageManager(
   cwd: string,
+  // 探索の終端。省略時はファイルシステムのルートまで遡る。
+  stopDir?: DetectOptions["stopDir"],
 ): Promise<{ agent: AgentName; source: "project" | "runner" }> {
-  const detected = await detect({ cwd });
+  const detected = await detect(stopDir === undefined ? { cwd } : { cwd, stopDir });
 
   if (detected !== null) {
     return { agent: detected.name, source: "project" };


### PR DESCRIPTION
## 何を直したか

`packages/nozo/src/commands/init.test.ts` が実行環境に依存して落ちていた。

`resolvePackageManager` が使う `package-manager-detector` の `detect()` はファイルシステムのルートまで上位ディレクトリを遡る。`os.tmpdir()` の上位に `packageManager` を持つ package.json があると (例: `/tmp/package.json`)、lockfile も packageManager も無いはずの fixture でそれが検出され、runner fallback と throw の 2 テストが壊れていた。

## 変更

- `resolvePackageManager` に省略可能な `stopDir` を追加し、テストからのみ渡して探索を fixture 内に閉じた。production の呼び出しは無引数のままなので、monorepo の子パッケージでルートの lockfile を拾う挙動は変わらない。
- fixture を 2 階層にし、親に別の `packageManager` を書いた package.json を置いた。`stopDir` の受け渡しを外すと TMPDIR に関係なく 2 テストが落ちる。

## 検証

| 実行 | 結果 |
| --- | --- |
| `TMPDIR=/tmp/claude-501` (上位に `packageManager` あり) | 5 passed |
| `TMPDIR=/var/folders/…/T` (クリーン) | 5 passed |
| `pnpm -r --if-present run lint` / `pnpm --filter nozo tsc` | 通過 |
| `pnpm -r --if-present run test` | 81 passed |

## 備考

oxfmt は当てていない。当てると `type ToolInit` と happy path の `test(...)` という依頼と無関係な既存コードまで書き換わるため。`packages/` を oxfmt 管理下に置く作業は、この PR を base にした stacked PR で分けている。