### PR TITLE
chore: let postinstall build the workspace on CI

### DIFF
--- a/.github/workflows/commitlint-config.yaml
+++ b/.github/workflows/commitlint-config.yaml
@@ -60,11 +60,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ github.workspace }}
-        run: pnpm install --ignore-scripts
-
-      - name: Build workspace packages
-        working-directory: ${{ github.workspace }}
-        run: pnpm -r run build
+        run: pnpm install
 
       - name: Format Check
         run: pnpm format
@@ -94,11 +90,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ github.workspace }}
-        run: pnpm install --ignore-scripts
-
-      - name: Build workspace packages
-        working-directory: ${{ github.workspace }}
-        run: pnpm -r run build
+        run: pnpm install
 
       - name: Test
         run: pnpm test

--- a/.github/workflows/cspell-config.yaml
+++ b/.github/workflows/cspell-config.yaml
@@ -60,11 +60,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ github.workspace }}
-        run: pnpm install --ignore-scripts
-
-      - name: Build workspace packages
-        working-directory: ${{ github.workspace }}
-        run: pnpm -r run build
+        run: pnpm install
 
       - name: Format Check
         run: pnpm format

--- a/.github/workflows/eslint-config.yaml
+++ b/.github/workflows/eslint-config.yaml
@@ -60,11 +60,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ github.workspace }}
-        run: pnpm install --ignore-scripts
-
-      - name: Build workspace packages
-        working-directory: ${{ github.workspace }}
-        run: pnpm -r run build
+        run: pnpm install
 
       - name: Format Check
         run: pnpm format
@@ -94,11 +90,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ github.workspace }}
-        run: pnpm install --ignore-scripts
-
-      - name: Build workspace packages
-        working-directory: ${{ github.workspace }}
-        run: pnpm -r run build
+        run: pnpm install
 
       - name: Test
         run: pnpm test

--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -40,10 +40,7 @@ jobs:
         uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
 
       - name: Install dependencies
-        run: pnpm install --ignore-scripts
-
-      - name: Build workspace packages
-        run: pnpm -r run build
+        run: pnpm install
 
       - name: Build eslint config inspector
         working-directory: packages/eslint-config

--- a/.github/workflows/lefthook-config.yaml
+++ b/.github/workflows/lefthook-config.yaml
@@ -60,11 +60,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ github.workspace }}
-        run: pnpm install --ignore-scripts
-
-      - name: Build workspace packages
-        working-directory: ${{ github.workspace }}
-        run: pnpm -r run build
+        run: pnpm install
 
       - name: Format Check
         run: pnpm format
@@ -94,11 +90,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ github.workspace }}
-        run: pnpm install --ignore-scripts
-
-      - name: Build workspace packages
-        working-directory: ${{ github.workspace }}
-        run: pnpm -r run build
+        run: pnpm install
 
       - name: Test
         run: pnpm test

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -48,10 +48,7 @@ jobs:
         uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
 
       - name: Install dependencies
-        run: pnpm install --ignore-scripts
-
-      - name: Build workspace packages
-        run: pnpm -r run build
+        run: pnpm install
 
       - name: lint
         run: pnpm exec markdownlint-cli2 "**/*.md"

--- a/.github/workflows/markdownlint-cli2-config.yaml
+++ b/.github/workflows/markdownlint-cli2-config.yaml
@@ -60,11 +60,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ github.workspace }}
-        run: pnpm install --ignore-scripts
-
-      - name: Build workspace packages
-        working-directory: ${{ github.workspace }}
-        run: pnpm -r run build
+        run: pnpm install
 
       - name: Format Check
         run: pnpm format

--- a/.github/workflows/nozo.yaml
+++ b/.github/workflows/nozo.yaml
@@ -60,11 +60,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ github.workspace }}
-        run: pnpm install --ignore-scripts
-
-      - name: Build workspace packages
-        working-directory: ${{ github.workspace }}
-        run: pnpm -r run build
+        run: pnpm install
 
       - name: Format Check
         run: pnpm format
@@ -94,11 +90,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ github.workspace }}
-        run: pnpm install --ignore-scripts
-
-      - name: Build workspace packages
-        working-directory: ${{ github.workspace }}
-        run: pnpm -r run build
+        run: pnpm install
 
       - name: Test
         run: pnpm test

--- a/.github/workflows/oxfmt-config.yaml
+++ b/.github/workflows/oxfmt-config.yaml
@@ -60,11 +60,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ github.workspace }}
-        run: pnpm install --ignore-scripts
-
-      - name: Build workspace packages
-        working-directory: ${{ github.workspace }}
-        run: pnpm -r run build
+        run: pnpm install
 
       - name: Format Check
         run: pnpm format
@@ -94,11 +90,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ github.workspace }}
-        run: pnpm install --ignore-scripts
-
-      - name: Build workspace packages
-        working-directory: ${{ github.workspace }}
-        run: pnpm -r run build
+        run: pnpm install
 
       - name: Test
         run: pnpm test

