### PR TITLE
chore: apply oxfmt to packages and check it in CI

### DIFF
--- a/.github/workflows/commitlint-config.yaml
+++ b/.github/workflows/commitlint-config.yaml
@@ -58,6 +58,9 @@ jobs:
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
+      - name: Format Check
+        run: pnpm format
+
       - name: Lint
         run: pnpm lint
 

--- a/.github/workflows/cspell-config.yaml
+++ b/.github/workflows/cspell-config.yaml
@@ -58,6 +58,9 @@ jobs:
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
+      - name: Format Check
+        run: pnpm format
+
       - name: Lint
         run: pnpm lint
 

--- a/.github/workflows/eslint-config.yaml
+++ b/.github/workflows/eslint-config.yaml
@@ -58,6 +58,9 @@ jobs:
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
+      - name: Format Check
+        run: pnpm format
+
       - name: Lint
         run: pnpm lint
 

--- a/.github/workflows/lefthook-config.yaml
+++ b/.github/workflows/lefthook-config.yaml
@@ -58,6 +58,9 @@ jobs:
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
+      - name: Format Check
+        run: pnpm format
+
       - name: Lint
         run: pnpm lint
 

--- a/.github/workflows/markdownlint-cli2-config.yaml
+++ b/.github/workflows/markdownlint-cli2-config.yaml
@@ -58,6 +58,9 @@ jobs:
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
+      - name: Format Check
+        run: pnpm format
+
       - name: Lint
         run: pnpm lint
 

--- a/.github/workflows/nozo.yaml
+++ b/.github/workflows/nozo.yaml
@@ -58,6 +58,9 @@ jobs:
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
+      - name: Format Check
+        run: pnpm format
+
       - name: Lint
         run: pnpm lint
 

--- a/.github/workflows/postinstall.yaml
+++ b/.github/workflows/postinstall.yaml
@@ -58,6 +58,9 @@ jobs:
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
+      - name: Format Check
+        run: pnpm format
+
       - name: Lint
         run: pnpm lint
 

--- a/.github/workflows/prettier-config.yaml
+++ b/.github/workflows/prettier-config.yaml
@@ -58,6 +58,9 @@ jobs:
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
+      - name: Format Check
+        run: pnpm format
+
       - name: Lint
         run: pnpm lint
 

--- a/.github/workflows/tsconfig.yaml
+++ b/.github/workflows/tsconfig.yaml
@@ -58,6 +58,9 @@ jobs:
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
+      - name: Format Check
+        run: pnpm format
+
       - name: Lint
         run: pnpm lint
 

--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -41,6 +41,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch --sourcemap",
+    "format": "pnpm oxfmt . --check",
     "lint": "eslint --max-warnings=0 .",
     "prepublishOnly": "pnpm run build",
     "test": "vitest run",

--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -10,20 +10,13 @@
   "bugs": {
     "url": "https://github.com/nozomiishii/configs/issues"
   },
+  "license": "MIT",
+  "author": "Nozomi Ishii",
   "repository": {
     "type": "git",
     "url": "https://github.com/nozomiishii/configs.git",
     "directory": "packages/commitlint-config"
   },
-  "license": "MIT",
-  "author": "Nozomi Ishii",
-  "type": "module",
-  "exports": {
-    ".": "./dist/index.js",
-    "./init": "./dist/init/index.js"
-  },
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "bin": {
     "nozo-commitlint": "./bin/nozo-commitlint.js",
     "nozo-commitlint-init": "./bin/nozo-commitlint-init.js"
@@ -34,6 +27,17 @@
     "starter.ts",
     "README.md"
   ],
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./init": "./dist/init/index.js"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch --sourcemap",
@@ -58,9 +62,5 @@
     "typescript": "6.0.3",
     "vitest": "4.1.11"
   },
-  "packageManager": "pnpm@11.22.0",
-  "publishConfig": {
-    "access": "public",
-    "provenance": true
-  }
+  "packageManager": "pnpm@11.22.0"
 }

--- a/packages/cspell-config/package.json
+++ b/packages/cspell-config/package.json
@@ -39,6 +39,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch --sourcemap",
+    "format": "pnpm oxfmt . --check",
     "lint": "eslint --max-warnings=0 .",
     "prepublishOnly": "pnpm run build",
     "tsc": "tsc"