--- a/.github/workflows/postinstall.yaml
+++ b/.github/workflows/postinstall.yaml
@@ -60,11 +60,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ github.workspace }}
-        run: pnpm install --ignore-scripts
-
-      - name: Build workspace packages
-        working-directory: ${{ github.workspace }}
-        run: pnpm -r run build
+        run: pnpm install
 
       - name: Format Check
         run: pnpm format
@@ -94,11 +90,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ github.workspace }}
-        run: pnpm install --ignore-scripts
-
-      - name: Build workspace packages
-        working-directory: ${{ github.workspace }}
-        run: pnpm -r run build
+        run: pnpm install
 
       - name: Test
         run: pnpm test

--- a/.github/workflows/prettier-config.yaml
+++ b/.github/workflows/prettier-config.yaml
@@ -60,11 +60,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ github.workspace }}
-        run: pnpm install --ignore-scripts
-
-      - name: Build workspace packages
-        working-directory: ${{ github.workspace }}
-        run: pnpm -r run build
+        run: pnpm install
 
       - name: Format Check
         run: pnpm format
@@ -94,11 +90,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ github.workspace }}
-        run: pnpm install --ignore-scripts
-
-      - name: Build workspace packages
-        working-directory: ${{ github.workspace }}
-        run: pnpm -r run build
+        run: pnpm install
 
       - name: Test
         run: pnpm test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -120,10 +120,7 @@ jobs:
         uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
 
       - name: Install dependencies
-        run: pnpm install --ignore-scripts
-
-      - name: Build workspace packages
-        run: pnpm -r run build
+        run: pnpm install
 
       - name: Configure Git user
         run: |
@@ -171,10 +168,7 @@ jobs:
         uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
 
       - name: Install dependencies
-        run: pnpm install --ignore-scripts
-
-      - name: Build workspace packages
-        run: pnpm -r run build
+        run: pnpm install
 
       - name: Publish all public packages
         run: pnpm -r publish --no-git-checks

--- a/.github/workflows/setting-files.yaml
+++ b/.github/workflows/setting-files.yaml
@@ -30,10 +30,7 @@ jobs:
         uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
 
       - name: Install dependencies
-        run: pnpm install --ignore-scripts
-
-      - name: Build workspace packages
-        run: pnpm -r run build
+        run: pnpm install
 
       - name: Format Check
         id: format-check

--- a/.github/workflows/tsconfig.yaml
+++ b/.github/workflows/tsconfig.yaml
@@ -60,11 +60,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ github.workspace }}
-        run: pnpm install --ignore-scripts
-
-      - name: Build workspace packages
-        working-directory: ${{ github.workspace }}
-        run: pnpm -r run build
+        run: pnpm install
 
       - name: Format Check
         run: pnpm format


### PR DESCRIPTION
## 変更
CI の `pnpm install --ignore-scripts` から `--ignore-scripts` を外し、直後にあった `Build workspace packages` ステップを削除した。22 組 / 14 ファイル。

```diff
       - name: Install dependencies
-        run: pnpm install --ignore-scripts
-
-      - name: Build workspace packages
-        run: pnpm -r run build
+        run: pnpm install
```

## 理由
root の `postinstall` は `pnpm -r run build && postinstall`。CI ではその暗黙ビルドを `--ignore-scripts` で止めて、同じビルドを明示ステップとして書き直していた。同じ処理を2箇所で持つ必要がない。

`--ignore-scripts` には副作用もあった。これは依存のビルドスクリプトも止めるため、`pnpm-workspace.yaml` の `allowBuilds` で `true` にしている `@swc/core` / `esbuild` / `lefthook` / `unrs-resolver` が CI では一切ビルドされていなかった。`allowBuilds` は依存の lifecycle script だけを対象にする設定で、`--ignore-scripts` はプロジェクト自身・workspace パッケージ・依存のすべてを止める（[pnpm docs](https://pnpm.io/settings/build)）。両方を書くと前者が無効になる。

nozomiishii/language で `--ignore-scripts` を付けたところ、workspace パッケージ自身の `postinstall: wxt prepare` が走らず、生成される `.wxt/tsconfig.json` が無いまま eslint が resolve error を出して lint が落ちた。`allowBuilds` では防げない領域。

## トレードオフ
ビルドが独立した名前付きステップではなくなり、install ステップの中に入る。ビルド失敗は install ステップの失敗として現れる。出力自体はログに残る。

## 検証
`CI=true pnpm install` で 9 パッケージすべてに `dist/` が生成されることを確認（20.2s）。`tsconfig` は build スクリプトを持たないので対象外。

そのうえで CI と同じコマンドを `packages/eslint-config` で実行し、`pnpm format` / `pnpm lint` / `pnpm check:ts` / `pnpm test` (15 tests) がすべて通ることを確認した。actionlint も通る。