--- a/packages/cspell-config/package.json
+++ b/packages/cspell-config/package.json
@@ -3,27 +3,20 @@
   "version": "2.2.0",
   "description": "Nozomi's Recommended cspell config",
   "keywords": [
-    "cspell",
-    "config"
+    "config",
+    "cspell"
   ],
   "homepage": "https://github.com/nozomiishii/configs/blob/main/packages/cspell-config/README.md",
   "bugs": {
     "url": "https://github.com/nozomiishii/configs/issues"
   },
+  "license": "MIT",
+  "author": "Nozomi Ishii",
   "repository": {
     "type": "git",
     "url": "https://github.com/nozomiishii/configs.git",
     "directory": "packages/cspell-config"
   },
-  "license": "MIT",
-  "author": "Nozomi Ishii",
-  "type": "module",
-  "exports": {
-    "./package.json": "./package.json",
-    ".": "./dist/index.js"
-  },
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "bin": {
     "nozo-cspell": "./dist/cli.js"
   },
@@ -32,6 +25,17 @@
     "dist",
     "README.md"
   ],
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./dist/index.js"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch --sourcemap",
@@ -50,18 +54,14 @@
     "tsdown": "0.22.14",
     "typescript": "6.0.3"
   },
-  "packageManager": "pnpm@11.22.0",
-  "engines": {
-    "node": ">=24"
-  },
   "devEngines": {
     "runtime": {
       "name": "node",
       "version": "24.19.0"
     }
   },
-  "publishConfig": {
-    "access": "public",
-    "provenance": true
-  }
+  "engines": {
+    "node": ">=24"
+  },
+  "packageManager": "pnpm@11.22.0"
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -49,6 +49,7 @@
     "check:ts": "tsc",
     "dev": "pnpm typegen && eslint --inspect-config",
     "eslint": "eslint --max-warnings=0",
+    "format": "pnpm oxfmt . --check",
     "link": "pnpm link --global",
     "lint": "pnpm eslint .",
     "lint:fix": "pnpm eslint . --fix",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -3,27 +3,21 @@
   "version": "2.2.0",
   "description": "Nozomi's Recommended eslint config",
   "keywords": [
+    "config",
     "eslint",
-    "lint",
-    "config"
+    "lint"
   ],
   "homepage": "https://github.com/nozomiishii/configs/blob/main/packages/eslint-config/README.md",
   "bugs": {
     "url": "https://github.com/nozomiishii/configs/issues"
   },
+  "license": "MIT",
+  "author": "Nozomi Ishii",
   "repository": {
     "type": "git",
     "url": "https://github.com/nozomiishii/configs.git",
     "directory": "packages/eslint-config"
   },
-  "license": "MIT",
-  "author": "Nozomi Ishii",
-  "type": "module",
-  "exports": {
-    ".": "./index.ts",
-    "./init": "./dist/init/index.js"
-  },
-  "main": "index.ts",
   "bin": {
     "nozo-eslint-init": "./bin/nozo-eslint-init.js"
   },
@@ -40,6 +34,16 @@
     "README.md",
     "README.ja.md"
   ],
+  "type": "module",
+  "main": "index.ts",
+  "exports": {
+    ".": "./index.ts",
+    "./init": "./dist/init/index.js"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "scripts": {
     "build": "tsdown",
     "check:ts": "tsc",
@@ -101,12 +105,8 @@
     "eslint": "10.8.1",
     "typescript": "6.0.3"
   },
-  "packageManager": "pnpm@11.22.0",
   "engines": {
     "node": ">=24.0.0"
   },
-  "publishConfig": {
-    "access": "public",
-    "provenance": true
-  }
+  "packageManager": "pnpm@11.22.0"
 }

--- a/packages/eslint-config/rules/n.ts
+++ b/packages/eslint-config/rules/n.ts
@@ -27,10 +27,7 @@ export function n() {
          *
          * @see https://github.com/eslint-community/eslint-plugin-n/blob/master/docs/rules/no-unsupported-features/node-builtins.md
          */
-        "n/no-unsupported-features/node-builtins": [
-          "error",
-          { allowExperimental: true },
-        ],
+        "n/no-unsupported-features/node-builtins": ["error", { allowExperimental: true }],
       },
       // pnpmでnode管理したいので設定。engines設定してるならここは省略できる。
       // pnpm.executionEnv.nodeVersionがcustomManagers書いてもenginesと同じタイミングでアップデートしてくれない。

--- a/packages/eslint-config/src/init/index.test.ts
+++ b/packages/eslint-config/src/init/index.test.ts
@@ -124,9 +124,7 @@ test("the tanstack-start starter does not reference nextjs", async () => {
 test("init with monorepo writes tsconfigRootDir", async () => {
   const { configContent } = await runInit("node", true);
 
-  expect(configContent).toContain(
-    "node({ typescript: { tsconfigRootDir: import.meta.dirname } })",
-  );
+  expect(configContent).toContain("node({ typescript: { tsconfigRootDir: import.meta.dirname } })");
 });
 
 // 単一 repo (既定) は tsconfigRootDir を入れない

--- a/packages/eslint-config/src/init/index.ts
+++ b/packages/eslint-config/src/init/index.ts
@@ -14,8 +14,8 @@ export type PresetId = "nextjs" | "node" | "tanstack-start";
  * starter が呼ぶ preset 関数名。ファイル名は kebab-case、関数は camelCase のため対応表で持つ。
  */
 const presetFunctions: Record<PresetId, string> = {
-  "nextjs": "nextjs",
-  "node": "node",
+  nextjs: "nextjs",
+  node: "node",
   "tanstack-start": "tanstackStart",
 };
 
@@ -40,10 +40,7 @@ export async function init({
     peerDependencies: { eslint: string; typescript: string };
   };
 
-  const starterRaw = await readFile(
-    path.join(root, "starters", `${preset}.ts`),
-    "utf-8",
-  );
+  const starterRaw = await readFile(path.join(root, "starters", `${preset}.ts`), "utf-8");
 
   // monorepo の per-package config は tsconfigRootDir を明示する。
   const presetFunction = presetFunctions[preset];
@@ -66,8 +63,8 @@ export async function init({
 
   target.scripts = {
     ...target.scripts,
-    "eslint": "eslint --max-warnings=0 --cache",
-    "lint": "pnpm eslint",
+    eslint: "eslint --max-warnings=0 --cache",
+    lint: "pnpm eslint",
     "lint:fix": "pnpm eslint --fix",
   };
 

--- a/packages/lefthook-config/hooks/post-merge/update-node-modules.yaml
+++ b/packages/lefthook-config/hooks/post-merge/update-node-modules.yaml
@@ -2,7 +2,7 @@ post-merge:
   jobs:
     - name: update-node-modules
       files: git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD
-      glob: '**/{package.json,pnpm-lock.yaml,bun.lock,bun.lockb,package-lock.json,yarn.lock}'
+      glob: "**/{package.json,pnpm-lock.yaml,bun.lock,bun.lockb,package-lock.json,yarn.lock}"
       run: |
         if [ -f "pnpm-lock.yaml" ]; then
           echo "🥊 Installing dependencies with pnpm..."

--- a/packages/lefthook-config/hooks/pre-commit/yaml.yaml
+++ b/packages/lefthook-config/hooks/pre-commit/yaml.yaml
@@ -2,5 +2,5 @@ pre-commit:
   jobs:
     - name: lint-file-extension-yaml
       files: git diff --name-only --staged
-      glob: '*.yml'
+      glob: "*.yml"
       run: echo "Error! \".yml\" extension found, please use \".yaml\" instead." && exit 1

--- a/packages/lefthook-config/package.json
+++ b/packages/lefthook-config/package.json
@@ -43,6 +43,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch --sourcemap",
+    "format": "pnpm oxfmt . --check",
     "lint": "eslint --max-warnings=0 .",
     "prepublishOnly": "pnpm run build",
     "test": "vitest run",

--- a/packages/lefthook-config/package.json
+++ b/packages/lefthook-config/package.json
@@ -3,27 +3,21 @@
   "version": "2.2.0",
   "description": "Nozomi's Recommended lefthook config",
   "keywords": [
-    "lefthook",
+    "config",
     "githooks",
-    "config"
+    "lefthook"
   ],
   "homepage": "https://github.com/nozomiishii/configs/blob/main/packages/lefthook-config/README.md",
   "bugs": {
     "url": "https://github.com/nozomiishii/configs/issues"
   },
+  "license": "MIT",
+  "author": "Nozomi Ishii",
   "repository": {
     "type": "git",
     "url": "https://github.com/nozomiishii/configs.git",
     "directory": "packages/lefthook-config"
   },
-  "license": "MIT",
-  "author": "Nozomi Ishii",
-  "type": "module",
-  "exports": {
-    ".": "./recommended.yaml",
-    "./init": "./dist/init/index.js"
-  },
-  "main": "recommended.yaml",
   "bin": {
     "nozo-git-harvest": "./bin/nozo-git-harvest.js",
     "nozo-lefthook-init": "./bin/nozo-lefthook-init.js"
@@ -36,6 +30,16 @@
     "starter.yaml",
     "README.md"
   ],
+  "type": "module",
+  "main": "recommended.yaml",
+  "exports": {
+    ".": "./recommended.yaml",
+    "./init": "./dist/init/index.js"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch --sourcemap",
@@ -60,9 +64,5 @@
   "peerDependencies": {
     "lefthook": "2.1.10"
   },
-  "packageManager": "pnpm@11.22.0",
-  "publishConfig": {
-    "access": "public",
-    "provenance": true
-  }
+  "packageManager": "pnpm@11.22.0"
 }

--- a/packages/markdownlint-cli2-config/package.json
+++ b/packages/markdownlint-cli2-config/package.json
@@ -39,6 +39,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch --sourcemap",
+    "format": "pnpm oxfmt . --check",
     "lint": "eslint --max-warnings=0 .",
     "prepublishOnly": "pnpm run build",
     "tsc": "tsc"

--- a/packages/markdownlint-cli2-config/package.json
+++ b/packages/markdownlint-cli2-config/package.json
@@ -3,35 +3,39 @@
   "version": "2.2.0",
   "description": "Nozomi's Recommended markdownlint-cli2 config",
   "keywords": [
-    "markdownlint-cli2",
-    "markdown",
+    "config",
     "lint",
-    "config"
+    "markdown",
+    "markdownlint-cli2"
   ],
   "homepage": "https://github.com/nozomiishii/configs/blob/main/packages/markdownlint-cli2-config/README.md",
   "bugs": {
     "url": "https://github.com/nozomiishii/configs/issues"
   },
+  "license": "MIT",
+  "author": "Nozomi Ishii",
   "repository": {
     "type": "git",
     "url": "https://github.com/nozomiishii/configs.git",
     "directory": "packages/markdownlint-cli2-config"
   },
-  "license": "MIT",
-  "author": "Nozomi Ishii",
-  "type": "module",
-  "exports": {
-    "./package.json": "./package.json",
-    ".": "./dist/index.js"
-  },
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "bin": "bin/cli.sh",
   "files": [
     "bin",
     "dist",
     "README.md"
   ],
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./dist/index.js"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch --sourcemap",
@@ -50,9 +54,5 @@
     "tsdown": "0.22.14",
     "typescript": "6.0.3"
   },
-  "packageManager": "pnpm@11.22.0",
-  "publishConfig": {
-    "access": "public",
-    "provenance": true
-  }
+  "packageManager": "pnpm@11.22.0"
 }

--- a/packages/nozo/package.json
+++ b/packages/nozo/package.json
@@ -30,6 +30,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch --sourcemap",
+    "format": "pnpm oxfmt . --check",
     "lint": "eslint --max-warnings=0 .",
     "lint:fix": "eslint --max-warnings=0 . --fix",
     "prepublishOnly": "pnpm run build",

--- a/packages/nozo/package.json
+++ b/packages/nozo/package.json
@@ -10,19 +10,23 @@
   "bugs": {
     "url": "https://github.com/nozomiishii/configs/issues"
   },
+  "license": "MIT",
+  "author": "Nozomi Ishii",
   "repository": {
     "type": "git",
     "url": "https://github.com/nozomiishii/configs.git",
     "directory": "packages/nozo"
   },
-  "license": "MIT",
-  "author": "Nozomi Ishii",
-  "type": "module",
   "bin": "./dist/index.js",
   "files": [
     "dist",
     "README.md"
   ],
+  "type": "module",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch --sourcemap",
@@ -54,12 +58,8 @@
     "typescript": "6.0.3",
     "vitest": "4.1.11"
   },
-  "packageManager": "pnpm@11.22.0",
   "engines": {
     "node": ">=24.0.0"
   },
-  "publishConfig": {
-    "access": "public",
-    "provenance": true
-  }
+  "packageManager": "pnpm@11.22.0"
 }

--- a/packages/nozo/src/commands/init.test.ts
+++ b/packages/nozo/src/commands/init.test.ts
@@ -38,19 +38,15 @@ function stubUserAgent(value?: string) {
 
 // 全ツールの install スクリプトが throw せずに完走することだけを確認する。
 // 各ツールの生成物・package.json 内容の検証は各 config パッケージ側の責務。
-test(
-  "happy path: every tool's install script completes without throwing",
-  async () => {
-    expect.hasAssertions();
+test("happy path: every tool's install script completes without throwing", async () => {
+  expect.hasAssertions();
 
-    const cwd = createTestProject();
+  const cwd = createTestProject();
 
-    for (const id of toolIds) {
-      await expect(tools[id].run({ cwd })).resolves.toBeUndefined();
-    }
-  },
-  15_000,
-);
+  for (const id of toolIds) {
+    await expect(tools[id].run({ cwd })).resolves.toBeUndefined();
+  }
+}, 15_000);
 
 // Prettier は選択肢に残し、デフォルトの formatter は oxfmt だけにする。
 test("keeps Prettier available as an opt-in formatter", () => {

--- a/packages/nozo/src/commands/init.ts
+++ b/packages/nozo/src/commands/init.ts
@@ -21,11 +21,7 @@ type Tool = {
 
 type ToolConfig = { monorepo: boolean; preset: PresetId };
 
-type ToolInit = (options: {
-  cwd: string;
-  monorepo?: boolean;
-  preset?: PresetId;
-}) => Promise<void>;
+type ToolInit = (options: { cwd: string; monorepo?: boolean; preset?: PresetId }) => Promise<void>;
 
 export const tools = {
   commitlint: {

--- a/packages/postinstall/package.json
+++ b/packages/postinstall/package.json
@@ -39,6 +39,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch --sourcemap",
+    "format": "pnpm oxfmt . --check",
     "link": "pnpm link --global",
     "lint": "eslint --max-warnings=0 .",
     "prepublishOnly": "pnpm run build",

--- a/packages/postinstall/package.json
+++ b/packages/postinstall/package.json
@@ -10,19 +10,13 @@
   "bugs": {
     "url": "https://github.com/nozomiishii/configs/issues"
   },
+  "license": "MIT",
+  "author": "Nozomi Ishii",
   "repository": {
     "type": "git",
     "url": "https://github.com/nozomiishii/configs.git",
     "directory": "packages/postinstall"
   },
-  "license": "MIT",
-  "author": "Nozomi Ishii",
-  "type": "module",
-  "exports": {
-    ".": "./dist/index.js",
-    "./init": "./dist/init/index.js"
-  },
-  "types": "./dist/index.d.ts",
   "bin": {
     "nozo-postinstall-init": "./bin/nozo-postinstall-init.js",
     "postinstall": "./bin/postinstall.js"
@@ -32,6 +26,16 @@
     "dist",
     "README.md"
   ],
+  "type": "module",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./init": "./dist/init/index.js"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch --sourcemap",
@@ -55,9 +59,5 @@
     "typescript": "6.0.3",
     "vitest": "4.1.11"
   },
-  "packageManager": "pnpm@11.22.0",
-  "publishConfig": {
-    "access": "public",
-    "provenance": true
-  }
+  "packageManager": "pnpm@11.22.0"
 }

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -40,6 +40,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch --sourcemap",
+    "format": "pnpm oxfmt . --check",
     "lint": "eslint --max-warnings=0 .",
     "prepublishOnly": "pnpm run build",
     "test": "vitest run",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -3,27 +3,20 @@
   "version": "2.2.0",
   "description": "Nozomi's Recommended Prettier config",
   "keywords": [
-    "prettier",
-    "config"
+    "config",
+    "prettier"
   ],
   "homepage": "https://github.com/nozomiishii/configs/blob/main/packages/prettier-config/README.md",
   "bugs": {
     "url": "https://github.com/nozomiishii/configs/issues"
   },
+  "license": "MIT",
+  "author": "Nozomi Ishii",
   "repository": {
     "type": "git",
     "url": "https://github.com/nozomiishii/configs.git",
     "directory": "packages/prettier-config"
   },
-  "license": "MIT",
-  "author": "Nozomi Ishii",
-  "type": "module",
-  "exports": {
-    ".": "./dist/index.js",
-    "./init": "./dist/init/index.js"
-  },
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "bin": {
     "nozo-prettier-init": "./bin/nozo-prettier-init.js"
   },
@@ -33,6 +26,17 @@
     "starter.ts",
     "README.md"
   ],
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./init": "./dist/init/index.js"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch --sourcemap",
@@ -57,9 +61,5 @@
   "peerDependencies": {
     "prettier": "3.9.6"
   },
-  "packageManager": "pnpm@11.22.0",
-  "publishConfig": {
-    "access": "public",
-    "provenance": true
-  }
+  "packageManager": "pnpm@11.22.0"
 }

--- a/packages/prettier-config/src/init/index.ts
+++ b/packages/prettier-config/src/init/index.ts
@@ -41,9 +41,9 @@ export async function init({ cwd }: InitOptions): Promise<void> {
 
   target.scripts = {
     ...target.scripts,
-    "format": "pnpm prettier . --check",
+    format: "pnpm prettier . --check",
     "format:fix": "pnpm prettier . --write",
-    "prettier": "prettier --ignore-unknown --cache",
+    prettier: "prettier --ignore-unknown --cache",
   };
 
   await writeFile(targetPath, `${JSON.stringify(target, null, 2)}\n`);

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -3,20 +3,24 @@
   "version": "2.2.0",
   "description": "Nozomi's Recommended tsconfig",
   "keywords": [
-    "tsconfig",
-    "config"
+    "config",
+    "tsconfig"
   ],
   "homepage": "https://github.com/nozomiishii/configs/blob/main/packages/tsconfig/README.md",
   "bugs": {
     "url": "https://github.com/nozomiishii/configs/issues"
   },
+  "license": "MIT",
+  "author": "Nozomi Ishii",
   "repository": {
     "type": "git",
     "url": "https://github.com/nozomiishii/configs.git",
     "directory": "packages/tsconfig"
   },
-  "license": "MIT",
-  "author": "Nozomi Ishii",
+  "files": [
+    "src/*.json",
+    "README.md"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/tsconfig.json",
@@ -27,10 +31,10 @@
     "./tsconfig.tsc.json": "./src/tsconfig.tsc.json",
     "./package.json": "./package.json"
   },
-  "files": [
-    "src/*.json",
-    "README.md"
-  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "scripts": {
     "link": "pnpm link --global",
     "lint": "eslint --max-warnings=0 ."
@@ -41,9 +45,5 @@
     "eslint": "10.8.1",
     "typescript": "6.0.3"
   },
-  "packageManager": "pnpm@11.22.0",
-  "publishConfig": {
-    "access": "public",
-    "provenance": true
-  }
+  "packageManager": "pnpm@11.22.0"
 }

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -36,6 +36,7 @@
     "provenance": true
   },
   "scripts": {
+    "format": "pnpm oxfmt . --check",
     "link": "pnpm link --global",
     "lint": "eslint --max-warnings=0 ."
   },


### PR DESCRIPTION
## 概要

`packages/` 配下を oxfmt の管理下に戻す。

`pnpm format` (root) は #2015 で `'!packages/**'` を付けて packages を除外した。
「各パッケージが自分の format check を持つ」前提だったが、実際に `format` script を持つのは
`packages/oxfmt-config` だけで、残り 9 パッケージは未実装のまま放置されていた。
その結果 packages 配下の 17 ファイルが oxfmt 未適用で drift していた。

`packages/oxfmt-config` のパターンをそのまま残りのパッケージへ横展開する。

## 変更内容

- `chore: apply oxfmt to packages`
  - `pnpm oxfmt .` を実行し、drift していた 17 ファイルを整形。整形のみでロジック変更なし
- `chore: run oxfmt format check in every package`
  - 9 パッケージの `package.json` に `"format": "pnpm oxfmt . --check"` を追加
  - 対応する 9 つの workflow の `static` job に `Format Check` ステップを Lint の前に追加

`format` script の形と workflow のステップ配置は `packages/oxfmt-config` に合わせた。
required job の name は変更していないため、infra 側の `required_status_checks` の更新は不要。

## 確認

| コマンド | 結果 |
| --- | --- |
| `pnpm oxfmt --check .` | pass (175 files) |
| `pnpm -r --if-present run format` | pass (10 packages) |
| `pnpm -r --if-present run lint` | pass (10 packages) |
| `pnpm -r --if-present run test` | pass (7 packages / 11 test files) |

## 補足

- base は `claude/cool-shannon-394a9c` (Stacked PR)。同ブランチが `packages/nozo/src/commands/init.ts` と `init.test.ts` を触っており、整形対象と重なるため
- root の `pnpm format` は `'!packages/**'` を残したまま。packages 側は各パッケージの `format` script が担当する
- `oxfmt` は各パッケージの devDependencies に無くても workspace root の `node_modules/.bin` から解決され、root の `oxfmt.config.ts` と ignore 設定も拾える。依存の追加は不要だった
